### PR TITLE
Dump latlon

### DIFF
--- a/dcore/configuration.py
+++ b/dcore/configuration.py
@@ -37,6 +37,7 @@ class OutputParameters(Configuration):
     Verbose = False
     dumpfreq = 1
     dumplist = None
+    dumplist_latlon = []
     dirname = None
     #: Should the output fields be interpolated or projected to
     #: a linear space?  Default is interpolation.

--- a/dcore/state.py
+++ b/dcore/state.py
@@ -127,7 +127,9 @@ class State(object):
 
         # make functions on latlon mesh, as specified by dumplist_latlon
         to_dump_latlon = []
-        if name in self.output.dumplist_latlon:
+        for name in self.output.dumplist_latlon:
+            print name
+            f = field_dict[name]
             f_ll = Function(functionspaceimpl.WithGeometry(f.function_space(), mesh_ll), val=f.topological, name=name+'_ll')
             field_dict_ll[name] = f_ll
             to_dump_latlon.append(f_ll)
@@ -141,10 +143,10 @@ class State(object):
             self.dumpfile = File(outfile, project_output=self.output.project_fields)
             self.diagnostic_data = defaultdict(partial(defaultdict, list))
 
-        # make output file for fields on latlon mesh if required
-        if len(self.output.dumplist_latlon) > 0:
-            outfile_latlon = path.join(self.dumpdir, "field_output_latlon.pvd")
-            self.dumpfile_latlon = File(outfile_latlon, project_output=self.output.project_fields)
+            # make output file for fields on latlon mesh if required
+            if len(self.output.dumplist_latlon) > 0:
+                outfile_latlon = path.join(self.dumpdir, "field_output_latlon.pvd")
+                self.dumpfile_latlon = File(outfile_latlon, project_output=self.output.project_fields)
 
         if (next(self.dumpcount) % self.output.dumpfreq) == 0:
 

--- a/dcore/state.py
+++ b/dcore/state.py
@@ -175,20 +175,23 @@ class State(object):
 
         self.dumpdir = path.join("results", self.output.dirname)
         outfile = path.join(self.dumpdir, "field_output.pvd")
-        outfile_latlon = path.join(self.dumpdir, "field_output_latlon.pvd")
         if self.dumpfile is None:
             if path.exists(self.dumpdir):
                 exit("results directory '%s' already exists" % self.dumpdir)
             self.dumpcount = itertools.count()
             self.dumpfile = File(outfile, project_output=self.output.project_fields)
-            self.dumpfile_latlon = File(outfile_latlon, project_output=self.output.project_fields)
             self.diagnostic_data = defaultdict(partial(defaultdict, list))
+
+        if len(self.output.dumplist_latlon) > 0:
+            outfile_latlon = path.join(self.dumpdir, "field_output_latlon.pvd")
+            self.dumpfile_latlon = File(outfile_latlon, project_output=self.output.project_fields)
 
         if (next(self.dumpcount) % self.output.dumpfreq) == 0:
 
             self.dumpfile.write(*to_dump)
 
-            self.dumpfile_latlon.write(*to_dump_latlon)
+            if len(self.output.dumplist_latlon) > 0:
+                self.dumpfile_latlon.write(*to_dump_latlon)
 
             for name in self.diagnostics.fields:
                 data = self.diagnostics.l2(field_dict[name])

--- a/dcore/state.py
+++ b/dcore/state.py
@@ -129,7 +129,6 @@ class State(object):
         # make functions on latlon mesh, as specified by dumplist_latlon
         to_dump_latlon = []
         for name in self.output.dumplist_latlon:
-            print name
             f = field_dict[name]
             f_ll = Function(functionspaceimpl.WithGeometry(f.function_space(), mesh_ll), val=f.topological, name=name+'_ll')
             field_dict_ll[name] = f_ll

--- a/examples/sw_williamson2_triangle.py
+++ b/examples/sw_williamson2_triangle.py
@@ -25,7 +25,7 @@ for ref_level, dt in ref_dt.iteritems():
     mesh.init_cell_orientations(global_normal)
 
     timestepping = TimesteppingParameters(dt=dt)
-    output = OutputParameters(dirname=dirname, steady_state_dump_err={'D':True,'u':True})
+    output = OutputParameters(dirname=dirname, dumplist_latlon=['D','Derr'], steady_state_dump_err={'D':True,'u':True})
 
     state = ShallowWaterState(mesh, vertical_degree=None, horizontal_degree=1,
                               family="BDM",

--- a/examples/sw_williamson6_triangle.py
+++ b/examples/sw_williamson6_triangle.py
@@ -18,9 +18,9 @@ timestepping = TimesteppingParameters(dt=120.)
 output = OutputParameters(dirname='sw_rossby_wave_ll', dumpfreq=1, dumplist_latlon=['D'])
 parameters = ShallowWaterParameters(H=H)
 diagnostics = Diagnostics(*fieldlist)
-diagnostic_fields = [CourantNumber()]#, Divergence(), Vorticity(), PotentialVorticity()]
+diagnostic_fields = [CourantNumber()]
 
-state = ShallowWaterState(mesh, vertical_degree=None, horizontal_degree=2,
+state = ShallowWaterState(mesh, vertical_degree=None, horizontal_degree=1,
                           family="BDM",
                           timestepping=timestepping,
                           output=output,
@@ -60,7 +60,6 @@ D0.interpolate(Dexpr)
 Vdg = VectorFunctionSpace(mesh, "DG", 2)
 state.initialise([u0, D0])
 advection_list = []
-#velocity_advection = EulerPoincareForm(state, state.V[0])
 velocity_advection = NoAdvection(state)
 advection_list.append((velocity_advection, 0))
 D_advection = DGAdvection(state, state.V[1], continuity=True)

--- a/examples/sw_williamson6_triangle.py
+++ b/examples/sw_williamson6_triangle.py
@@ -1,0 +1,78 @@
+from dcore import *
+from firedrake import IcosahedralSphereMesh, Expression, SpatialCoordinate, \
+    Constant, as_vector, VectorFunctionSpace, cos, sin
+
+refinements = 5  # number of horizontal cells = 20*(4^refinements)
+
+R = 6371220.
+H = 8000.
+day = 24.*60.*60.
+
+mesh = IcosahedralSphereMesh(radius=R,
+                             refinement_level=refinements)
+global_normal = Expression(("x[0]", "x[1]", "x[2]"))
+mesh.init_cell_orientations(global_normal)
+
+fieldlist = ['u', 'D']
+timestepping = TimesteppingParameters(dt=120.)
+output = OutputParameters(dirname='sw_rossby_wave_ll', dumpfreq=1, dumplist_latlon=['D'])
+parameters = ShallowWaterParameters(H=H)
+diagnostics = Diagnostics(*fieldlist)
+diagnostic_fields = [CourantNumber()]#, Divergence(), Vorticity(), PotentialVorticity()]
+
+state = ShallowWaterState(mesh, vertical_degree=None, horizontal_degree=2,
+                          family="BDM",
+                          timestepping=timestepping,
+                          output=output,
+                          parameters=parameters,
+                          diagnostics=diagnostics,
+                          fieldlist=fieldlist,
+                          diagnostic_fields=diagnostic_fields)
+
+g = parameters.g
+Omega = parameters.Omega
+
+# interpolate initial conditions
+# Initial/current conditions
+u0, D0 = Function(state.V[0]), Function(state.V[1])
+x = SpatialCoordinate(mesh)
+R = Constant(R)
+V = FunctionSpace(mesh, "CG", 2)
+phi = Function(V).interpolate(Expression("atan2(x[1],x[0])"))
+lambda0 = Function(V).interpolate(Expression("asin(x[2]/R)", R=R))
+omega = Constant(7.848e-6)
+K = omega
+uexpr = as_vector([R*omega*cos(lambda0) + R*K*cos(lambda0)**3*(4*sin(lambda0)**2 - cos(lambda0)**2)*cos(4*phi), -4*R*K*cos(lambda0)**3*sin(lambda0)*sin(4*phi), 0.0])
+h0 = Constant(H)
+Omega = Constant(parameters.Omega)
+g = Constant(parameters.g)
+Dexpr = h0 + R**2/g*(0.5*omega*(2*Omega+omega)*cos(lambda0)**2 + 0.25*K**2*cos(lambda0)**8*(5*cos(lambda0)**2 + 26 - 32/(cos(lambda0)**2)) + ((Omega+omega)*K/15.*cos(lambda0)**4*(26 - 25*cos(lambda0)**2))*cos(4*phi) + 0.25*K**2*cos(lambda0)**8*(5*cos(lambda0)**2-6)*cos(8*phi))
+# Coriolis expression
+fexpr = 2*Omega*x[2]/R
+V = FunctionSpace(mesh, "CG", 1)
+state.f = Function(V).interpolate(fexpr)  # Coriolis frequency (1/s)
+
+VX = VectorFunctionSpace(mesh, "Lagrange", 1)
+u_init = Function(VX).interpolate(uexpr)
+u0.project(u_init)
+D0.interpolate(Dexpr)
+
+Vdg = VectorFunctionSpace(mesh, "DG", 2)
+state.initialise([u0, D0])
+advection_list = []
+#velocity_advection = EulerPoincareForm(state, state.V[0])
+velocity_advection = NoAdvection(state)
+advection_list.append((velocity_advection, 0))
+D_advection = DGAdvection(state, state.V[1], continuity=True)
+advection_list.append((D_advection, 1))
+
+linear_solver = ShallowWaterSolver(state)
+
+# Set up forcing
+sw_forcing = ShallowWaterForcing(state)
+
+# build time stepper
+stepper = Timestepper(state, advection_list, linear_solver,
+                      sw_forcing)
+
+stepper.run(t=0, tmax=14*day)

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -20,7 +20,7 @@ def setup_sw(dirname):
 
     fieldlist = ['u', 'D']
     timestepping = TimesteppingParameters(dt=3600.)
-    output = OutputParameters(dirname=dirname+"/sw_linear_w2", steady_state_dump_err={'u':True,'D':True}, dumpfreq=12, dumplist_latlon=['D'])
+    output = OutputParameters(dirname=dirname+"/sw_linear_w2", steady_state_dump_err={'u':True,'D':True}, dumpfreq=12)
     parameters = ShallowWaterParameters(H=H)
     diagnostics = Diagnostics(*fieldlist)
 

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -20,7 +20,7 @@ def setup_sw(dirname):
 
     fieldlist = ['u', 'D']
     timestepping = TimesteppingParameters(dt=3600.)
-    output = OutputParameters(dirname=dirname+"/sw_linear_w2", steady_state_dump_err={'u':True,'D':True}, dumpfreq=12)
+    output = OutputParameters(dirname=dirname+"/sw_linear_w2", steady_state_dump_err={'u':True,'D':True}, dumpfreq=12, dumplist_latlon=['D'])
     parameters = ShallowWaterParameters(H=H)
     diagnostics = Diagnostics(*fieldlist)
 

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -19,7 +19,7 @@ def setup_sw(dirname):
 
     fieldlist = ['u', 'D']
     timestepping = TimesteppingParameters()
-    output = OutputParameters(dumplist=(True,True), dirname=dirname+"/sw")
+    output = OutputParameters(dumplist_latlon=['D'], dirname=dirname+"/sw")
     parameters = ShallowWaterParameters()
     diagnostics = Diagnostics(*fieldlist)
 


### PR DESCRIPTION
This provides the option to dump fields on a latlon coordinate mesh. The user specifies fieldnames in  output.dumplist_latlon, which is set by default to be an empty list. This option has been added to the sw_williamson_triangle test but this test doesn't currently do anything more than set up the initial conditions.

Concerns:
- the dump method is becoming rather long - would it be a good idea to move the creation of the latlon mesh to another place?
- is there a way to check if the original mesh is actually a sphere?! (or is this overkill?)