### PR TITLE
change default max iterations to the ones that work

### DIFF
--- a/dcore/configuration.py
+++ b/dcore/configuration.py
@@ -24,8 +24,8 @@ class TimesteppingParameters(Configuration):
     """
     dt = None
     alpha = 0.5
-    maxk = 2
-    maxi = 2
+    maxk = 4
+    maxi = 1
 
 
 class OutputParameters(Configuration):


### PR DESCRIPTION
With the current default number of outer and inner iterations we have stability issues. This pull requests changes the default number of inner and outer iterations which removes the stability issues for the shallow water Williamson 2 test case.