### PR TITLE
Fix diffusion

### DIFF
--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -80,7 +80,7 @@ for delta, dt in res_dt.iteritems():
     advection_dict["u"] = EulerPoincareForm(state, state.V[0])
     advection_dict["rho"] = DGAdvection(state, state.V[1], continuity=True)
     advection_dict["theta"] = SUPGAdvection(state, state.V[2], direction=[1])
-    #advection_dict["theta"] = EmbeddedDGAdvection(state, state.V[2], Vdg=Vtdg, continuity=False)
+    # advection_dict["theta"] = EmbeddedDGAdvection(state, state.V[2], Vdg=Vtdg, continuity=False)
 
     # Set up linear solver
     schur_params = {'pc_type': 'fieldsplit',
@@ -115,8 +115,8 @@ for delta, dt in res_dt.iteritems():
     V = state.V[0]
     bcs = [DirichletBC(V, Expression(("0.0","0.0")), "bottom"),
            DirichletBC(V, Expression(("0.0","0.0")), "top")]
-    diffusion_dict = {"u": InteriorPenalty(state, state.V[0], kappa=Constant(75.), mu=Constant(1./delta), bcs=bcs),
-                      "theta": InteriorPenalty(state, state.V[2], kappa=Constant(75.), mu=Constant(0.005))}
+    diffusion_dict = {"u": InteriorPenalty(state, state.V[0], kappa=Constant(75.), mu=Constant(10./delta), bcs=bcs),
+                      "theta": InteriorPenalty(state, state.V[2], kappa=Constant(75.), mu=Constant(10./delta))}
 
     # build time stepper
     stepper = Timestepper(state, advection_dict, linear_solver,

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -80,7 +80,7 @@ for delta, dt in res_dt.iteritems():
     advection_dict["u"] = EulerPoincareForm(state, state.V[0])
     advection_dict["rho"] = DGAdvection(state, state.V[1], continuity=True)
     advection_dict["theta"] = SUPGAdvection(state, state.V[2], direction=[1])
-    # theta_advection = EmbeddedDGAdvection(state, state.V[2], Vdg=Vtdg, continuity=False)
+    #advection_dict["theta"] = EmbeddedDGAdvection(state, state.V[2], Vdg=Vtdg, continuity=False)
 
     # Set up linear solver
     schur_params = {'pc_type': 'fieldsplit',
@@ -112,8 +112,11 @@ for delta, dt in res_dt.iteritems():
     # Set up forcing
     compressible_forcing = CompressibleForcing(state)
 
-    diffusion_dict = {"u": InteriorPenalty(state, state.V[0],direction=[2], params={"kappa":Constant(75.), "mu":Constant(1./delta)}),
-                      "theta": InteriorPenalty(state, state.V[2],direction=[2], params={"kappa":75., "mu":0.005})}
+    V = state.V[0]
+    bcs = [DirichletBC(V, Expression(("0.0","0.0")), "bottom"),
+           DirichletBC(V, Expression(("0.0","0.0")), "top")]
+    diffusion_dict = {"u": InteriorPenalty(state, state.V[0], kappa=Constant(75.), mu=Constant(1./delta), bcs=bcs),
+                      "theta": InteriorPenalty(state, state.V[2], kappa=Constant(75.), mu=Constant(0.005))}
 
     # build time stepper
     stepper = Timestepper(state, advection_dict, linear_solver,

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -1,6 +1,7 @@
 from gusto import *
 from firedrake import Expression, FunctionSpace,\
-    VectorFunctionSpace, PeriodicIntervalMesh, ExtrudedMesh, SpatialCoordinate
+    VectorFunctionSpace, PeriodicIntervalMesh, ExtrudedMesh, SpatialCoordinate,\
+    DirichletBC
 import sys
 
 if '--running-tests' in sys.argv:
@@ -113,8 +114,8 @@ for delta, dt in res_dt.iteritems():
     compressible_forcing = CompressibleForcing(state)
 
     V = state.V[0]
-    bcs = [DirichletBC(V, Expression(("0.0","0.0")), "bottom"),
-           DirichletBC(V, Expression(("0.0","0.0")), "top")]
+    bcs = [DirichletBC(V, 0.0, "bottom"),
+           DirichletBC(V, 0.0, "top")]
     diffusion_dict = {"u": InteriorPenalty(state, state.V[0], kappa=Constant(75.), mu=Constant(10./delta), bcs=bcs),
                       "theta": InteriorPenalty(state, state.V[2], kappa=Constant(75.), mu=Constant(10./delta))}
 

--- a/gusto/diffusion.py
+++ b/gusto/diffusion.py
@@ -42,12 +42,10 @@ class InteriorPenalty(Diffusion):
 
     """
 
-    def __init__(self, state, V, direction=[1,2], params=None):
+    def __init__(self, state, V, kappa, mu, bcs=None):
         super(InteriorPenalty, self).__init__(state)
 
         dt = state.timestepping.dt
-        kappa = params['kappa']
-        mu = params['mu']
         gamma = TestFunction(V)
         phi = TrialFunction(V)
         self.phi1 = Function(V)
@@ -61,12 +59,10 @@ class InteriorPenalty(Diffusion):
                       + mu*inner(2*avg(outer(phi, n)), 2*avg(outer(gamma, n)*kappa)))*dS
             return fluxes
 
-        if 1 in direction:
-            a += dt*get_flux_form(dS_v, kappa)
-        if 2 in direction:
-            a += dt*get_flux_form(dS_h, kappa)
+        a += dt*get_flux_form(dS_v, kappa)
+        a += dt*get_flux_form(dS_h, kappa)
         L = inner(gamma,phi)*dx
-        problem = LinearVariationalProblem(a, action(L,self.phi1), self.phi1)
+        problem = LinearVariationalProblem(a, action(L,self.phi1), self.phi1, bcs=bcs)
         self.solver = LinearVariationalSolver(problem)
 
     def apply(self, x_in, x_out):

--- a/gusto/diffusion.py
+++ b/gusto/diffusion.py
@@ -35,10 +35,10 @@ class InteriorPenalty(Diffusion):
     :arg state: :class:`.State` object.
     :arg V: Function space of diffused field
     :arg direction: list containing directions in which function space
-    is discontinuous: 1 corresponds to vertical, 2 to horizontal.
-    :arg params: dictionary containing the interior penalty parameters
-    :mu and kappa where mu is the penalty weighting function, which is
+    :arg: mu: the penalty weighting function, which is
     :recommended to be proportional to 1/dx
+    :arg: kappa: strength of diffusion
+    :arg: bcs: (optional) a list of boundary conditions to apply
 
     """
 

--- a/tests/test_IP_diffusion.py
+++ b/tests/test_IP_diffusion.py
@@ -57,8 +57,8 @@ def run(dirname, vector, DG):
 
     kappa = Constant(0.05)
     if vector:
-        kappa = as_tensor([[kappa, 0.],[0., kappa]])
-    mu = 5.
+        kappa = Constant([[0.05, 0.],[0., 0.05]])
+    mu = Constant(5.)
     dt = state.timestepping.dt
     tmax = 2.5
     t = 0.

--- a/tests/test_IP_diffusion.py
+++ b/tests/test_IP_diffusion.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, Expression, \
-    VectorFunctionSpace, File, as_tensor
+    VectorFunctionSpace, File
 import pytest
 
 

--- a/tests/test_IP_diffusion.py
+++ b/tests/test_IP_diffusion.py
@@ -55,19 +55,14 @@ def run(dirname, vector, DG):
 
     state, f = setup_IPdiffusion(vector, DG)
 
-    if DG:
-        direction = [1,2]
-    else:
-        direction = [1]
-
-    kappa = 0.05
+    kappa = Constant(0.05)
     if vector:
         kappa = as_tensor([[kappa, 0.],[0., kappa]])
     mu = 5.
     dt = state.timestepping.dt
     tmax = 2.5
     t = 0.
-    f_diffusion = InteriorPenalty(state, f.function_space(), direction=direction, params={"kappa":kappa, "mu":Constant(mu)})
+    f_diffusion = InteriorPenalty(state, f.function_space(), kappa=kappa, mu=Constant(mu))
     outfile = File(path.join(dirname, "IPdiffusion/field_output.pvd"))
 
     dumpcount = itertools.count()


### PR DESCRIPTION
This pull request fixes some issues with the InteriorPenalty diffusion method.

1) kappa and mu are now keyword arguments as they must be provided
2) added optional bcs argument so that we can apply to correct no normal flow boundary conditions for the dense bubble test
3) removed the directions argument that was used to specify the direction in which the field was discontinuous so that only the surface terms in that direction were added - instead we now assemble all the surface terms and those in the continuous direction are zero. This is less confusing for the user.