### PR TITLE
Eady model works on Gusto

### DIFF
--- a/examples/nonlinear_eady.py
+++ b/examples/nonlinear_eady.py
@@ -159,7 +159,7 @@ linear_solver = IncompressibleSolver(state, 2.*L, params=linear_solver_params)
 ##############################################################################
 # Set up forcing
 ##############################################################################
-forcing = EadyForcing(state, linear=True)
+forcing = EadyForcing(state, euler_poincare=False)
 
 ##############################################################################
 # build time stepper

--- a/examples/nonlinear_eady.py
+++ b/examples/nonlinear_eady.py
@@ -4,7 +4,7 @@ from firedrake import as_vector, SpatialCoordinate, \
     cos, sin, cosh, sinh, tanh, pi
 import sys
 
-dt = 100.
+dt = 20.
 if '--running-tests' in sys.argv:
     tmax = dt
     # avoid using mumps on Travis
@@ -56,7 +56,7 @@ timestepping = TimesteppingParameters(dt=dt)
 # class containing output parameters
 # all values not explicitly set here use the default values provided
 # and documented in configuration.py
-output = OutputParameters(dirname='nonlinear_eady', dumpfreq=12*36, dumplist=['u','p'], perturbation_fields=['b'])
+output = OutputParameters(dirname='nonlinear_eady', dumpfreq=60*36, dumplist=['u','p'], perturbation_fields=['b'])
 
 # class containing physical parameters
 # all values not explicitly set here use the default values provided
@@ -100,9 +100,9 @@ Vb = b0.function_space()
 # from the parameters class.
 x, y, z = SpatialCoordinate(mesh)
 Nsq = parameters.Nsq
-bref = z*Nsq
+bref = (z-H/2)*Nsq
 # interpolate the expression to the function
-b_b = Function(Vb).interpolate(bref)
+b_b = Function(Vb).project(bref)
 
 
 # setup constants
@@ -138,7 +138,7 @@ state.set_reference_profiles({'b':b_b})
 # Set up advection schemes
 ##############################################################################
 # we need a DG funciton space for the embedded DG advection scheme
-ueqn = EulerPoincare(state, Vu)
+ueqn = AdvectionEquation(state, Vu)
 supg = True
 if supg:
     beqn = SUPGAdvection(state, Vb,
@@ -148,7 +148,7 @@ else:
     beqn = EmbeddedDGAdvection(state, Vb,
                                equation_form="advective")
 advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
+advection_dict["u"] = SSPRK3(state, u0, ueqn)
 advection_dict["b"] = SSPRK3(state, b0, beqn)
 
 ##############################################################################
@@ -159,7 +159,7 @@ linear_solver = IncompressibleSolver(state, 2.*L, params=linear_solver_params)
 ##############################################################################
 # Set up forcing
 ##############################################################################
-forcing = EadyForcing(state)
+forcing = EadyForcing(state, linear=True)
 
 ##############################################################################
 # build time stepper

--- a/examples/nonlinear_eady.py
+++ b/examples/nonlinear_eady.py
@@ -4,7 +4,7 @@ from firedrake import as_vector, SpatialCoordinate, \
     cos, sin, cosh, sinh, tanh, pi
 import sys
 
-dt = 20.
+dt = 30.
 if '--running-tests' in sys.argv:
     tmax = dt
     # avoid using mumps on Travis
@@ -56,7 +56,7 @@ timestepping = TimesteppingParameters(dt=dt)
 # class containing output parameters
 # all values not explicitly set here use the default values provided
 # and documented in configuration.py
-output = OutputParameters(dirname='nonlinear_eady', dumpfreq=60*36, dumplist=['u','p'], perturbation_fields=['b'])
+output = OutputParameters(dirname='nonlinear_eady', dumpfreq=40*36, dumplist=['u','p'], perturbation_fields=['b'])
 
 # class containing physical parameters
 # all values not explicitly set here use the default values provided
@@ -139,7 +139,7 @@ state.set_reference_profiles({'b':b_b})
 ##############################################################################
 # we need a DG funciton space for the embedded DG advection scheme
 ueqn = AdvectionEquation(state, Vu)
-supg = True
+supg = False
 if supg:
     beqn = SUPGAdvection(state, Vb,
                          supg_params={"dg_direction":"horizontal"},

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -239,14 +239,9 @@ class EadyForcing(Forcing):
     Forcing class for Eady Boussinesq equations.
     """
 
-    def __init__(self, state, linear=False):
-        self.state = state
-
-        self._build_forcing_solver(linear)
-
-    def _build_forcing_solver(self, linear):
+    def _build_forcing_solver(self):
         """
-        Only put forcing terms into the u equation.
+        Put forcing terms into the u & b equations.
         """
 
         state = self.state
@@ -279,7 +274,7 @@ class EadyForcing(Forcing):
             - dbdy*eady_exp*inner(w,as_vector([0.,1.,0.]))  # Eady forcing
         )*dx
 
-        if not linear:
+        if self.euler_poincare:
             L -= self.scaling*0.5*div(w)*inner(u0, u0)*dx
 
         if Omega is not None:
@@ -298,7 +293,7 @@ class EadyForcing(Forcing):
 
         self.u_forcing_solver = LinearVariationalSolver(u_forcing_problem)
 
-        # b_forcing
+# b_forcing
 
         Vb = state.spaces("HDiv_v")
 
@@ -315,7 +310,7 @@ class EadyForcing(Forcing):
 
         self.b_forcing_solver = LinearVariationalSolver(b_forcing_problem)
 
-        # divergence_free
+# divergence_free
 
         Vp = state.spaces("DG")
         p = TrialFunction(Vp)


### PR DESCRIPTION
Eady model works on Gusto when using both:

1. ueqn = AdvectionEquation with euler_poincare = False in the forcing
2. about one third of the time step used in slicemodels

With this setting, beqn = EmbeddedDGAdvection also works so I made it as default.
For the time-stepping of u, SSPRK3 is used as it currently allows the use of a bigger dt than ThetaMethod.