### PR TITLE
Change default solver parameters for advection schemes and add optional argument

### DIFF
--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -21,10 +21,12 @@ class TransportEquation(object):
     :arg V: :class:`.FunctionSpace object. The function space that q lives in.
     :arg ibp: string, stands for 'integrate by parts' and can take the value
               None, "once" or "twice". Defaults to "once".
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, state, V, ibp="once"):
+    def __init__(self, state, V, ibp="once", solver_params=None):
         self.state = state
         self.V = V
         self.ibp = ibp
@@ -56,10 +58,14 @@ class TransportEquation(object):
             self.n = FacetNormal(state.mesh)
             self.un = 0.5*(dot(self.ubar, self.n) + abs(dot(self.ubar, self.n)))
 
+        if solver_params:
+            self.solver_parameters = solver_params
+
         # default solver options
-        self.solver_parameters = {'ksp_type':'preonly',
-                                  'pc_type':'lu',
-                                  'pc_factor_mat_solver_package': 'mumps'}
+        else:
+            self.solver_parameters = {'ksp_type': 'cg',
+                                      'pc_type': 'bjacobi',
+                                      'sub_pc_type': 'ilu'}
 
     def mass_term(self, q):
         return inner(self.test, q)*dx
@@ -86,10 +92,12 @@ class LinearAdvection(TransportEquation):
                         L(q) = div(u'*qbar), or 'advective', which means the
                         equation is in advective form L(q) = u' dot grad(qbar).
                         Default is "advective"
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
 
-    def __init__(self, state, V, qbar, ibp=None, equation_form="advective"):
-        super(LinearAdvection, self).__init__(state, V, ibp)
+    def __init__(self, state, V, qbar, ibp=None, equation_form="advective", solver_params=None):
+        super(LinearAdvection, self).__init__(state, V, ibp, solver_params)
         if equation_form == "advective" or equation_form == "continuity":
             self.continuity = (equation_form == "continuity")
         else:
@@ -131,9 +139,11 @@ class AdvectionEquation(TransportEquation):
                         L(q) = div(u*q), or 'advective', which means the
                         equation is in advective form L(q) = u dot grad(q).
                         Default is "advective"
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
-    def __init__(self, state, V, ibp="once", equation_form="advective"):
-        super(AdvectionEquation, self).__init__(state, V, ibp)
+    def __init__(self, state, V, ibp="once", equation_form="advective", solver_params=None):
+        super(AdvectionEquation, self).__init__(state, V, ibp, solver_params)
         if equation_form == "advective" or equation_form == "continuity":
             self.continuity = (equation_form == "continuity")
         else:
@@ -179,9 +189,11 @@ class EmbeddedDGAdvection(AdvectionEquation):
     :arg Vdg: (optional) :class:`.FunctionSpace object. The embedding function
               space. Defaults to None which means that a broken space is
               constructed for you.
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
 
-    def __init__(self, state, V, ibp="once", equation_form="advective", Vdg=None):
+    def __init__(self, state, V, ibp="once", equation_form="advective", Vdg=None, solver_params=None):
 
         if Vdg is None:
             # Create broken space, functions and projector
@@ -190,7 +202,7 @@ class EmbeddedDGAdvection(AdvectionEquation):
         else:
             self.space = Vdg
 
-        super(EmbeddedDGAdvection, self).__init__(state, self.space, ibp, equation_form)
+        super(EmbeddedDGAdvection, self).__init__(state, self.space, ibp, equation_form, solver_params)
 
 
 class SUPGAdvection(AdvectionEquation):
@@ -220,9 +232,11 @@ class SUPGAdvection(AdvectionEquation):
                       this direction.
                       Appropriate defaults are provided for these parameters,
                       in particular, the space is assumed to be continuous.
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
-    def __init__(self, state, V, ibp="twice", equation_form="advective", supg_params=None):
-        super(SUPGAdvection, self).__init__(state, V, ibp, equation_form)
+    def __init__(self, state, V, ibp="twice", equation_form="advective", supg_params=None, solver_params=None):
+        super(SUPGAdvection, self).__init__(state, V, ibp, equation_form, solver_params)
 
         # if using SUPG we either integrate by parts twice, or not at all
         if ibp == "once":
@@ -285,9 +299,11 @@ class VectorInvariant(TransportEquation):
     :arg V: Function space
     :arg ibp: (optional) string, stands for 'integrate by parts' and can
               take the value None, "once" or "twice". Defaults to "once".
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
-    def __init__(self, state, V, ibp="once"):
-        super(VectorInvariant, self).__init__(state, V, ibp)
+    def __init__(self, state, V, ibp="once", solver_params=None):
+        super(VectorInvariant, self).__init__(state, V, ibp, solver_params)
 
         self.Upwind = 0.5*(sign(dot(self.ubar, self.n))+1)
 
@@ -351,6 +367,8 @@ class EulerPoincare(VectorInvariant):
     :arg V: Function space
     :arg ibp: string, stands for 'integrate by parts' and can take the value
               None, "once" or "twice". Defaults to "once".
+    :arg solver_params: (optional) dictionary of solver parameters to pass to the
+                        linear solver.
     """
 
     def advection_term(self, q):


### PR DESCRIPTION
The current default parameters for `TransportEquation` uses LU+MUMPS, and causes everything to choke for higher resolution problems. I believe conjugate gradient preconditioned with block-jacobi/ILU is a better compromise. Larger problems no longer freeze up and everything continues as normal.

If the default parameters are not sufficient for a particular problem, you can now pass an optional set of solver parameters to use instead (via `solver_params`). Just like the linear solvers.