### PR TITLE
use GMRES rather than CG in asymmetric advection cases

### DIFF
--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -197,6 +197,14 @@ class ThetaMethod(Advection):
     y_(n+1) = y_n + dt*(theta*L(y_n) + (1-theta)*L(y_(n+1))) where L is the advection operator.
     """
     def __init__(self, state, field, equation, theta=0.5, solver_params=None):
+
+        if not solver_params:
+            # theta method leads to asymmetric matrix, per lhs function below,
+            # so don't use CG
+            solver_params = {'ksp_type': 'gmres',
+                             'pc_type': 'bjacobi',
+                             'sub_pc_type': 'ilu'}
+
         super(ThetaMethod, self).__init__(state, field, equation, solver_params)
 
         self.theta = theta

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -236,6 +236,14 @@ class SUPGAdvection(AdvectionEquation):
                         linear solver.
     """
     def __init__(self, state, V, ibp="twice", equation_form="advective", supg_params=None, solver_params=None):
+
+        if not solver_params:
+            # SUPG method leads to asymmetric matrix (since the test function
+            # is effectively modified), so don't use CG
+            solver_params = {'ksp_type': 'gmres',
+                             'pc_type': 'bjacobi',
+                             'sub_pc_type': 'ilu'}
+
         super(SUPGAdvection, self).__init__(state, V, ibp, equation_form, solver_params)
 
         # if using SUPG we either integrate by parts twice, or not at all


### PR DESCRIPTION
Turns out these options get used for nonsymmetric systems (e.g. via `ThetaMethod`), and CG is a Bad Idea for those.  At this point, I'm wondering if these options should be here at all... GMRES/BJacobi/ILU is just the Firedrake -- rather, PETSc -- default, no?