### PR TITLE
Perturbed diagnostics

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -165,7 +165,7 @@ state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
 
 # set the background profiles
 state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
-state.set_diagnostic_reference_profiles({'Exner_pi':Pi_b}, diagnostic_fields)
+state.set_diagnostic_reference_profiles({'Exner_pi': Pi_b}, diagnostic_fields)
 
 ##############################################################################
 # Set up advection schemes

--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -67,7 +67,7 @@ diagnostics = Diagnostics(*fieldlist)
 
 # list of diagnostic fields, each defined in a class in diagnostics.py
 diagnostic_fields = [CourantNumber(), VelocityY(),
-                     ExnerPi(), ExnerPi_perturbation(),
+                     ExnerPi(), Perturbed_Diagnostic(ExnerPi(), key='Exner_pi'),
                      CompressibleKineticEnergy(),
                      CompressibleKineticEnergyY(),
                      CompressibleEadyPotentialEnergy(),
@@ -140,6 +140,7 @@ theta0.interpolate(theta_b + theta_pert)
 rho_b = Function(Vr)
 compressible_hydrostatic_balance(state, theta_b, rho_b)
 compressible_hydrostatic_balance(state, theta0, rho0)
+Pi_b = exner(theta_b, rho_b, state)
 
 # set Pi0
 Pi0 = calculate_Pi0(state, theta0, rho0)
@@ -164,6 +165,7 @@ state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
 
 # set the background profiles
 state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.set_diagnostic_reference_profiles({'Exner_pi':Pi_b}, diagnostic_fields)
 
 ##############################################################################
 # Set up advection schemes

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -289,3 +289,33 @@ class Perturbation(Difference):
     @property
     def name(self):
         return self.field1+"_perturbation"
+
+
+class Perturbed_Diagnostic(DiagnosticField):
+
+    def __init__(self, diagnostic, key=None):
+        self.diagnostic = diagnostic
+        self.perturbation = True
+        self.key = key # a string to identify the diagnostic
+
+
+    @property
+    def name(self):
+        return self.diagnostic.name+"_perturbation"
+
+
+    def initialise(self, state):
+        # set up the base field for the diagnostic
+        self.initial_field = Function(self.diagnostic.field(state.mesh).function_space()).assign(diagnostic.compute(state))
+
+
+    def field(self, mesh):
+        if hasattr(self, "_field"):
+            return self._field
+        self._field = Function(self.diagnostic.field(mesh).function_space(), name=self.name)
+        return self._field
+
+
+    def compute(self, state):
+        current_field = self.diagnostic.compute(state)
+        return self.field(state.mesh).assign(current_field - self.initial_field)

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -296,25 +296,21 @@ class Perturbed_Diagnostic(DiagnosticField):
     def __init__(self, diagnostic, key=None):
         self.diagnostic = diagnostic
         self.perturbation = True
-        self.key = key # a string to identify the diagnostic
-
+        self.key = key  # a string to identify the diagnostic
 
     @property
     def name(self):
         return self.diagnostic.name+"_perturbation"
 
-
     def initialise(self, state):
         # set up the base field for the diagnostic
-        self.initial_field = Function(self.diagnostic.field(state.mesh).function_space()).assign(diagnostic.compute(state))
-
+        self.initial_field = Function(self.diagnostic.field(state.mesh).function_space()).assign(self.diagnostic.compute(state))
 
     def field(self, mesh):
         if hasattr(self, "_field"):
             return self._field
         self._field = Function(self.diagnostic.field(mesh).function_space(), name=self.name)
         return self._field
-
 
     def compute(self, state):
         current_field = self.diagnostic.compute(state)

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -195,19 +195,6 @@ class ExnerPi(DiagnosticField):
         return self.field(state.mesh).interpolate(Pi)
 
 
-class ExnerPi_perturbation(ExnerPi):
-    name = "ExnerPi_perturbation"
-
-    def compute(self, state):
-        rho = state.fields("rho")
-        rhobar = state.fields("rhobar")
-        theta = state.fields("theta")
-        thetabar = state.fields("thetabar")
-        Pi = exner(theta, rho, state)
-        Pibar = exner(thetabar, rhobar, state)
-        return self.field(state.mesh).interpolate(Pi-Pibar)
-
-
 class Sum(DiagnosticField):
 
     def __init__(self, field1, field2):

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -317,16 +317,20 @@ class State(object):
         Initialise the perturbed diagnostic fields with base fields of the user's choice.
         """
         for name, profile in reference_profiles.iteritems():
+            found_diagnostic = False
             for diagnostic in diagnostic_fields:
+                print diagnostic
                 if hasattr(diagnostic, 'perturbation'):
                     if hasattr(diagnostic, 'key'):
                         if name is diagnostic.key:
                             diagnostic.initialise(self)
                             diagnostic.initial_field.interpolate(profile)
                             diagnostic.perturbation = False
+                            found_diagnostic = True
                             break
-            print "Error: no matching key found for perturbed diagnostic."
-            raise LookupError
+            if not found_diagnostic:
+                print "Error: no matching key found for perturbed diagnostic", name
+                raise LookupError
 
     def _build_spaces(self, mesh, vertical_degree, horizontal_degree, family):
         """

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -192,6 +192,12 @@ class State(object):
             self.diagnostic_fields.append(f)
             self.diagnostics.register(f.name)
 
+        # initialise the base state for any perturbed diagnostic fields
+        for diagnostic in self.diagnostic_fields:
+            if hasattr(diagnostic, "perturbation"):
+                if diagnostic.perturbation:
+                    diagnostic.initialise(self)
+
         # add diagnostic fields to field dictionary and ensure they are dumped
         for diagnostic in self.diagnostic_fields:
             f = diagnostic(self)

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -326,6 +326,7 @@ class State(object):
                             diagnostic.perturbation = False
                             break
             print "Error: no matching key found for perturbed diagnostic."
+            raise LookupError
 
     def _build_spaces(self, mesh, vertical_degree, horizontal_degree, family):
         """

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -324,6 +324,8 @@ class State(object):
                             diagnostic.initialise(self)
                             diagnostic.initial_field.interpolate(profile)
                             diagnostic.perturbation = False
+                            break
+            print "Error: no matching key found for perturbed diagnostic."
 
     def _build_spaces(self, mesh, vertical_degree, horizontal_degree, family):
         """

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -312,6 +312,19 @@ class State(object):
             ref = self.fields(name+'bar', field.function_space(), False)
             ref.interpolate(profile)
 
+    def set_diagnostic_reference_profiles(self, reference_profiles, diagnostic_fields):
+        """
+        Initialise the perturbed diagnostic fields with base fields of the user's choice.
+        """
+        for name, profile in reference_profiles.iteritems():
+            for diagnostic in diagnostic_fields:
+                if hasattr(diagnostic, 'perturbation'):
+                    if hasattr(diagnostic, 'key'):
+                        if name is diagnostic.key:
+                            diagnostic.initialise(self)
+                            diagnostic.initial_field.interpolate(profile)
+                            diagnostic.perturbation = False
+
     def _build_spaces(self, mesh, vertical_degree, horizontal_degree, family):
         """
         Build:


### PR DESCRIPTION
This pull request is intended to provide a facility for making diagnostic fields that are perturbations of other diagnostic fields.

There are two sections of code for setting the base field. Either you can set a chosen reference profile, or the base field will be automatically calculated from the initial model state.

I've also edited the compressible eady test to use this feature.