### PR TITLE
Python3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
     environment {
         PATH = "/usr/local/bin:/usr/bin:/bin"
         CC = "mpicc"
+        PYTHONHASHSEED="1243123"
     }
     stages {
         stage('Clean') {
@@ -19,10 +20,8 @@ pipeline {
                 sh 'mkdir build'
                 dir('build') {
                     timestamps {
-                        sh 'pip2 install virtualenv'
                         sh 'curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install'
-                        sh 'python2 ./firedrake-install --disable-ssh --minimal-petsc'
-                        sh '$HOME/.local/bin/virtualenv --relocatable firedrake'
+                        sh 'python3 ./firedrake-install --disable-ssh --minimal-petsc'
                     }
                 }
             }
@@ -32,7 +31,7 @@ pipeline {
                 timestamps {
                     sh '''
 . build/firedrake/bin/activate
-pip install -e .
+python -m pip install -e .
 '''
                 }
             }
@@ -54,8 +53,8 @@ make lint
 . build/firedrake/bin/activate
 export PYOP2_CACHE_DIR=${VIRTUAL_ENV}/pyop2_cache
 export FIREDRAKE_TSFC_KERNEL_CACHE_DIR=${VIRTUAL_ENV}/tsfc_cache
-firedrake-clean
-py.test -v tests -n 4
+python $(which firedrake-clean)
+python -m pytest -n 4 -v tests
 '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
                 sh 'mkdir build'
                 dir('build') {
                     timestamps {
-                        sh 'curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install'
-                        sh 'python3 ./firedrake-install --disable-ssh --minimal-petsc'
+                        sh 'curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/python3/scripts/firedrake-install'
+                        sh 'python3 ./firedrake-install --disable-ssh --minimal-petsc --package-branch firedrake python3'
                     }
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 lint:
 	@echo "    Linting gusto codebase"
-	@flake8 gusto
+	@python3 -m flake8 gusto
 	@echo "    Linting gusto examples"
-	@flake8 examples
+	@python3 -m flake8 examples
 	@echo "    Linting gusto tests"
-	@flake8 tests
+	@python3 -m flake8 tests
 
 test:
 	@echo "    Running all tests"
-	@py.test tests $(PYTEST_ARGS)
+	@python3 - m pytest tests $(PYTEST_ARGS)

--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -173,10 +173,10 @@ ueqn = AdvectionEquation(state, Vu)
 rhoeqn = AdvectionEquation(state, Vr, equation_form="continuity")
 thetaeqn = SUPGAdvection(state, Vt, supg_params={"dg_direction": "horizontal"})
 
-advection_dict = {}
-advection_dict["u"] = SSPRK3(state, u0, ueqn)
-advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+advected_fields = []
+advected_fields.append(("u", SSPRK3(state, u0, ueqn)))
+advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 ##############################################################################
 # Set up linear solver for the timestepping scheme
@@ -213,7 +213,7 @@ forcing = CompressibleEadyForcing(state, euler_poincare=False)
 ##############################################################################
 # build time stepper
 ##############################################################################
-stepper = Timestepper(state, advection_dict, linear_solver, forcing)
+stepper = Timestepper(state, advected_fields, linear_solver, forcing)
 
 ##############################################################################
 # Run!

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -15,7 +15,7 @@ L = 51200.
 # build volume mesh
 H = 6400.  # Height position of the model top
 
-for delta, dt in res_dt.iteritems():
+for delta, dt in res_dt.items():
 
     dirname = "db_dx%s_dt%s" % (delta, dt)
     nlayers = int(H/delta)  # horizontal layers

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -81,10 +81,10 @@ for delta, dt in res_dt.items():
     else:
         thetaeqn = EmbeddedDGAdvection(state, Vt,
                                        equation_form="advective")
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-    advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+    advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
     # Set up linear solver
     schur_params = {'pc_type': 'fieldsplit',
@@ -118,13 +118,13 @@ for delta, dt in res_dt.items():
 
     bcs = [DirichletBC(Vu, 0.0, "bottom"),
            DirichletBC(Vu, 0.0, "top")]
-    diffusion_dict = {"u": InteriorPenalty(state, Vu, kappa=Constant(75.),
-                                           mu=Constant(10./delta), bcs=bcs),
-                      "theta": InteriorPenalty(state, Vt, kappa=Constant(75.),
-                                               mu=Constant(10./delta))}
+    diffused_fields = [("u", InteriorPenalty(state, Vu, kappa=Constant(75.),
+                                             mu=Constant(10./delta), bcs=bcs)),
+                       ("theta", InteriorPenalty(state, Vt, kappa=Constant(75.),
+                                                 mu=Constant(10./delta)))]
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
-                          compressible_forcing, diffusion_dict)
+    stepper = Timestepper(state, advected_fields, linear_solver,
+                          compressible_forcing, diffused_fields)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -131,7 +131,7 @@ state.set_reference_profiles({'b': b_b})
 ##############################################################################
 # Set up advection schemes
 ##############################################################################
-# advection_dict is a dictionary containing field_name: advection class
+# advected_fields is a dictionary containing field_name: advection class
 ueqn = EulerPoincare(state, Vu)
 supg = True
 if supg:
@@ -141,9 +141,9 @@ if supg:
 else:
     beqn = EmbeddedDGAdvection(state, Vb,
                                equation_form="advective")
-advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-advection_dict["b"] = SSPRK3(state, b0, beqn)
+advected_fields = []
+advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+advected_fields.append(("b", SSPRK3(state, b0, beqn)))
 
 ##############################################################################
 # Set up linear solver for the timestepping scheme
@@ -158,7 +158,7 @@ forcing = IncompressibleForcing(state)
 ##############################################################################
 # build time stepper
 ##############################################################################
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       forcing)
 
 ##############################################################################

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -184,9 +184,9 @@ if supg:
 else:
     beqn = EmbeddedDGAdvection(state, Vb,
                                equation_form="advective")
-advection_dict = {}
-advection_dict["u"] = SSPRK3(state, u0, ueqn)
-advection_dict["b"] = SSPRK3(state, b0, beqn)
+advected_fields = []
+advected_fields.append(("u", SSPRK3(state, u0, ueqn)))
+advected_fields.append(("b", SSPRK3(state, b0, beqn)))
 
 ##############################################################################
 # Set up linear solver for the timestepping scheme
@@ -201,7 +201,7 @@ forcing = EadyForcing(state, euler_poincare=False)
 ##############################################################################
 # build time stepper
 ##############################################################################
-stepper = Timestepper(state, advection_dict, linear_solver, forcing)
+stepper = Timestepper(state, advected_fields, linear_solver, forcing)
 
 ##############################################################################
 # Run!

--- a/examples/nh_mountain.py
+++ b/examples/nh_mountain.py
@@ -136,10 +136,10 @@ if supg:
     thetaeqn = SUPGAdvection(state, Vt, supg_params={"dg_direction": "horizontal"}, equation_form="advective")
 else:
     thetaeqn = EmbeddedDGAdvection(state, Vt, equation_form="advective")
-advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+advected_fields = []
+advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
 schur_params = {'pc_type': 'fieldsplit',
@@ -172,7 +172,7 @@ linear_solver = CompressibleSolver(state, params=schur_params)
 compressible_forcing = CompressibleForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -73,10 +73,10 @@ if supg:
 else:
     thetaeqn = EmbeddedDGAdvection(state, Vt,
                                    equation_form="advective")
-advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+advected_fields = []
+advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
 schur_params = {'pc_type': 'fieldsplit',
@@ -109,7 +109,7 @@ linear_solver = CompressibleSolver(state, params=schur_params)
 compressible_forcing = CompressibleForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -84,10 +84,10 @@ state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
 ueqn = EulerPoincare(state, Vu)
 rhoeqn = AdvectionEquation(state, Vr, equation_form="continuity")
 thetaeqn = SUPGAdvection(state, Vt, supg_params={"dg_direction": "horizontal"})
-advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+advected_fields = []
+advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
 schur_params = {'pc_type': 'fieldsplit',
@@ -120,7 +120,7 @@ balanced_pg = as_vector((0., 1.0e-4*20, 0.))
 compressible_forcing = CompressibleForcing(state, extra_terms=balanced_pg)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -76,10 +76,10 @@ state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
 # Set up advection schemes
 rhoeqn = LinearAdvection(state, Vr, qbar=rho_b, ibp="once", equation_form="continuity")
 thetaeqn = LinearAdvection(state, Vt, qbar=theta_b)
-advection_dict = {}
-advection_dict["u"] = NoAdvection(state, u0, None)
-advection_dict["rho"] = ForwardEuler(state, rho0, rhoeqn)
-advection_dict["theta"] = ForwardEuler(state, theta0, thetaeqn)
+advected_fields = []
+advected_fields.append(("u", NoAdvection(state, u0, None)))
+advected_fields.append(("rho", ForwardEuler(state, rho0, rhoeqn)))
+advected_fields.append(("theta", ForwardEuler(state, theta0, thetaeqn)))
 
 # Set up linear solver
 schur_params = {'pc_type': 'fieldsplit',
@@ -112,7 +112,7 @@ linear_solver = CompressibleSolver(state, params=schur_params)
 compressible_forcing = CompressibleForcing(state, linear=True)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -84,10 +84,10 @@ if supg:
     thetaeqn = SUPGAdvection(state, Vt, supg_params={"dg_direction": "horizontal"}, equation_form="advective")
 else:
     thetaeqn = EmbeddedDGAdvection(state, Vt, equation_form="advective")
-advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+advected_fields = []
+advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
 schur_params = {'pc_type': 'fieldsplit',
@@ -120,7 +120,7 @@ linear_solver = CompressibleSolver(state, params=schur_params)
 compressible_forcing = CompressibleForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sw_hollingsworth.py
+++ b/examples/sw_hollingsworth.py
@@ -73,9 +73,9 @@ for ref_level, dt in ref_dt.items():
     else:
         ueqn = VectorInvariant(state, u0.function_space())
     Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["D"] = SSPRK3(state, D0, Deqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("D", SSPRK3(state, D0, Deqn)))
 
     linear_solver = ShallowWaterSolver(state)
 
@@ -83,7 +83,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state, euler_poincare=euler_poincare)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_hollingsworth.py
+++ b/examples/sw_hollingsworth.py
@@ -24,7 +24,7 @@ fieldlist = ['u', 'D']
 parameters = ShallowWaterParameters(H=H)
 diagnostics = Diagnostics(*fieldlist)
 
-for ref_level, dt in ref_dt.iteritems():
+for ref_level, dt in ref_dt.items():
 
     dirname = "sw_hollingsworth_ref%s_dt%s" % (ref_level, dt)
     mesh = IcosahedralSphereMesh(radius=R,

--- a/examples/sw_linear_williamson2_triangle.py
+++ b/examples/sw_linear_williamson2_triangle.py
@@ -61,9 +61,9 @@ D0.interpolate(Dexpr)
 state.initialise({'u': u0, 'D': D0})
 
 Deqn = LinearAdvection(state, D0.function_space(), state.parameters.H, ibp="once", equation_form="continuity")
-advection_dict = {}
-advection_dict["u"] = NoAdvection(state, u0, None)
-advection_dict["D"] = ForwardEuler(state, D0, Deqn)
+advected_fields = []
+advected_fields.append(("u", NoAdvection(state, u0, None)))
+advected_fields.append(("D", ForwardEuler(state, D0, Deqn)))
 
 linear_solver = ShallowWaterSolver(state)
 
@@ -71,7 +71,7 @@ linear_solver = ShallowWaterSolver(state)
 sw_forcing = ShallowWaterForcing(state, linear=True)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       sw_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson2_triangle.py
+++ b/examples/sw_williamson2_triangle.py
@@ -65,9 +65,9 @@ for ref_level, dt in ref_dt.items():
 
     ueqn = EulerPoincare(state, u0.function_space())
     Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["D"] = SSPRK3(state, D0, Deqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("D", SSPRK3(state, D0, Deqn)))
 
     linear_solver = ShallowWaterSolver(state)
 
@@ -75,7 +75,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson2_triangle.py
+++ b/examples/sw_williamson2_triangle.py
@@ -23,7 +23,7 @@ fieldlist = ['u', 'D']
 parameters = ShallowWaterParameters(H=H)
 diagnostics = Diagnostics(*fieldlist)
 
-for ref_level, dt in ref_dt.iteritems():
+for ref_level, dt in ref_dt.items():
 
     dirname = "sw_W2_ref%s_dt%s" % (ref_level, dt)
     mesh = IcosahedralSphereMesh(radius=R,

--- a/examples/sw_williamson5.py
+++ b/examples/sw_williamson5.py
@@ -69,9 +69,9 @@ for ref_level, dt in ref_dt.items():
 
     ueqn = EulerPoincare(state, u0.function_space())
     Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["D"] = SSPRK3(state, D0, Deqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("D", SSPRK3(state, D0, Deqn)))
 
     linear_solver = ShallowWaterSolver(state)
 
@@ -79,7 +79,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson5.py
+++ b/examples/sw_williamson5.py
@@ -22,7 +22,7 @@ fieldlist = ['u', 'D']
 parameters = ShallowWaterParameters(H=H)
 diagnostics = Diagnostics(*fieldlist)
 
-for ref_level, dt in ref_dt.iteritems():
+for ref_level, dt in ref_dt.items():
 
     dirname = "sw_W5_ref%s_dt%s" % (ref_level, dt)
     mesh = IcosahedralSphereMesh(radius=R,

--- a/examples/sw_williamson6_triangle.py
+++ b/examples/sw_williamson6_triangle.py
@@ -83,9 +83,9 @@ state.initialise({'u': u0, 'D': D0})
 ueqn = EulerPoincare(state, u0.function_space())
 Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")
 
-advection_dict = {}
-advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-advection_dict["D"] = SSPRK3(state, D0, Deqn)
+advected_fields = []
+advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+advected_fields.append(("D", SSPRK3(state, D0, Deqn)))
 
 linear_solver = ShallowWaterSolver(state)
 
@@ -93,7 +93,7 @@ linear_solver = ShallowWaterSolver(state)
 sw_forcing = ShallowWaterForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advection_dict, linear_solver,
+stepper = Timestepper(state, advected_fields, linear_solver,
                       sw_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -88,11 +88,11 @@ for delta, dt in res_dt.items():
                                        equation_form="advective")
         watereqn = EmbeddedDGAdvection(state, Vt,
                                        equation_form="advective")
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-    advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
-    advection_dict["water"] = SSPRK3(state, water0, watereqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+    advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
+    advected_fields.append(("water", SSPRK3(state, water0, watereqn)))
 
     # Set up linear solver
     schur_params = {'pc_type': 'fieldsplit',
@@ -126,11 +126,11 @@ for delta, dt in res_dt.items():
 
     bcs = [DirichletBC(Vu, 0.0, "bottom"),
            DirichletBC(Vu, 0.0, "top")]
-    diffusion_dict = {"u": InteriorPenalty(state, Vu, kappa=Constant(75.), mu=Constant(10./delta), bcs=bcs),
-                      "theta": InteriorPenalty(state, Vt, kappa=Constant(75.), mu=Constant(10./delta))}
+    diffused_fields = [("u", InteriorPenalty(state, Vu, kappa=Constant(75.), mu=Constant(10./delta), bcs=bcs)),
+                       ("theta", InteriorPenalty(state, Vt, kappa=Constant(75.), mu=Constant(10./delta)))]
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
-                          compressible_forcing, diffusion_dict)
+    stepper = Timestepper(state, advected_fields, linear_solver,
+                          compressible_forcing, diffused_fields)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -15,7 +15,7 @@ L = 51200.
 # build volume mesh
 H = 6400.  # Height position of the model top
 
-for delta, dt in res_dt.iteritems():
+for delta, dt in res_dt.items():
 
     dirname = "tracer_dx%s_dt%s" % (delta, dt)
     nlayers = int(H/delta)  # horizontal layers

--- a/gusto/__init__.py
+++ b/gusto/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from gusto.configuration import *   # noqa
 from gusto.advection import *       # noqa
 from gusto.diagnostics import *     # noqa

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod, abstractproperty
 from firedrake import Function, LinearVariationalProblem, \
     LinearVariationalSolver, Projector
@@ -25,7 +24,7 @@ def embedded_dg(original_apply):
     return get_apply
 
 
-class Advection(object):
+class Advection(object, metaclass=ABCMeta):
     """
     Base class for advection schemes.
 
@@ -35,7 +34,6 @@ class Advection(object):
     that field satisfies
     :arg solver_params: solver_parameters
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state, field, equation=None, solver_params=None):
 

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -9,7 +9,7 @@ class Configuration(object):
 
     def __init__(self, **kwargs):
 
-        for name, value in kwargs.iteritems():
+        for name, value in kwargs.items():
             self.__setattr__(name, value)
 
     def __setattr__(self, name, value):

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -56,9 +56,7 @@ void maxify(double *a, double *b) {
         return assemble(f * dx)
 
 
-class DiagnosticField(object):
-
-    __metaclass__ = ABCMeta
+class DiagnosticField(object, metaclass=ABCMeta):
 
     @abstractproperty
     def name(self):

--- a/gusto/diffusion.py
+++ b/gusto/diffusion.py
@@ -1,17 +1,15 @@
-from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 from firedrake import TestFunction, TrialFunction, \
     Function, inner, outer, grad, avg, dx, dS_h, dS_v, \
     FacetNormal, LinearVariationalProblem, LinearVariationalSolver, action
 
 
-class Diffusion(object):
+class Diffusion(object, metaclass=ABCMeta):
     """
     Base class for diffusion schemes for gusto.
 
     :arg state: :class:`.State` object.
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state):
         self.state = state

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 from firedrake import Function, split, TrialFunction, TestFunction, \
     FacetNormal, inner, dx, cross, div, jump, avg, dS_v, \
@@ -6,7 +5,7 @@ from firedrake import Function, split, TrialFunction, TestFunction, \
     dot, dS, Constant, warning, Expression, as_vector
 
 
-class Forcing(object):
+class Forcing(object, metaclass=ABCMeta):
     """
     Base class for forcing terms for Gusto.
 
@@ -19,7 +18,6 @@ class Forcing(object):
     :arg extra_terms: extra terms to add to the u component of the forcing
     term - these will be multiplied by the appropriate test function.
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state, euler_poincare=True, linear=False, extra_terms=None):
         self.state = state

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -3,7 +3,6 @@ A module containing some tools for computing initial conditions, such
 as balanced initial conditions.
 """
 
-from __future__ import absolute_import
 from firedrake import MixedFunctionSpace, TrialFunctions, TestFunctions, \
     TestFunction, TrialFunction, SpatialCoordinate, \
     FacetNormal, inner, div, dx, ds_b, ds_t, ds_tb, DirichletBC, \

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from firedrake import split, LinearVariationalProblem, \
     LinearVariationalSolver, TestFunctions, TrialFunctions, \
     TestFunction, TrialFunction, lhs, rhs, DirichletBC, FacetNormal, \
@@ -9,7 +8,7 @@ from gusto.forcing import exner, exner_rho, exner_theta
 from abc import ABCMeta, abstractmethod
 
 
-class TimesteppingSolver(object):
+class TimesteppingSolver(object, metaclass=ABCMeta):
     """
     Base class for timestepping linear solvers for Gusto.
 
@@ -18,7 +17,6 @@ class TimesteppingSolver(object):
     :arg state: :class:`.State` object.
     :arg params (optional): solver parameters
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state, params=None):
 

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -2,13 +2,12 @@ from abc import ABCMeta, abstractmethod
 from firedrake import exp, Interpolator, conditional, interpolate
 
 
-class Physics(object):
+class Physics(object, metaclass=ABCMeta):
     """
     Base class for physics processes for Gusto.
 
     :arg state: :class:`.State` object.
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state):
         self.state = state

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -1,6 +1,6 @@
 from os import path
 import itertools
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from functools import partial
 import json
 from gusto.diagnostics import Diagnostics, Perturbation, \
@@ -174,7 +174,7 @@ class State(object):
         self.diagnostic_data = defaultdict(partial(defaultdict, list))
 
         # create field dictionary
-        self.field_dict = {field.name(): field for field in self.fields}
+        self.field_dict = OrderedDict((field.name(), field) for field in self.fields)
 
         # register any diagnostic fields to diagnostics
         for diagnostic in self.diagnostic_fields:
@@ -214,11 +214,10 @@ class State(object):
 
         # make functions on latlon mesh, as specified by dumplist_latlon
         self.to_dump_latlon = []
-        fields_ll = {}
         for name in self.output.dumplist_latlon:
             f = self.field_dict[name]
-            fields_ll[name] = Function(functionspaceimpl.WithGeometry(f.function_space(), mesh_ll), val=f.topological, name=name+'_ll')
-            self.to_dump_latlon.append(fields_ll[name])
+            field = Function(functionspaceimpl.WithGeometry(f.function_space(), mesh_ll), val=f.topological, name=name+'_ll')
+            self.to_dump_latlon.append(field)
 
     def dump(self, t=0, diagnostic_everydump=False, pickup=False):
         """

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from os import path
 import itertools
 from collections import defaultdict
@@ -199,7 +198,7 @@ class State(object):
             self.field_dict[f.name()] = f
 
         # make list of fields to dump
-        self.to_dump = [field for (name, field) in self.field_dict.iteritems() if field.dump]
+        self.to_dump = [field for (name, field) in self.field_dict.items() if field.dump]
 
         # if there are fields to be dumped in latlon coordinates,
         # setup the latlon coordinate mesh and make output file
@@ -242,7 +241,7 @@ class State(object):
 
         elif (next(self.dumpcount) % self.output.dumpfreq) == 0:
 
-            print "DBG dumping", t
+            print("DBG dumping", t)
 
             # calculate diagnostic fields
             for field in self.diagnostic_fields:
@@ -292,7 +291,7 @@ class State(object):
         """
         Initialise state variables
         """
-        for name, ic in initial_conditions.iteritems():
+        for name, ic in initial_conditions.items():
             f_init = getattr(self.fields, name)
             f_init.assign(ic)
             f_init.rename(name)
@@ -301,7 +300,7 @@ class State(object):
         """
         Initialise reference profiles
         """
-        for name, profile in reference_profiles.iteritems():
+        for name, profile in reference_profiles.items():
             field = getattr(self.fields, name)
             ref = self.fields(name+'bar', field.function_space(), False)
             ref.interpolate(profile)

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 from pyop2.profiling import timed_stage
 from gusto.linear_solvers import IncompressibleSolver
 from firedrake import DirichletBC
 
 
-class BaseTimestepper(object):
+class BaseTimestepper(object, metaclass=ABCMeta):
     """
     Base timestepping class for Gusto
 
@@ -14,7 +13,6 @@ class BaseTimestepper(object):
         fieldname is the name of the field to be advection and scheme is an
         :class:`.AdvectionScheme` object
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state, advection_dict):
 
@@ -99,7 +97,7 @@ class Timestepper(BaseTimestepper):
 
         while t < tmax - 0.5*dt:
             if state.output.Verbose:
-                print "STEP", t, dt
+                print("STEP", t, dt)
 
             t += dt
             with timed_stage("Apply forcing terms"):
@@ -148,7 +146,7 @@ class Timestepper(BaseTimestepper):
             state.xn.assign(state.xnp1)
 
             with timed_stage("Diffusion"):
-                for name, diffusion in self.diffusion_dict.iteritems():
+                for name, diffusion in self.diffusion_dict.items():
                     field = getattr(state.fields, name)
                     diffusion.apply(field, field)
 
@@ -160,7 +158,7 @@ class Timestepper(BaseTimestepper):
                 state.dump(t, diagnostic_everydump, pickup=False)
 
         state.diagnostic_dump()
-        print "TIMELOOP complete. t= " + str(t) + " tmax=" + str(tmax)
+        print("TIMELOOP complete. t= " + str(t) + " tmax=" + str(tmax))
 
 
 class AdvectionTimestepper(BaseTimestepper):
@@ -185,12 +183,12 @@ class AdvectionTimestepper(BaseTimestepper):
 
         while t < tmax - 0.5*dt:
             if state.output.Verbose:
-                print "STEP", t, dt
+                print("STEP", t, dt)
 
             t += dt
 
             with timed_stage("Advection"):
-                for name, advection in self.advection_dict.iteritems():
+                for name, advection in self.advection_dict.items():
                     field = getattr(state.fields, name)
                     # first computes ubar from state.xn and state.xnp1
                     advection.update_ubar(state.xn, state.xnp1, state.timestepping.alpha)

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 from firedrake import Function, TestFunction, TrialFunction, \
     FacetNormal, \
@@ -7,7 +6,7 @@ from firedrake import Function, TestFunction, TrialFunction, \
     curl, BrokenElement, FunctionSpace
 
 
-class TransportEquation(object):
+class TransportEquation(object, metaclass=ABCMeta):
     """
     Base class for transport equations in Gusto.
 
@@ -24,7 +23,6 @@ class TransportEquation(object):
     :arg solver_params: (optional) dictionary of solver parameters to pass to the
                         linear solver.
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, state, V, ibp="once", solver_params=None):
         self.state = state

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -111,9 +111,8 @@ def setup_advection(dirname, geometry, time_discretisation, ibp, equation_form, 
     elif time_discretisation == "implicit_midpoint":
         f_advection = ThetaMethod(state, f, fequation)
 
-    advection_dict = {}
-    advection_dict["f"] = f_advection
-    timestepper = AdvectionTimestepper(state, advection_dict)
+    advected_fields = [("f", f_advection)]
+    timestepper = AdvectionTimestepper(state, advected_fields)
 
     return timestepper, tmax, f_end
 

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -97,17 +97,17 @@ def setup_condens(dirname):
                              equation_form="advective")
 
     # build advection dictionary
-    advection_dict = {}
-    advection_dict["u"] = NoAdvection(state, u0, None)
-    advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-    advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
-    advection_dict["water_v"] = SSPRK3(state, water_v0, thetaeqn)
-    advection_dict["water_c"] = SSPRK3(state, water_c0, thetaeqn)
+    advected_fields = []
+    advected_fields.append(("u", NoAdvection(state, u0, None)))
+    advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+    advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
+    advected_fields.append(("water_v", SSPRK3(state, water_v0, thetaeqn)))
+    advected_fields.append(("water_c", SSPRK3(state, water_c0, thetaeqn)))
 
     physics_list = [Condensation(state)]
 
     # build time stepper
-    stepper = AdvectionTimestepper(state, advection_dict, physics_list=physics_list)
+    stepper = AdvectionTimestepper(state, advected_fields, physics_list=physics_list)
 
     return stepper, 5.0
 

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -124,7 +124,6 @@ def test_condens_setup(tmpdir):
     run_condens(dirname)
     with open(path.join(dirname, "condens/diagnostics.json"), "r") as f:
         data = json.load(f)
-    print data.keys()
 
     water_t_0 = data["water_v_plus_water_c"]["total"][0]
     water_t_T = data["water_v_plus_water_c"]["total"][-1]

--- a/tests/test_dcmip_setup.py
+++ b/tests/test_dcmip_setup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from gusto import *
 from firedrake import CubedSphereMesh, ExtrudedMesh, Expression
 import numpy as np

--- a/tests/test_dcmip_setup.py
+++ b/tests/test_dcmip_setup.py
@@ -97,10 +97,10 @@ def setup_dcmip(dirname):
     # Set up advection schemes
     rhoeqn = LinearAdvection(state, Vr, qbar=rho_b, ibp="once", equation_form="continuity")
     thetaeqn = LinearAdvection(state, Vt, qbar=theta_b)
-    advection_dict = {}
-    advection_dict["u"] = NoAdvection(state, state.fields("u"))
-    advection_dict["rho"] = ForwardEuler(state, rho0, rhoeqn)
-    advection_dict["theta"] = ForwardEuler(state, theta0, thetaeqn)
+    advected_fields = []
+    advected_fields.append(("u", NoAdvection(state, state.fields("u"))))
+    advected_fields.append(("rho", ForwardEuler(state, rho0, rhoeqn)))
+    advected_fields.append(("theta", ForwardEuler(state, theta0, thetaeqn)))
 
     # Set up linear solver
     params = {'pc_type': 'fieldsplit',
@@ -133,7 +133,7 @@ def setup_dcmip(dirname):
     compressible_forcing = CompressibleForcing(state, linear=True)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           compressible_forcing)
 
     return stepper, timestepping.dt

--- a/tests/test_sk_nonlinear.py
+++ b/tests/test_sk_nonlinear.py
@@ -69,10 +69,10 @@ def setup_sk(dirname):
     ueqn = EulerPoincare(state, Vu)
     rhoeqn = AdvectionEquation(state, Vr, equation_form="continuity")
     thetaeqn = SUPGAdvection(state, Vt, supg_params={"dg_direction": "horizontal"})
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-    advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+    advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
     # Set up linear solver
     schur_params = {'pc_type': 'fieldsplit',
@@ -105,7 +105,7 @@ def setup_sk(dirname):
     compressible_forcing = CompressibleForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           compressible_forcing)
 
     return stepper, 10*dt

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -57,9 +57,9 @@ def setup_sw(dirname):
     state.initialise({'u': u0, 'D': D0})
 
     Deqn = LinearAdvection(state, D0.function_space(), state.parameters.H, ibp="once", equation_form="continuity")
-    advection_dict = {}
-    advection_dict["u"] = NoAdvection(state, u0, None)
-    advection_dict["D"] = ForwardEuler(state, D0, Deqn)
+    advected_fields = []
+    advected_fields.append(("u", NoAdvection(state, u0, None)))
+    advected_fields.append(("D", ForwardEuler(state, D0, Deqn)))
 
     linear_solver = ShallowWaterSolver(state)
 
@@ -67,7 +67,7 @@ def setup_sw(dirname):
     sw_forcing = ShallowWaterForcing(state, linear=True)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           sw_forcing)
 
     return stepper, 2*day

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -89,7 +89,6 @@ def test_sw_setup(tmpdir, euler_poincare):
     run_sw(dirname, euler_poincare=euler_poincare)
     with open(path.join(dirname, "sw/diagnostics.json"), "r") as f:
         data = json.load(f)
-    print data.keys()
     Dl2 = data["D_error"]["l2"][-1]/data["D"]["l2"][0]
     ul2 = data["u_error"]["l2"][-1]/data["u"]["l2"][0]
 

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -63,14 +63,14 @@ def setup_sw(dirname, euler_poincare):
         sw_forcing = ShallowWaterForcing(state, euler_poincare=False)
 
     Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["D"] = SSPRK3(state, D0, Deqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("D", SSPRK3(state, D0, Deqn)))
 
     linear_solver = ShallowWaterSolver(state)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           sw_forcing)
 
     return stepper, 0.25*day

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -133,7 +133,6 @@ def test_tracer_setup(tmpdir):
     run_tracer(dirname)
     with open(path.join(dirname, "tracer/diagnostics.json"), "r") as f:
         data = json.load(f)
-    print data.keys()
 
     diffl2 = data["theta_minus_tracer"]["l2"][-1] / data["theta"]["l2"][0]
 

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -79,11 +79,11 @@ def setup_tracer(dirname):
                              equation_form="advective")
 
     # build advection dictionary
-    advection_dict = {}
-    advection_dict["u"] = ThetaMethod(state, u0, ueqn)
-    advection_dict["rho"] = SSPRK3(state, rho0, rhoeqn)
-    advection_dict["theta"] = SSPRK3(state, theta0, thetaeqn)
-    advection_dict["tracer"] = SSPRK3(state, tracer0, thetaeqn)
+    advected_fields = []
+    advected_fields.append(("u", ThetaMethod(state, u0, ueqn)))
+    advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+    advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
+    advected_fields.append(("tracer", SSPRK3(state, tracer0, thetaeqn)))
 
     # Set up linear solver
     schur_params = {'pc_type': 'fieldsplit',
@@ -115,7 +115,7 @@ def setup_tracer(dirname):
     compressible_forcing = CompressibleForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advection_dict, linear_solver,
+    stepper = Timestepper(state, advected_fields, linear_solver,
                           compressible_forcing)
 
     return stepper, 100.0


### PR DESCRIPTION
Changes to make gusto Python 3 compatible once the Firedrake update lands.  I've opened this now because there's a design change as well as mindless code fixing.

To whit, I change the arguments in the Timestepper to take a list of `advected_fields` and `diffused_fields`.  Each entry is a pair `(field_name, scheme)`.

Previously, these were dicts, but I noticed they are always just iterated over (no lookups are done).  By changing to a list, the iteration order is consistent.

Python3 has hash-randomisation turned on by default: that means you're guaranteed that dicts on different MPI processes will have different iteration orders.

In some sense, this bit of the code was always broken, but you were just lucky.

The other option, to keep the same interface, is to use an `OrderedDict`.  But now users writing examples have to remember to use an `OrderedDict`, and terrifically bad things happen if they don't (or you have to sort and so forth internally).