### PR TITLE
initialisation: Switch to deterministic iterables

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -160,10 +160,13 @@ u_exp = as_vector([u, v, 0.])
 u0.project(u_exp)
 
 # pass these initial conditions to the state.initialise method
-state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
 
 # set the background profiles
-state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
 
 ##############################################################################
 # Set up advection schemes

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -67,8 +67,11 @@ for delta, dt in res_dt.items():
     theta0.interpolate(theta_b + theta_pert)
     rho0.assign(rho_b)
 
-    state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-    state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+    state.initialise([('u', u0),
+                      ('rho', rho0),
+                      ('theta', theta0)])
+    state.set_reference_profiles([('rho', rho_b),
+                                  ('theta', theta_b)])
 
     # Set up advection schemes
     ueqn = EulerPoincare(state, Vu)

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -124,9 +124,10 @@ uinit = Function(W_VectorCG1).interpolate(as_vector([20.0, 0.0]))
 u0.project(uinit)
 
 # pass these initial conditions to the state.initialise method
-state.initialise({'u': u0, 'b': b0})
+state.initialise([('u', u0),
+                  ('b', b0)])
 # set the background buoyancy
-state.set_reference_profiles({'b': b_b})
+state.set_reference_profiles([('b', b_b)])
 
 ##############################################################################
 # Set up advection schemes

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -166,10 +166,13 @@ u_exp = as_vector([u, v, 0.])
 u0.project(u_exp)
 
 # pass these initial conditions to the state.initialise method
-state.initialise({'u': u0, 'p': p0, 'b': b0})
+state.initialise([('u', u0),
+                  ('p', p0),
+                  ('b', b0)])
 
 # set the background profiles
-state.set_reference_profiles({'p': p_b, 'b': b_b})
+state.set_reference_profiles([('p', p_b),
+                              ('b', b_b)])
 
 ##############################################################################
 # Set up advection schemes

--- a/examples/nh_mountain.py
+++ b/examples/nh_mountain.py
@@ -125,8 +125,11 @@ rho0.assign(rho_b)
 u0.project(as_vector([10.0, 0.0]))
 remove_initial_w(u0, state.Vv)
 
-state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
 
 # Set up advection schemes
 ueqn = EulerPoincare(state, Vu)

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -59,8 +59,11 @@ theta_pert = Function(Vt).interpolate(Expression("sqrt(pow(x[0]-xc,2)+pow(x[1]-z
 theta0.interpolate(theta_b + theta_pert)
 rho0.interpolate(rho_b)
 
-state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
 
 # Set up advection schemes
 ueqn = EulerPoincare(state, Vu)

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -77,8 +77,11 @@ compressible_hydrostatic_balance(state, theta_b, rho_b, solve_for_rho=True)
 rho0.assign(rho_b)
 u0.project(as_vector([20.0, 0.0, 0.0]))
 
-state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
 
 # Set up advection schemes
 ueqn = EulerPoincare(state, Vu)

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -70,8 +70,11 @@ theta_pert = deltaTheta*sin(np.pi*z/H)/(1 + (x - L/2)**2/a**2)
 theta0.interpolate(theta_b + theta_pert)
 rho0.assign(rho_b)
 
-state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
 
 # Set up advection schemes
 rhoeqn = LinearAdvection(state, Vr, qbar=rho_b, ibp="once", equation_form="continuity")

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -73,8 +73,11 @@ theta0.interpolate(theta_b + theta_pert)
 rho0.assign(rho_b)
 u0.project(as_vector([20.0, 0.0]))
 
-state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
 
 # Set up advection schemes
 ueqn = EulerPoincare(state, Vu)

--- a/examples/sw_hollingsworth.py
+++ b/examples/sw_hollingsworth.py
@@ -65,7 +65,8 @@ for ref_level, dt in ref_dt.items():
 
     u0.project(uexpr)
     D0.interpolate(Dexpr)
-    state.initialise({'u': u0, 'D': D0})
+    state.initialise([('u', u0),
+                      ('D', D0)])
 
     euler_poincare = False
     if euler_poincare:

--- a/examples/sw_linear_williamson2_triangle.py
+++ b/examples/sw_linear_williamson2_triangle.py
@@ -58,7 +58,8 @@ g = Constant(parameters.g)
 Dexpr = - ((R * Omega * u_max)*(x[2]*x[2]/(R*R)))/g
 u0.project(uexpr)
 D0.interpolate(Dexpr)
-state.initialise({'u': u0, 'D': D0})
+state.initialise([('u', u0),
+                  ('D', D0)])
 
 Deqn = LinearAdvection(state, D0.function_space(), state.parameters.H, ibp="once", equation_form="continuity")
 advected_fields = []

--- a/examples/sw_williamson2_triangle.py
+++ b/examples/sw_williamson2_triangle.py
@@ -61,7 +61,8 @@ for ref_level, dt in ref_dt.items():
 
     u0.project(uexpr)
     D0.interpolate(Dexpr)
-    state.initialise({'u': u0, 'D': D0})
+    state.initialise([('u', u0),
+                      ('D', D0)])
 
     ueqn = EulerPoincare(state, u0.function_space())
     Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")

--- a/examples/sw_williamson5.py
+++ b/examples/sw_williamson5.py
@@ -65,7 +65,8 @@ for ref_level, dt in ref_dt.items():
 
     u0.project(uexpr)
     D0.interpolate(Dexpr)
-    state.initialise({'u': u0, 'D': D0})
+    state.initialise([('u', u0),
+                      ('D', D0)])
 
     ueqn = EulerPoincare(state, u0.function_space())
     Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")

--- a/examples/sw_williamson6_triangle.py
+++ b/examples/sw_williamson6_triangle.py
@@ -78,7 +78,8 @@ f.interpolate(fexpr)  # Coriolis frequency (1/s)
 u0.project(uexpr, form_compiler_parameters={'quadrature_degree': 8})
 D0.interpolate(Dexpr)
 
-state.initialise({'u': u0, 'D': D0})
+state.initialise([('u', u0),
+                  ('D', D0)])
 
 ueqn = EulerPoincare(state, u0.function_space())
 Deqn = AdvectionEquation(state, D0.function_space(), equation_form="continuity")

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -71,7 +71,7 @@ for delta, dt in res_dt.items():
 
     state.initialise([('u', u0),
                       ('rho', rho0),
-                      ('theta', theta0)
+                      ('theta', theta0),
                       ('water', water0)])
     state.set_reference_profiles([('rho', rho_b),
                                   ('theta', theta_b)])

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -69,8 +69,12 @@ for delta, dt in res_dt.items():
     water0.interpolate(theta_pert)
     rho0.assign(rho_b)
 
-    state.initialise({'u': u0, 'rho': rho0, 'theta': theta0, 'water': water0})
-    state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+    state.initialise([('u', u0),
+                      ('rho', rho0),
+                      ('theta', theta0)
+                      ('water', water0)])
+    state.set_reference_profiles([('rho', rho_b),
+                                  ('theta', theta_b)])
 
     # Set up advection schemes
     ueqn = EulerPoincare(state, Vu)

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -5,7 +5,6 @@ from functools import partial
 import json
 from gusto.diagnostics import Diagnostics, Perturbation, \
     SteadyStateError
-from sys import exit
 from firedrake import FiniteElement, TensorProductElement, HDiv, \
     FunctionSpace, MixedFunctionSpace, VectorFunctionSpace, \
     interval, Function, Mesh, functionspaceimpl,\
@@ -168,7 +167,7 @@ class State(object):
         outfile = path.join(self.dumpdir, "field_output.pvd")
         if self.mesh.comm.rank == 0 and "pytest" not in self.output.dirname \
            and path.exists(self.dumpdir) and not pickup:
-            exit("results directory '%s' already exists" % self.dumpdir)
+            raise IOError("results directory '%s' already exists" % self.dumpdir)
         self.dumpcount = itertools.count()
         self.dumpfile = File(outfile, project_output=self.output.project_fields, comm=self.mesh.comm)
         self.diagnostic_data = defaultdict(partial(defaultdict, list))

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -289,8 +289,10 @@ class State(object):
     def initialise(self, initial_conditions):
         """
         Initialise state variables
+
+        :arg initial_conditions: An iterable of pairs (field_name, pointwise_value)
         """
-        for name, ic in initial_conditions.items():
+        for name, ic in initial_conditions:
             f_init = getattr(self.fields, name)
             f_init.assign(ic)
             f_init.rename(name)
@@ -298,8 +300,10 @@ class State(object):
     def set_reference_profiles(self, reference_profiles):
         """
         Initialise reference profiles
+
+        :arg reference_profiles: An iterable of pairs (field_name, interpolatory_value)
         """
-        for name, profile in reference_profiles.items():
+        for name, profile in reference_profiles:
             field = getattr(self.fields, name)
             ref = self.fields(name+'bar', field.function_space(), False)
             ref.interpolate(profile)

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -94,7 +94,7 @@ def setup_advection(dirname, geometry, time_discretisation, ibp, equation_form, 
     # interpolate initial conditions
     f.interpolate(fexpr)
     f_end.interpolate(f_end_expr)
-    state.initialise({'u': u0, 'f': f})
+    state.initialise([('u', u0), ('f', f)])
 
     if spatial_opts is None:
         fequation = AdvectionEquation(state, f.function_space(), ibp=ibp, equation_form=equation_form)

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -86,9 +86,13 @@ def setup_condens(dirname):
     rho0.interpolate(rho_b)
     water_v0.interpolate(w_expr)
 
-    state.initialise({'u': u0, 'rho': rho0, 'theta': theta0,
-                      'water_v': water_v0, 'water_c': water_c0})
-    state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+    state.initialise([('u', u0),
+                      ('rho', rho0),
+                      ('theta', theta0),
+                      ('water_v', water_v0),
+                      ('water_c', water_c0)])
+    state.set_reference_profiles([('rho', rho_b),
+                                  ('theta', theta_b)])
 
     # set up advection schemes
     rhoeqn = AdvectionEquation(state, Vr, equation_form="continuity")

--- a/tests/test_dcmip_setup.py
+++ b/tests/test_dcmip_setup.py
@@ -91,8 +91,10 @@ def setup_dcmip(dirname):
     theta0.assign(theta_b + theta_prime)
     rho0.assign(rho_b)
 
-    state.initialise({'rho': rho0, 'theta': theta0})
-    state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+    state.initialise([('rho', rho0),
+                      ('theta', theta0)])
+    state.set_reference_profiles([('rho', rho_b),
+                                  ('theta', theta_b)])
 
     # Set up advection schemes
     rhoeqn = LinearAdvection(state, Vr, qbar=rho_b, ibp="once", equation_form="continuity")

--- a/tests/test_gw_incompressible.py
+++ b/tests/test_gw_incompressible.py
@@ -38,7 +38,9 @@ def setup_gw(dirname):
     b_b = Function(b0.function_space()).interpolate(bref)
     b0.interpolate(b_b)
     incompressible_hydrostatic_balance(state, b0, p0)
-    state.initialise({'u': u0, 'p': p0, 'b': b0})
+    state.initialise([('u', u0),
+                      ('p', p0),
+                      ('b', b0)])
 
     # Set up forcing
     forcing = IncompressibleForcing(state)

--- a/tests/test_sk_nonlinear.py
+++ b/tests/test_sk_nonlinear.py
@@ -62,8 +62,11 @@ def setup_sk(dirname):
     rho0.assign(rho_b)
     u0.project(as_vector([20.0, 0.0]))
 
-    state.initialise({'u': u0, 'rho': rho0, 'theta': theta0})
-    state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+    state.initialise([('u', u0),
+                      ('rho', rho0),
+                      ('theta', theta0)])
+    state.set_reference_profiles([('rho', rho_b),
+                                  ('theta', theta_b)])
 
     # Set up advection schemes
     ueqn = EulerPoincare(state, Vu)

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -54,7 +54,8 @@ def setup_sw(dirname):
     Dexpr = - ((R * Omega * u_max)*(x[2]*x[2]/(R*R)))/g
     u0.project(uexpr)
     D0.interpolate(Dexpr)
-    state.initialise({'u': u0, 'D': D0})
+    state.initialise([('u', u0),
+                      ('D', D0)])
 
     Deqn = LinearAdvection(state, D0.function_space(), state.parameters.H, ibp="once", equation_form="continuity")
     advected_fields = []

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -53,7 +53,8 @@ def setup_sw(dirname, euler_poincare):
 
     u0.project(uexpr)
     D0.interpolate(Dexpr)
-    state.initialise({'u': u0, 'D': D0})
+    state.initialise([('u', u0),
+                      ('D', D0)])
 
     if euler_poincare:
         ueqn = EulerPoincare(state, u0.function_space())

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -67,9 +67,12 @@ def setup_tracer(dirname):
     rho0.interpolate(rho_b)
     tracer0.interpolate(theta0)
 
-    state.initialise({'u': u0, 'rho': rho0, 'theta': theta0,
-                      'tracer': tracer0})
-    state.set_reference_profiles({'rho': rho_b, 'theta': theta_b})
+    state.initialise([('u', u0),
+                      ('rho', rho0),
+                      ('theta', theta0),
+                      ('tracer', tracer0)])
+    state.set_reference_profiles([('rho', rho_b),
+                                  ('theta', theta_b)])
 
     # set up advection schemes
     ueqn = EulerPoincare(state, Vu)


### PR DESCRIPTION
Change API so that one has to provide an iterable of pairs for both
state.initialise and state.set_reference_profiles.

More sanitisation of parallel-unsafe iteration.