### PR TITLE
Add __all__ to each file

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -1,7 +1,7 @@
 from gusto import *
 from firedrake import as_vector, SpatialCoordinate,\
     PeriodicRectangleMesh, ExtrudedMesh, \
-    exp, cos, sin, cosh, sinh, tanh, pi
+    exp, cos, sin, cosh, sinh, tanh, pi, Function, sqrt
 import sys
 
 day = 24.*60.*60.

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -1,6 +1,7 @@
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, \
-    SpatialCoordinate, Constant, DirichletBC, pi, cos
+    SpatialCoordinate, Constant, DirichletBC, pi, cos, Function, sqrt, \
+    conditional
 import sys
 
 if '--running-tests' in sys.argv:

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -1,7 +1,7 @@
 from gusto import *
 from firedrake import as_vector,\
     VectorFunctionSpace, PeriodicIntervalMesh, ExtrudedMesh, \
-    sin, SpatialCoordinate
+    sin, SpatialCoordinate, Function
 import numpy as np
 import sys
 

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -1,7 +1,7 @@
 from gusto import *
 from firedrake import as_vector, SpatialCoordinate, \
     PeriodicRectangleMesh, ExtrudedMesh, \
-    cos, sin, cosh, sinh, tanh, pi
+    cos, sin, cosh, sinh, tanh, pi, Function, sqrt
 import sys
 
 day = 24.*60.*60.

--- a/examples/nh_mountain.py
+++ b/examples/nh_mountain.py
@@ -1,6 +1,7 @@
 from gusto import *
-from firedrake import FunctionSpace, as_vector,\
-    VectorFunctionSpace, PeriodicIntervalMesh, ExtrudedMesh, SpatialCoordinate, exp, pi, cos
+from firedrake import FunctionSpace, as_vector, \
+    VectorFunctionSpace, PeriodicIntervalMesh, ExtrudedMesh, \
+    SpatialCoordinate, exp, pi, cos, Function, conditional, Mesh, sin, op2
 import sys
 
 dt = 5.0

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, \
-    SpatialCoordinate, Constant, pi, cos
+    SpatialCoordinate, Constant, pi, cos, Function, sqrt, conditional
 import sys
 
 dt = 1.

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import as_vector, SpatialCoordinate,\
-    PeriodicRectangleMesh, ExtrudedMesh, exp, sin
+    PeriodicRectangleMesh, ExtrudedMesh, exp, sin, Function
 import numpy as np
 import sys
 

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, \
-    SpatialCoordinate, exp, sin
+    SpatialCoordinate, exp, sin, Function, FunctionSpace
 import numpy as np
 import sys
 

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import as_vector, SpatialCoordinate, PeriodicIntervalMesh, \
-    ExtrudedMesh, exp, sin
+    ExtrudedMesh, exp, sin, Function
 import numpy as np
 import sys
 

--- a/examples/sw_hollingsworth.py
+++ b/examples/sw_hollingsworth.py
@@ -1,5 +1,6 @@
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, Constant
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, \
+    Constant, FunctionSpace
 from math import pi
 import sys
 

--- a/examples/sw_linear_williamson2_triangle.py
+++ b/examples/sw_linear_williamson2_triangle.py
@@ -1,5 +1,6 @@
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, \
+    FunctionSpace
 from math import pi
 import sys
 

--- a/examples/sw_williamson2_triangle.py
+++ b/examples/sw_williamson2_triangle.py
@@ -1,5 +1,6 @@
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, \
+    FunctionSpace
 from math import pi
 import sys
 

--- a/examples/sw_williamson5.py
+++ b/examples/sw_williamson5.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import IcosahedralSphereMesh, SpatialCoordinate, \
-    as_vector, pi, sqrt
+    as_vector, pi, sqrt, Min, FunctionSpace
 import sys
 
 day = 24.*60.*60.

--- a/examples/sw_williamson6_triangle.py
+++ b/examples/sw_williamson6_triangle.py
@@ -1,5 +1,6 @@
 from gusto import *
-from firedrake import IcosahedralSphereMesh, cos, sin, SpatialCoordinate
+from firedrake import IcosahedralSphereMesh, cos, sin, SpatialCoordinate, \
+    FunctionSpace
 import sys
 
 dt = 900.

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -1,6 +1,7 @@
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, \
-    SpatialCoordinate, Constant, DirichletBC, cos, pi
+    SpatialCoordinate, Constant, DirichletBC, cos, pi, Function, sqrt, \
+    conditional
 import sys
 
 if '--running-tests' in sys.argv:

--- a/gusto/__init__.py
+++ b/gusto/__init__.py
@@ -1,12 +1,12 @@
-from gusto.configuration import *   # noqa
 from gusto.advection import *       # noqa
+from gusto.configuration import *   # noqa
 from gusto.diagnostics import *     # noqa
-from gusto.eady_diagnostics import *     # noqa
 from gusto.diffusion import *     # noqa
-from gusto.transport_equation import *     # noqa
+from gusto.eady_diagnostics import *     # noqa
 from gusto.forcing import *         # noqa
+from gusto.initialisation_tools import *  # noqa
 from gusto.linear_solvers import *  # noqa
 from gusto.physics import *         # noqa
 from gusto.state import *           # noqa
 from gusto.timeloop import *        # noqa
-from gusto.initialisation_tools import *  # noqa
+from gusto.transport_equation import *     # noqa

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -5,6 +5,9 @@ from firedrake.utils import cached_property
 from gusto.transport_equation import EmbeddedDGAdvection
 
 
+__all__ = ["NoAdvection", "ForwardEuler", "SSPRK3", "ThetaMethod"]
+
+
 def embedded_dg(original_apply):
     """
     Decorator to add interpolation and projection steps for embedded

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -5,6 +5,9 @@ Some simple tools for making model configuration nicer.
 from firedrake import sqrt
 
 
+__all__ = ["TimesteppingParameters", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters"]
+
+
 class Configuration(object):
 
     def __init__(self, **kwargs):

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -6,7 +6,7 @@ from gusto.forcing import exner
 import numpy as np
 
 
-__all__ = ["CourantNumber", "VelocityX", "VelocityZ", "VelocityY", "Energy", "KineticEnergy", "CompressibleKineticEnergy", "ExnerPi", "Sum", "Difference", "SteadyStateError", "Perturbation", "PotentialVorticity"]
+__all__ = ["Diagnostics", "CourantNumber", "VelocityX", "VelocityZ", "VelocityY", "Energy", "KineticEnergy", "CompressibleKineticEnergy", "ExnerPi", "Sum", "Difference", "SteadyStateError", "Perturbation", "PotentialVorticity"]
 
 
 class Diagnostics(object):

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -6,6 +6,9 @@ from gusto.forcing import exner
 import numpy as np
 
 
+__all__ = ["CourantNumber", "VelocityX", "VelocityZ", "VelocityY", "Energy", "KineticEnergy", "CompressibleKineticEnergy", "ExnerPi", "Sum", "Difference", "SteadyStateError", "Perturbation", "PotentialVorticity"]
+
+
 class Diagnostics(object):
 
     def __init__(self, *fields):

--- a/gusto/diffusion.py
+++ b/gusto/diffusion.py
@@ -4,6 +4,9 @@ from firedrake import TestFunction, TrialFunction, \
     FacetNormal, LinearVariationalProblem, LinearVariationalSolver, action
 
 
+__all__ = ["InteriorPenalty"]
+
+
 class Diffusion(object, metaclass=ABCMeta):
     """
     Base class for diffusion schemes for gusto.

--- a/gusto/eady_diagnostics.py
+++ b/gusto/eady_diagnostics.py
@@ -8,6 +8,9 @@ from gusto.diagnostics import DiagnosticField, Energy
 from gusto.forcing import exner
 
 
+__all__ = ["KineticEnergyY", "CompressibleKineticEnergyY", "EadyPotentialEnergy", "CompressibleEadyPotentialEnergy", "GeostrophicImbalance", "TrueResidualV", "SawyerEliassenU"]
+
+
 class KineticEnergyY(Energy):
     name = "KineticEnergyY"
 

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -5,6 +5,9 @@ from firedrake import Function, split, TrialFunction, TestFunction, \
     dot, dS, Constant, warning, as_vector, SpatialCoordinate
 
 
+__all__ = ["CompressibleForcing", "IncompressibleForcing", "EadyForcing", "CompressibleEadyForcing", "ShallowWaterForcing", "NoForcing"]
+
+
 class Forcing(object, metaclass=ABCMeta):
     """
     Base class for forcing terms for Gusto.

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -5,7 +5,7 @@ from firedrake import Function, split, TrialFunction, TestFunction, \
     dot, dS, Constant, warning, as_vector, SpatialCoordinate
 
 
-__all__ = ["CompressibleForcing", "IncompressibleForcing", "EadyForcing", "CompressibleEadyForcing", "ShallowWaterForcing", "NoForcing"]
+__all__ = ["CompressibleForcing", "IncompressibleForcing", "EadyForcing", "CompressibleEadyForcing", "ShallowWaterForcing", "NoForcing", "exner", "exner_rho", "exner_theta"]
 
 
 class Forcing(object, metaclass=ABCMeta):

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -13,6 +13,9 @@ from firedrake import MixedFunctionSpace, TrialFunctions, TestFunctions, \
 from gusto.forcing import exner
 
 
+__all__ = ["latlon_coords", "sphere_to_cartesian", "incompressible_hydrostatic_balance", "compressible_hydrostatic_balance", "remove_initial_w", "eady_initial_v", "compressible_eady_initial_v", "calculate_Pi0"]
+
+
 def latlon_coords(mesh):
     x0, y0, z0 = SpatialCoordinate(mesh)
     unsafe = z0/sqrt(x0*x0 + y0*y0 + z0*z0)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -8,6 +8,9 @@ from gusto.forcing import exner, exner_rho, exner_theta
 from abc import ABCMeta, abstractmethod
 
 
+__all__ = ["CompressibleSolver", "IncompressibleSolver", "ShallowWaterSolver"]
+
+
 class TimesteppingSolver(object, metaclass=ABCMeta):
     """
     Base class for timestepping linear solvers for Gusto.

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -2,6 +2,9 @@ from abc import ABCMeta, abstractmethod
 from firedrake import exp, Interpolator, conditional, interpolate
 
 
+__all__ = ["Condensation"]
+
+
 class Physics(object, metaclass=ABCMeta):
     """
     Base class for physics processes for Gusto.

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -14,6 +14,9 @@ from firedrake import FiniteElement, TensorProductElement, HDiv, \
 import numpy as np
 
 
+__all__ = ["State"]
+
+
 class SpaceCreator(object):
 
     def __call__(self, name, mesh=None, family=None, degree=None):

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -4,6 +4,9 @@ from gusto.linear_solvers import IncompressibleSolver
 from firedrake import DirichletBC
 
 
+__all__ = ["Timestepper", "AdvectionTimestepper"]
+
+
 class BaseTimestepper(object, metaclass=ABCMeta):
     """
     Base timestepping class for Gusto

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -6,6 +6,9 @@ from firedrake import Function, TestFunction, TrialFunction, \
     curl, BrokenElement, FunctionSpace
 
 
+__all__ = ["LinearAdvection", "AdvectionEquation", "EmbeddedDGAdvection", "SUPGAdvection", "VectorInvariant", "EulerPoincare"]
+
+
 class TransportEquation(object, metaclass=ABCMeta):
     """
     Base class for transport equations in Gusto.

--- a/tests/test_IP_diffusion.py
+++ b/tests/test_IP_diffusion.py
@@ -1,6 +1,8 @@
+import itertools
+from os import path
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, SpatialCoordinate,\
-    VectorFunctionSpace, File, Constant
+    VectorFunctionSpace, File, Constant, Function, exp, as_vector
 import pytest
 
 

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -1,7 +1,7 @@
 from gusto import *
 from firedrake import IcosahedralSphereMesh, PeriodicIntervalMesh, \
     ExtrudedMesh, SpatialCoordinate, \
-    as_vector, VectorFunctionSpace, sin
+    as_vector, VectorFunctionSpace, sin, exp, Function, FunctionSpace
 import pytest
 from math import pi
 

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -1,6 +1,8 @@
+from os import path
 from gusto import *
 from firedrake import as_vector, Constant, sin, PeriodicIntervalMesh, \
-    SpatialCoordinate, ExtrudedMesh
+    SpatialCoordinate, ExtrudedMesh, FunctionSpace, Function, sqrt, \
+    conditional, cos
 import json
 from math import pi
 

--- a/tests/test_gw_incompressible.py
+++ b/tests/test_gw_incompressible.py
@@ -1,5 +1,6 @@
 from gusto import *
-from firedrake import SpatialCoordinate, PeriodicRectangleMesh, ExtrudedMesh
+from firedrake import SpatialCoordinate, PeriodicRectangleMesh, ExtrudedMesh, \
+    Function
 
 
 def setup_gw(dirname):

--- a/tests/test_sk_nonlinear.py
+++ b/tests/test_sk_nonlinear.py
@@ -1,6 +1,6 @@
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, \
-    SpatialCoordinate, exp, sin
+    SpatialCoordinate, exp, sin, Function, as_vector
 import numpy as np
 
 

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -1,5 +1,7 @@
+from os import path
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, \
+    FunctionSpace, Function
 from math import pi
 import json
 

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -1,5 +1,7 @@
+from os import path
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, \
+    FunctionSpace, Function
 from math import pi
 import json
 import pytest

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -1,6 +1,7 @@
+from os import path
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, \
-    Constant, SpatialCoordinate, pi
+    Constant, SpatialCoordinate, pi, Function, sqrt, conditional, cos
 import json
 
 


### PR DESCRIPTION
Better namespace control.  At the moment, any import in a file is also available in any subsequent file that imports the first file, which is a bad thing.