### PR TITLE
Solver params

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -185,28 +185,11 @@ advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 # Set up linear solver for the timestepping scheme
 ##############################################################################
 # Set up linear solver
-linear_solver_params = {'pc_type': 'fieldsplit',
-                        'pc_fieldsplit_type': 'schur',
-                        'ksp_type': 'gmres',
-                        'ksp_monitor_true_residual': False,
-                        'ksp_max_it': 100,
-                        'ksp_gmres_restart': 50,
-                        'pc_fieldsplit_schur_fact_type': 'FULL',
-                        'pc_fieldsplit_schur_precondition': 'selfp',
-                        'fieldsplit_0_ksp_type': 'preonly',
-                        'fieldsplit_0_pc_type': 'bjacobi',
-                        'fieldsplit_0_sub_pc_type': 'ilu',
-                        'fieldsplit_1_ksp_type': 'preonly',
-                        'fieldsplit_1_pc_type': 'gamg',
+linear_solver_params = {'ksp_monitor_true_residual': False,
                         'fieldsplit_1_pc_gamg_sym_graph': True,
-                        'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                        'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                        'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                        'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                        'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                        'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
+                        'fieldsplit_1_mg_levels_ksp_max_it': 5}
 
-linear_solver = CompressibleSolver(state, params=linear_solver_params)
+linear_solver = CompressibleSolver(state, solver_parameters=linear_solver_params)
 
 ##############################################################################
 # Set up forcing

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -95,31 +95,7 @@ for delta, dt in res_dt.items():
     advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
     # Set up linear solver
-    schur_params = {'pc_type': 'fieldsplit',
-                    'pc_fieldsplit_type': 'schur',
-                    'ksp_type': 'gmres',
-                    'ksp_monitor_true_residual': True,
-                    'ksp_max_it': 100,
-                    'ksp_gmres_restart': 50,
-                    'pc_fieldsplit_schur_fact_type': 'FULL',
-                    'pc_fieldsplit_schur_precondition': 'selfp',
-                    'fieldsplit_0_ksp_type': 'richardson',
-                    'fieldsplit_0_ksp_max_it': 5,
-                    'fieldsplit_0_pc_type': 'bjacobi',
-                    'fieldsplit_0_sub_pc_type': 'ilu',
-                    'fieldsplit_1_ksp_type': 'richardson',
-                    'fieldsplit_1_ksp_max_it': 5,
-                    "fieldsplit_1_ksp_monitor_true_residual": True,
-                    'fieldsplit_1_pc_type': 'gamg',
-                    'fieldsplit_1_pc_gamg_sym_graph': True,
-                    'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                    'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                    'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                    'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-    linear_solver = CompressibleSolver(state, params=schur_params)
+    linear_solver = CompressibleSolver(state)
 
     # Set up forcing
     compressible_forcing = CompressibleForcing(state)

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -16,10 +16,12 @@ if '--running-tests' in sys.argv:
                             'fieldsplit_1_pc_type': 'lu',
                             'fieldsplit_0_ksp_type': 'preonly',
                             'fieldsplit_1_ksp_type': 'preonly'}
+    overwrite = True
 else:
     tmax = 3600.
     # use default linear solver parameters (i.e. mumps)
     linear_solver_params = None
+    overwrite = False
 
 ##############################################################################
 # set up mesh
@@ -147,7 +149,7 @@ advected_fields.append(("b", SSPRK3(state, b0, beqn)))
 ##############################################################################
 # Set up linear solver for the timestepping scheme
 ##############################################################################
-linear_solver = IncompressibleSolver(state, L, params=linear_solver_params)
+linear_solver = IncompressibleSolver(state, L, solver_parameters=linear_solver_params, overwrite_solver_parameters=overwrite)
 
 ##############################################################################
 # Set up forcing

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -18,11 +18,13 @@ if '--running-tests' in sys.argv:
                             'fieldsplit_1_pc_type': 'lu',
                             'fieldsplit_0_ksp_type': 'preonly',
                             'fieldsplit_1_ksp_type': 'preonly'}
+    overwrite = True
 else:
     tmax = 30*day
     tdump = 2*hour
     # use default linear solver parameters (i.e. mumps)
     linear_solver_params = None
+    overwrite = False
 
 ##############################################################################
 # set up mesh
@@ -194,7 +196,7 @@ advected_fields.append(("b", SSPRK3(state, b0, beqn)))
 ##############################################################################
 # Set up linear solver for the timestepping scheme
 ##############################################################################
-linear_solver = IncompressibleSolver(state, 2.*L, params=linear_solver_params)
+linear_solver = IncompressibleSolver(state, 2.*L, solver_parameters=linear_solver_params, overwrite_solver_parameters=overwrite)
 
 ##############################################################################
 # Set up forcing

--- a/examples/nh_mountain.py
+++ b/examples/nh_mountain.py
@@ -149,7 +149,7 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
-linear_solver = CompressibleSolver(state, params=schur_params)
+linear_solver = CompressibleSolver(state)
 
 # Set up forcing
 compressible_forcing = CompressibleForcing(state)

--- a/examples/nh_mountain.py
+++ b/examples/nh_mountain.py
@@ -149,30 +149,6 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
-schur_params = {'pc_type': 'fieldsplit',
-                'pc_fieldsplit_type': 'schur',
-                'ksp_type': 'gmres',
-                'ksp_monitor_true_residual': True,
-                'ksp_max_it': 100,
-                'ksp_gmres_restart': 50,
-                'pc_fieldsplit_schur_fact_type': 'FULL',
-                'pc_fieldsplit_schur_precondition': 'selfp',
-                'fieldsplit_0_ksp_type': 'richardson',
-                'fieldsplit_0_ksp_max_it': 5,
-                'fieldsplit_0_pc_type': 'bjacobi',
-                'fieldsplit_0_sub_pc_type': 'ilu',
-                'fieldsplit_1_ksp_type': 'richardson',
-                'fieldsplit_1_ksp_max_it': 5,
-                "fieldsplit_1_ksp_monitor_true_residual": True,
-                'fieldsplit_1_pc_type': 'gamg',
-                'fieldsplit_1_pc_gamg_sym_graph': True,
-                'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
 linear_solver = CompressibleSolver(state, params=schur_params)
 
 # Set up forcing

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -85,31 +85,7 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
-schur_params = {'pc_type': 'fieldsplit',
-                'pc_fieldsplit_type': 'schur',
-                'ksp_type': 'gmres',
-                'ksp_monitor_true_residual': True,
-                'ksp_max_it': 100,
-                'ksp_gmres_restart': 50,
-                'pc_fieldsplit_schur_fact_type': 'FULL',
-                'pc_fieldsplit_schur_precondition': 'selfp',
-                'fieldsplit_0_ksp_type': 'richardson',
-                'fieldsplit_0_ksp_max_it': 5,
-                'fieldsplit_0_pc_type': 'bjacobi',
-                'fieldsplit_0_sub_pc_type': 'ilu',
-                'fieldsplit_1_ksp_type': 'richardson',
-                'fieldsplit_1_ksp_max_it': 5,
-                "fieldsplit_1_ksp_monitor_true_residual": True,
-                'fieldsplit_1_pc_type': 'gamg',
-                'fieldsplit_1_pc_gamg_sym_graph': True,
-                'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-linear_solver = CompressibleSolver(state, params=schur_params)
+linear_solver = CompressibleSolver(state)
 
 # Set up forcing
 compressible_forcing = CompressibleForcing(state)

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -93,29 +93,7 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
-schur_params = {'pc_type': 'fieldsplit',
-                'pc_fieldsplit_type': 'schur',
-                'ksp_type': 'gmres',
-                'ksp_monitor_true_residual': True,
-                'ksp_max_it': 100,
-                'ksp_gmres_restart': 50,
-                'pc_fieldsplit_schur_fact_type': 'FULL',
-                'pc_fieldsplit_schur_precondition': 'selfp',
-                'fieldsplit_0_ksp_type': 'preonly',
-                'fieldsplit_0_pc_type': 'bjacobi',
-                'fieldsplit_0_sub_pc_type': 'ilu',
-                'fieldsplit_1_ksp_type': 'preonly',
-                "fieldsplit_1_ksp_monitor_true_residual": True,
-                'fieldsplit_1_pc_type': 'gamg',
-                'fieldsplit_1_pc_gamg_sym_graph': True,
-                'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-linear_solver = CompressibleSolver(state, params=schur_params)
+linear_solver = CompressibleSolver(state)
 
 # Set up forcing
 # [0,0,2*omega] cross [u,v,0] = [-2*omega*v, 2*omega*u, 0]

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -84,31 +84,7 @@ advected_fields.append(("rho", ForwardEuler(state, rho0, rhoeqn)))
 advected_fields.append(("theta", ForwardEuler(state, theta0, thetaeqn)))
 
 # Set up linear solver
-schur_params = {'pc_type': 'fieldsplit',
-                'pc_fieldsplit_type': 'schur',
-                'ksp_type': 'gmres',
-                'ksp_monitor_true_residual': True,
-                'ksp_max_it': 100,
-                'ksp_gmres_restart': 50,
-                'pc_fieldsplit_schur_fact_type': 'FULL',
-                'pc_fieldsplit_schur_precondition': 'selfp',
-                'fieldsplit_0_ksp_type': 'richardson',
-                'fieldsplit_0_ksp_max_it': 5,
-                'fieldsplit_0_pc_type': 'bjacobi',
-                'fieldsplit_0_sub_pc_type': 'ilu',
-                'fieldsplit_1_ksp_type': 'richardson',
-                'fieldsplit_1_ksp_max_it': 5,
-                "fieldsplit_1_ksp_monitor_true_residual": True,
-                'fieldsplit_1_pc_type': 'gamg',
-                'fieldsplit_1_pc_gamg_sym_graph': True,
-                'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-linear_solver = CompressibleSolver(state, params=schur_params)
+linear_solver = CompressibleSolver(state)
 
 # Set up forcing
 compressible_forcing = CompressibleForcing(state, linear=True)

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -93,31 +93,7 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
-schur_params = {'pc_type': 'fieldsplit',
-                'pc_fieldsplit_type': 'schur',
-                'ksp_type': 'gmres',
-                'ksp_monitor_true_residual': True,
-                'ksp_max_it': 100,
-                'ksp_gmres_restart': 50,
-                'pc_fieldsplit_schur_fact_type': 'FULL',
-                'pc_fieldsplit_schur_precondition': 'selfp',
-                'fieldsplit_0_ksp_type': 'richardson',
-                'fieldsplit_0_ksp_max_it': 5,
-                'fieldsplit_0_pc_type': 'bjacobi',
-                'fieldsplit_0_sub_pc_type': 'ilu',
-                'fieldsplit_1_ksp_type': 'richardson',
-                'fieldsplit_1_ksp_max_it': 5,
-                "fieldsplit_1_ksp_monitor_true_residual": True,
-                'fieldsplit_1_pc_type': 'gamg',
-                'fieldsplit_1_pc_gamg_sym_graph': True,
-                'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-linear_solver = CompressibleSolver(state, params=schur_params)
+linear_solver = CompressibleSolver(state)
 
 # Set up forcing
 compressible_forcing = CompressibleForcing(state)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -104,31 +104,7 @@ for delta, dt in res_dt.items():
     advected_fields.append(("water", SSPRK3(state, water0, watereqn)))
 
     # Set up linear solver
-    schur_params = {'pc_type': 'fieldsplit',
-                    'pc_fieldsplit_type': 'schur',
-                    'ksp_type': 'gmres',
-                    'ksp_monitor_true_residual': True,
-                    'ksp_max_it': 100,
-                    'ksp_gmres_restart': 50,
-                    'pc_fieldsplit_schur_fact_type': 'FULL',
-                    'pc_fieldsplit_schur_precondition': 'selfp',
-                    'fieldsplit_0_ksp_type': 'richardson',
-                    'fieldsplit_0_ksp_max_it': 5,
-                    'fieldsplit_0_pc_type': 'bjacobi',
-                    'fieldsplit_0_sub_pc_type': 'ilu',
-                    'fieldsplit_1_ksp_type': 'richardson',
-                    'fieldsplit_1_ksp_max_it': 5,
-                    "fieldsplit_1_ksp_monitor_true_residual": True,
-                    'fieldsplit_1_pc_type': 'gamg',
-                    'fieldsplit_1_pc_gamg_sym_graph': True,
-                    'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                    'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                    'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                    'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-    linear_solver = CompressibleSolver(state, params=schur_params)
+    linear_solver = CompressibleSolver(state)
 
     # Set up forcing
     compressible_forcing = CompressibleForcing(state)

--- a/tests/test_sk_nonlinear.py
+++ b/tests/test_sk_nonlinear.py
@@ -78,31 +78,7 @@ def setup_sk(dirname):
     advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
     # Set up linear solver
-    schur_params = {'pc_type': 'fieldsplit',
-                    'pc_fieldsplit_type': 'schur',
-                    'ksp_type': 'gmres',
-                    'ksp_monitor_true_residual': True,
-                    'ksp_max_it': 100,
-                    'ksp_gmres_restart': 50,
-                    'pc_fieldsplit_schur_fact_type': 'FULL',
-                    'pc_fieldsplit_schur_precondition': 'selfp',
-                    'fieldsplit_0_ksp_type': 'richardson',
-                    'fieldsplit_0_ksp_max_it': 5,
-                    'fieldsplit_0_pc_type': 'bjacobi',
-                    'fieldsplit_0_sub_pc_type': 'ilu',
-                    'fieldsplit_1_ksp_type': 'richardson',
-                    'fieldsplit_1_ksp_max_it': 5,
-                    "fieldsplit_1_ksp_monitor_true_residual": True,
-                    'fieldsplit_1_pc_type': 'gamg',
-                    'fieldsplit_1_pc_gamg_sym_graph': True,
-                    'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                    'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                    'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                    'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-    linear_solver = CompressibleSolver(state, params=schur_params)
+    linear_solver = CompressibleSolver(state)
 
     # Set up forcing
     compressible_forcing = CompressibleForcing(state)

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -90,31 +90,7 @@ def setup_tracer(dirname):
     advected_fields.append(("tracer", SSPRK3(state, tracer0, thetaeqn)))
 
     # Set up linear solver
-    schur_params = {'pc_type': 'fieldsplit',
-                    'pc_fieldsplit_type': 'schur',
-                    'ksp_type': 'gmres',
-                    'ksp_monitor_true_residual': True,
-                    'ksp_max_it': 100,
-                    'ksp_gmres_restart': 50,
-                    'pc_fieldsplit_schur_fact_type': 'FULL',
-                    'pc_fieldsplit_schur_precondition': 'selfp',
-                    'fieldsplit_0_ksp_type': 'richardson',
-                    'fieldsplit_0_ksp_max_it': 5,
-                    'fieldsplit_0_pc_type': 'bjacobi',
-                    'fieldsplit_0_sub_pc_type': 'ilu',
-                    'fieldsplit_1_ksp_type': 'richardson',
-                    'fieldsplit_1_ksp_max_it': 5,
-                    'fieldsplit_1_ksp_monitor_true_residual': True,
-                    'fieldsplit_1_pc_type': 'gamg',
-                    'fieldsplit_1_pc_gamg_sym_graph': True,
-                    'fieldsplit_1_mg_levels_ksp_type': 'chebyshev',
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig': True,
-                    'fieldsplit_1_mg_levels_ksp_chebyshev_esteig_random': True,
-                    'fieldsplit_1_mg_levels_ksp_max_it': 5,
-                    'fieldsplit_1_mg_levels_pc_type': 'bjacobi',
-                    'fieldsplit_1_mg_levels_sub_pc_type': 'ilu'}
-
-    linear_solver = CompressibleSolver(state, params=schur_params)
+    linear_solver = CompressibleSolver(state)
 
     compressible_forcing = CompressibleForcing(state)
 


### PR DESCRIPTION
This PR deals with the solver parameters for the linear solve. A lot of the vertical slice examples and tests were using outdated solver parameters when they should have been using the defaults provided in their linear_solver class. To make it easier to tweak these options, I have rejigged the linear solver classes a bit:

- the child classes now all call the base class __init__ method
- the base class defines an abstract property called default_solver_parameters - a dictionary of default solver parameters
- the __init__ method has optional args solver_parameters (default None) and overwrite_solver_parameters (default False). If the user provides solver_parameters then the defaults are either updated or replaced, depending on the value of overwrite_solver_paramters.

All vertical slice tests have been updated to use this. I have left the shallow water examples and tests as they are (so they currently fail) - I propose adding the hybridised preconditioner options from https://github.com/firedrakeproject/gusto/pull/112 as the default options - @thomasgibson what do you think?