### PR TITLE
Output options

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -44,6 +44,7 @@ class OutputParameters(Configuration):
     dumplist = None
     dumplist_latlon = []
     dump_diagnostics = True
+    checkpoint = False
     dirname = None
     #: Should the output fields be interpolated or projected to
     #: a linear space?  Default is interpolation.

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -43,6 +43,7 @@ class OutputParameters(Configuration):
     dumpfreq = 1
     dumplist = None
     dumplist_latlon = []
+    dump_diagnostics = True
     dirname = None
     #: Should the output fields be interpolated or projected to
     #: a linear space?  Default is interpolation.

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -78,7 +78,7 @@ class PointDataOutput(object):
             # FIXME add versioning information.
             dataset.source = "Output from Gusto model"
             # Appendable dimension, timesteps in the model
-            dataset.createDimension("time", ndt)
+            dataset.createDimension("time", ndt+1)
 
             var = dataset.createVariable("time", np.float64, ("time"))
             var.units = "seconds"

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -314,7 +314,6 @@ class State(object):
             pointdata_filename = self.dumpdir+"/point_data.nc"
 
             ndt = int(tmax/self.timestepping.dt)
-            print(ndt)
             self.pointdata_output = PointDataOutput(pointdata_filename, ndt,
                                                     self.output.point_data,
                                                     self.output.dirname,

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -104,7 +104,6 @@ class PointDataOutput(object):
         """
         with Dataset(self.filename, "a") as dataset:
             # Add new time index
-            # idx = dataset.dimensions["time"].size
             dataset.variables["time"][self.dump_count] = t
             for field_name, points in self.field_points:
                 vals = np.asarray(field_creator(field_name).at(points))

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -326,14 +326,15 @@ class State(object):
         otherwise dump and checkpoint to disk. (default is False).
         """
         if pickup:
-            # Open the checkpointing file for writing
-            chkfile = path.join(self.dumpdir, "chkpt")
-            with DumbCheckpoint(chkfile, mode=FILE_READ) as chk:
-                # Recover all the fields from the checkpoint
-                for field in self.to_pickup:
-                    chk.load(field)
-                t = chk.read_attribute("/", "time")
-                next(self.dumpcount)
+            if self.output.checkpoint:
+                # Open the checkpointing file for writing
+                chkfile = path.join(self.dumpdir, "chkpt")
+                with DumbCheckpoint(chkfile, mode=FILE_READ) as chk:
+                    # Recover all the fields from the checkpoint
+                    for field in self.to_pickup:
+                        chk.load(field)
+                    t = chk.read_attribute("/", "time")
+                    next(self.dumpcount)
 
         else:
 
@@ -350,14 +351,15 @@ class State(object):
                 self.pointdata_output.dump(self.fields, t)
 
             # Open the checkpointing file (backup version)
-            #files = ["chkptbk", "chkpt"]
-            #for file in files:
-            #    chkfile = path.join(self.dumpdir, file)
-            #    with DumbCheckpoint(chkfile, mode=FILE_CREATE) as chk:
-            #        # Dump all the fields to a checkpoint
-            #        for field in self.to_pickup:
-            #            chk.store(field)
-            #        chk.write_attribute("/", "time", t)
+            if self.output.checkpoint:
+                files = ["chkptbk", "chkpt"]
+                for file in files:
+                    chkfile = path.join(self.dumpdir, file)
+                    with DumbCheckpoint(chkfile, mode=FILE_CREATE) as chk:
+                        # Dump all the fields to a checkpoint
+                        for field in self.to_pickup:
+                            chk.store(field)
+                        chk.write_attribute("/", "time", t)
 
             if (next(self.dumpcount) % self.output.dumpfreq) == 0:
                 # dump fields

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -102,16 +102,16 @@ class PointDataOutput(object):
             fields.
         :arg t: Simulation time at which dump occurs.
         """
-        self.dump_count += 1
         with Dataset(self.filename, "a") as dataset:
             # Add new time index
             # idx = dataset.dimensions["time"].size
-            # dataset.variables["time"][idx:idx + 1] = t
+            dataset.variables["time"][self.dump_count] = t
             for field_name, points in self.field_points:
                 vals = np.asarray(field_creator(field_name).at(points))
                 group = dataset.groups[field_name]
                 var = group.variables[field_name]
                 var[self.dump_count, :] = vals
+        self.dump_count += 1
 
 
 class DiagnosticsOutput(object):

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -350,14 +350,14 @@ class State(object):
                 self.pointdata_output.dump(self.fields, t)
 
             # Open the checkpointing file (backup version)
-            files = ["chkptbk", "chkpt"]
-            for file in files:
-                chkfile = path.join(self.dumpdir, file)
-                with DumbCheckpoint(chkfile, mode=FILE_CREATE) as chk:
-                    # Dump all the fields to a checkpoint
-                    for field in self.to_pickup:
-                        chk.store(field)
-                    chk.write_attribute("/", "time", t)
+            #files = ["chkptbk", "chkpt"]
+            #for file in files:
+            #    chkfile = path.join(self.dumpdir, file)
+            #    with DumbCheckpoint(chkfile, mode=FILE_CREATE) as chk:
+            #        # Dump all the fields to a checkpoint
+            #        for field in self.to_pickup:
+            #            chk.store(field)
+            #        chk.write_attribute("/", "time", t)
 
             if (next(self.dumpcount) % self.output.dumpfreq) == 0:
                 # dump fields

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -189,7 +189,7 @@ class AdvectionTimestepper(BaseTimestepper):
         state.xnp1.assign(state.xn)
 
         with timed_stage("Dump output"):
-            state.setup_dump()
+            state.setup_dump(tmax)
             state.dump(t)
 
         while t < tmax - 0.5*dt:

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -103,7 +103,7 @@ class Timestepper(BaseTimestepper):
             mu_alpha = [None, None]
 
         with timed_stage("Dump output"):
-            state.setup_dump(pickup)
+            state.setup_dump(tmax, pickup)
             t = state.dump(t, pickup)
 
         while t < tmax - 0.5*dt:

--- a/plotting/plot_1D_profile.py
+++ b/plotting/plot_1D_profile.py
@@ -46,7 +46,6 @@ class Plot1DProfile(Plotting):
         # field values
         self.f = self.field[time_entries, idx]
 
-
     def plot(self, same_plot):
 
         for i in range(len(self.times)):


### PR DESCRIPTION
This PR does the following:

- Add option to output diagnostics - previously this was automatically done, and the default is for it to happen, but it might be handy to be able to turn it off (we needed to do this for debugging purposes and also it might be necessary if anyone has trouble with netcdf output).

- Add option to disable checkpointing - maybe we don't need this after Golo's PR goes through but it might still be useful.

- Make creation of point_data.nc file depend on whether the user specifies some points at which to dump data. This means that we don't unnecessarily create an empty file.

- The unlimited time dimension in the point_data.nc file seemed to be causing problems with parallel output so I have just set its length to be `int(tmax/dt) + 1` and this fixes things. Netcdf should be able to do this in parallel and it doesn't seem to be a problem with the diagnostics.nc file...

- Fix some minor bugs in plot_1D_profile.py.