### PR TITLE
Fix dq warnings

### DIFF
--- a/gusto/state.py
+++ b/gusto/state.py
@@ -261,6 +261,7 @@ class State(object):
             f = SteadyStateError(self, name)
             self.diagnostic_fields.append(f)
 
+        self.diagnostics.setup(self)
         for diagnostic in self.diagnostic_fields:
             diagnostic.setup(self)
             self.diagnostics.register(diagnostic.name)


### PR DESCRIPTION
I wondered why there were so many warnings:
`UFL:WARNING Discontinuous Lagrange element requested on interval * interval, creating DQ element.`

Turns out we're creating a function space each timestep in order to calculate the rms value of field for the diagnostics file.

I'm sure there's a better way of fixing this... here I've just added a `setup` method to the `Diagnostics` class so that we can calculate the `area` field once. Then, if I understand correctly, `rms` can no longer be a `@staticmethod`.

Suggestions? (@wence- )