### PR TITLE
Timestepping restructure

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -199,7 +199,7 @@ forcing = CompressibleEadyForcing(state, euler_poincare=False)
 ##############################################################################
 # build time stepper
 ##############################################################################
-stepper = Timestepper(state, advected_fields, linear_solver, forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver, forcing)
 
 ##############################################################################
 # Run!

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -108,7 +108,7 @@ for delta, dt in res_dt.items():
                                                  mu=Constant(10./delta)))]
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          compressible_forcing, diffused_fields)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            compressible_forcing, diffused_fields)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -147,8 +147,8 @@ forcing = IncompressibleForcing(state)
 ##############################################################################
 # build time stepper
 ##############################################################################
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        forcing)
 
 ##############################################################################
 # Run!

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -206,7 +206,7 @@ forcing = EadyForcing(state, euler_poincare=False)
 ##############################################################################
 # build time stepper
 ##############################################################################
-stepper = Timestepper(state, advected_fields, linear_solver, forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver, forcing)
 
 ##############################################################################
 # Run!

--- a/examples/moist_bf_bubble.py
+++ b/examples/moist_bf_bubble.py
@@ -164,8 +164,8 @@ if diffusion:
 physics_list = [Condensation(state)]
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      compressible_forcing, physics_list=physics_list,
-                      diffused_fields=diffused_fields)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        compressible_forcing, physics_list=physics_list,
+                        diffused_fields=diffused_fields)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/nh_mountain.py
+++ b/examples/nh_mountain.py
@@ -155,7 +155,7 @@ linear_solver = CompressibleSolver(state)
 compressible_forcing = CompressibleForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      compressible_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -91,7 +91,7 @@ linear_solver = CompressibleSolver(state)
 compressible_forcing = CompressibleForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      compressible_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -101,7 +101,7 @@ balanced_pg = as_vector((0., 1.0e-4*20, 0.))
 compressible_forcing = CompressibleForcing(state, extra_terms=balanced_pg)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      compressible_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -90,7 +90,7 @@ linear_solver = CompressibleSolver(state)
 compressible_forcing = CompressibleForcing(state, linear=True)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      compressible_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -106,7 +106,7 @@ linear_solver = CompressibleSolver(state)
 compressible_forcing = CompressibleForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      compressible_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sw_hollingsworth.py
+++ b/examples/sw_hollingsworth.py
@@ -80,7 +80,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state, euler_poincare=euler_poincare)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          sw_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_linear_williamson2_triangle.py
+++ b/examples/sw_linear_williamson2_triangle.py
@@ -67,7 +67,7 @@ linear_solver = ShallowWaterSolver(state)
 sw_forcing = ShallowWaterForcing(state, linear=True)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      sw_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        sw_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson2_triangle.py
+++ b/examples/sw_williamson2_triangle.py
@@ -75,7 +75,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state, euler_poincare=False)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          sw_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson2_triangle_vector_invariant.py
+++ b/examples/sw_williamson2_triangle_vector_invariant.py
@@ -75,7 +75,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          sw_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson5.py
+++ b/examples/sw_williamson5.py
@@ -87,7 +87,7 @@ for ref_level, dt in ref_dt.items():
     sw_forcing = ShallowWaterForcing(state, euler_poincare=False)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          sw_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            sw_forcing)
 
     stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson6_triangle.py
+++ b/examples/sw_williamson6_triangle.py
@@ -92,7 +92,7 @@ linear_solver = ShallowWaterSolver(state)
 sw_forcing = ShallowWaterForcing(state)
 
 # build time stepper
-stepper = Timestepper(state, advected_fields, linear_solver,
-                      sw_forcing)
+stepper = CrankNicolson(state, advected_fields, linear_solver,
+                        sw_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -115,7 +115,7 @@ for delta, dt in res_dt.items():
                        ("theta", InteriorPenalty(state, Vt, kappa=75., mu=Constant(10./delta)))]
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          compressible_forcing, diffused_fields)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            compressible_forcing, diffused_fields)
 
     stepper.run(t=0, tmax=tmax)

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -174,7 +174,7 @@ class Timestepper(BaseTimestepper):
 
 class AdvectionDiffusion(BaseTimestepper):
 
-    def run(self, t, tmax, x_end=None):
+    def run(self, t, tmax):
         state = self.state
         state.setup_diagnostics()
 
@@ -205,6 +205,3 @@ class AdvectionDiffusion(BaseTimestepper):
 
             with timed_stage("Dump output"):
                 state.dump(t)
-
-        if x_end is not None:
-            return {field: getattr(state.fields, field) for field in x_end}

--- a/tests/test_IP_diffusion.py
+++ b/tests/test_IP_diffusion.py
@@ -1,12 +1,10 @@
-import itertools
-from os import path
 from gusto import *
 from firedrake import PeriodicIntervalMesh, ExtrudedMesh, SpatialCoordinate,\
-    VectorFunctionSpace, File, Constant, Function, exp, as_vector
+    VectorFunctionSpace, Constant, exp, as_vector
 import pytest
 
 
-def setup_IPdiffusion(vector, DG):
+def setup_IPdiffusion(dirname, vector, DG):
 
     dt = 0.01
     L = 10.
@@ -16,7 +14,7 @@ def setup_IPdiffusion(vector, DG):
     fieldlist = ['u', 'D']
     timestepping = TimesteppingParameters(dt=dt)
     parameters = CompressibleParameters()
-    output = OutputParameters(dirname="IPdiffusion")
+    output = OutputParameters(dirname=dirname)
 
     state = State(mesh, vertical_degree=1, horizontal_degree=1,
                   family="CG",
@@ -27,56 +25,38 @@ def setup_IPdiffusion(vector, DG):
 
     x = SpatialCoordinate(mesh)
     if vector:
+        kappa = Constant([[0.05, 0.], [0., 0.05]])
         if DG:
             Space = VectorFunctionSpace(mesh, "DG", 1)
         else:
             Space = state.spaces("HDiv")
-        f = Function(Space, name="f")
         fexpr = as_vector([exp(-(L/2.-x[0])**2 - (L/2.-x[1])**2), 0.])
     else:
+        kappa = 0.05
         if DG:
             Space = state.spaces("DG")
         else:
             Space = state.spaces("HDiv_v")
-        f = Function(Space, name='f')
         fexpr = exp(-(L/2.-x[0])**2 - (L/2.-x[1])**2)
 
+    f = state.fields("f", Space)
     try:
         f.interpolate(fexpr)
     except NotImplementedError:
         f.project(fexpr)
 
-    return state, f
+    mu = 5.
+    f_diffusion = InteriorPenalty(state, f.function_space(), kappa=kappa, mu=mu)
+    diffused_fields = [("f", f_diffusion)]
+    stepper = AdvectionDiffusion(state, diffused_fields=diffused_fields)
+    return stepper
 
 
 def run(dirname, vector, DG):
 
-    state, f = setup_IPdiffusion(vector, DG)
-
-    kappa = 0.05
-    if vector:
-        kappa = Constant([[0.05, 0.], [0., 0.05]])
-    mu = 5.
-    dt = state.timestepping.dt
-    tmax = 2.5
-    t = 0.
-    f_diffusion = InteriorPenalty(state, f.function_space(), kappa=kappa, mu=mu)
-    outfile = File(path.join(dirname, "IPdiffusion/field_output.pvd"))
-
-    dumpcount = itertools.count()
-
-    outfile.write(f)
-
-    fp1 = Function(f.function_space())
-
-    while t < tmax - 0.5*dt:
-        t += dt
-        f_diffusion.apply(f, fp1)
-        f.assign(fp1)
-
-        if (next(dumpcount) % 25) == 0:
-            outfile.write(f)
-    return f
+    stepper = setup_IPdiffusion(dirname, vector, DG)
+    stepper.run(t=0., tmax=2.5)
+    return stepper.state.fields("f")
 
 
 @pytest.mark.parametrize("vector", [True, False])

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -120,8 +120,8 @@ def run(dirname, geometry, time_discretisation, ibp, equation_form, vector, spat
 
     timestepper, tmax, f_end = setup_advection(dirname, geometry, time_discretisation, ibp, equation_form, vector, spatial_opts=spatial_opts)
 
-    f_dict = timestepper.run(0, tmax, x_end=["f"])
-    f = f_dict["f"]
+    timestepper.run(0, tmax)
+    f = timestepper.state.fields("f")
 
     f_err = Function(f.function_space()).assign(f_end - f)
     return f_err

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -111,7 +111,7 @@ def setup_advection(dirname, geometry, time_discretisation, ibp, equation_form, 
         f_advection = ThetaMethod(state, f, fequation)
 
     advected_fields = [("f", f_advection)]
-    timestepper = AdvectionTimestepper(state, advected_fields)
+    timestepper = AdvectionDiffusion(state, advected_fields)
 
     return timestepper, tmax, f_end
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -84,8 +84,8 @@ def setup_sk(dirname):
     compressible_forcing = CompressibleForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          compressible_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            compressible_forcing)
 
     return stepper, 2*dt
 

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -112,7 +112,7 @@ def setup_condens(dirname):
     physics_list = [Condensation(state)]
 
     # build time stepper
-    stepper = AdvectionTimestepper(state, advected_fields, physics_list=physics_list)
+    stepper = AdvectionDiffusion(state, advected_fields, physics_list=physics_list)
 
     return stepper, 5.0
 

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -63,8 +63,8 @@ def setup_sw(dirname):
     sw_forcing = ShallowWaterForcing(state, linear=True)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          sw_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            sw_forcing)
 
     return stepper, 2*day
 

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -68,8 +68,8 @@ def setup_sw(dirname, euler_poincare):
     linear_solver = ShallowWaterSolver(state)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          sw_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            sw_forcing)
 
     vspace = FunctionSpace(state.mesh, "CG", 3)
     vexpr = (2*u_max/R)*x[2]/R

--- a/tests/test_theta_limiter.py
+++ b/tests/test_theta_limiter.py
@@ -87,7 +87,7 @@ def setup_theta_limiter(dirname):
     advected_fields.append(('theta', SSPRK3(state, theta0, thetaeqn, limiter=ThetaLimiter(thetaeqn.space))))
 
     # build time stepper
-    stepper = AdvectionTimestepper(state, advected_fields)
+    stepper = AdvectionDiffusion(state, advected_fields)
 
     return stepper, 40.0
 

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -95,8 +95,8 @@ def setup_tracer(dirname):
     compressible_forcing = CompressibleForcing(state)
 
     # build time stepper
-    stepper = Timestepper(state, advected_fields, linear_solver,
-                          compressible_forcing)
+    stepper = CrankNicolson(state, advected_fields, linear_solver,
+                            compressible_forcing)
 
     return stepper, 100.0
 


### PR DESCRIPTION
This PR restructures the timestepper class so that code common to both current classes (Timestepper and AdvectionTimestepper) is pulled into the base class. This is done by expanding the base class `run` method to do the following:

1. set up the time loop - i.e. set up the diagnostics and do the first data dump and also check whether we are picking up from checkpointed code.
2. do the time loop, calling the `nonlinear_timestep` method 
3. compute passive advection of fields, if required
4. call the implicit diffusion step, if required
5. call the physics routines, if required
6. dump the data

To write a new timestepper class, you just have to define the `nonlinear_timestep` method. I'm not entirely happy with this name - any suggestions appreciated! 

