### PR TITLE
Logging

### DIFF
--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -35,10 +35,11 @@ class Advection(object, metaclass=ABCMeta):
     :arg field: field to be advected
     :arg equation: :class:`.Equation` object, specifying the equation
     that field satisfies
-    :arg solver_params: solver_parameters
+    :arg solver_parameters: solver_parameters
     """
 
-    def __init__(self, state, field, equation=None, solver_params=None, limiter=None):
+    def __init__(self, state, field, equation=None, solver_parameters=None,
+                 limiter=None):
 
         if equation is not None:
 
@@ -50,10 +51,12 @@ class Advection(object, metaclass=ABCMeta):
             self.dt = self.state.timestepping.dt
 
             # get default solver options if none passed in
-            if solver_params is None:
+            if solver_parameters is None:
                 self.solver_parameters = equation.solver_parameters
             else:
-                self.solver_parameters = solver_params
+                self.solver_parameters = solver_parameters
+                if state.output.Verbose:
+                    self.solver_parameters["ksp_monitor_true_residual"] = True
 
             self.limiter = limiter
 
@@ -205,16 +208,16 @@ class ThetaMethod(Advection):
     Class to implement the theta timestepping method:
     y_(n+1) = y_n + dt*(theta*L(y_n) + (1-theta)*L(y_(n+1))) where L is the advection operator.
     """
-    def __init__(self, state, field, equation, theta=0.5, solver_params=None):
+    def __init__(self, state, field, equation, theta=0.5, solver_parameters=None):
 
-        if not solver_params:
+        if not solver_parameters:
             # theta method leads to asymmetric matrix, per lhs function below,
             # so don't use CG
-            solver_params = {'ksp_type': 'gmres',
-                             'pc_type': 'bjacobi',
-                             'sub_pc_type': 'ilu'}
+            solver_parameters = {'ksp_type': 'gmres',
+                                 'pc_type': 'bjacobi',
+                                 'sub_pc_type': 'ilu'}
 
-        super(ThetaMethod, self).__init__(state, field, equation, solver_params)
+        super(ThetaMethod, self).__init__(state, field, equation, solver_parameters)
 
         self.theta = theta
 

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -151,12 +151,14 @@ class ExplicitAdvection(Advection):
     :arg equation: :class:`.Equation` object, specifying the equation
     that field satisfies
     :arg subcycles: (optional) integer specifying number of subcycles to perform
-    :arg solver_params: solver_parameters
+    :arg solver_parameters: solver_parameters
     :arg limiter: :class:`.Limiter` object.
     """
 
-    def __init__(self, state, field, equation=None, *, subcycles=None, solver_params=None, limiter=None):
-        super().__init__(state, field, equation, solver_params=solver_params, limiter=limiter)
+    def __init__(self, state, field, equation=None, *, subcycles=None,
+                 solver_parameters=None, limiter=None):
+        super().__init__(state, field, equation,
+                         solver_parameters=solver_parameters, limiter=limiter)
 
         # if user has specified a number of subcycles, then save this
         # and rescale dt accordingly; else perform just one cycle using dt

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from firedrake import Function, LinearVariationalProblem, \
     LinearVariationalSolver, Projector
 from firedrake.utils import cached_property
+from gusto.configuration import DEBUG
 from gusto.transport_equation import EmbeddedDGAdvection
 
 
@@ -62,7 +63,7 @@ class Advection(object, metaclass=ABCMeta):
                 self.solver_parameters = equation.solver_parameters
             else:
                 self.solver_parameters = solver_parameters
-                if state.output.log_level == "debug":
+                if state.output.log_level == DEBUG:
                     self.solver_parameters["ksp_monitor_true_residual"] = True
 
             self.limiter = limiter

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -55,7 +55,7 @@ class Advection(object, metaclass=ABCMeta):
                 self.solver_parameters = equation.solver_parameters
             else:
                 self.solver_parameters = solver_parameters
-                if state.output.Verbose:
+                if state.output.log_level == "debug":
                     self.solver_parameters["ksp_monitor_true_residual"] = True
 
             self.limiter = limiter

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -2,12 +2,22 @@
 Some simple tools for making model configuration nicer.
 """
 import logging
+from logging import DEBUG, INFO, WARNING
 from firedrake import sqrt
 
 
-__all__ = ["TimesteppingParameters", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters", "logger"]
+__all__ = ["WARNING", "INFO", "DEBUG", "TimesteppingParameters", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters", "logger"]
 
 logger = logging.getLogger("gusto")
+
+
+def set_log_handler(comm):
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt="%(name)s:%(levelname)s %(message)s"))
+    if comm.rank == 0:
+        logger.addHandler(handler)
+    else:
+        logger.addHandler(logging.NullHandler())
 
 
 class Configuration(object):
@@ -43,7 +53,7 @@ class OutputParameters(Configuration):
 
     #: log_level for logger, can be "debug", "info" or "warning". Take
     #: default value "warning"
-    log_level = "warning"
+    log_level = WARNING
     dumpfreq = 1
     dumplist = None
     dumplist_latlon = []

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -39,7 +39,7 @@ class OutputParameters(Configuration):
     Output parameters for Gusto
     """
 
-    Verbose = False
+    log_level = "warning"
     dumpfreq = 1
     dumplist = None
     dumplist_latlon = []

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -39,6 +39,8 @@ class OutputParameters(Configuration):
     Output parameters for Gusto
     """
 
+    #: log_level for logger, can be "debug", "info" or "warning". Take
+    #: default value "warning"
     log_level = "warning"
     dumpfreq = 1
     dumplist = None

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -1,11 +1,13 @@
 """
 Some simple tools for making model configuration nicer.
 """
-
+import logging
 from firedrake import sqrt
 
 
-__all__ = ["TimesteppingParameters", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters"]
+__all__ = ["TimesteppingParameters", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters", "logger"]
+
+logger = logging.getLogger("gusto")
 
 
 class Configuration(object):

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -51,7 +51,7 @@ class OutputParameters(Configuration):
     Output parameters for Gusto
     """
 
-    #: log_level for logger, can be "debug", "info" or "warning". Take
+    #: log_level for logger, can be DEBUG, INFO or WARNING. Takes
     #: default value "warning"
     log_level = WARNING
     dumpfreq = 1

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -3,6 +3,7 @@ from firedrake import Function, split, TrialFunction, TestFunction, \
     FacetNormal, inner, dx, cross, div, jump, avg, dS_v, \
     DirichletBC, LinearVariationalProblem, LinearVariationalSolver, \
     dot, dS, Constant, as_vector, SpatialCoordinate
+from gusto.configuration import logger
 
 
 __all__ = ["CompressibleForcing", "IncompressibleForcing", "EadyForcing", "CompressibleEadyForcing", "ShallowWaterForcing", "exner", "exner_rho", "exner_theta"]
@@ -26,7 +27,7 @@ class Forcing(object, metaclass=ABCMeta):
         self.state = state
         if linear:
             self.euler_poincare = False
-            state.logger.info('Setting euler_poincare to False because you have set linear=True')
+            logger.info('Setting euler_poincare to False because you have set linear=True')
         else:
             self.euler_poincare = euler_poincare
 

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -105,7 +105,14 @@ class Forcing(object, metaclass=ABCMeta):
             a, L, self.uF, bcs=bcs
         )
 
-        self.u_forcing_solver = LinearVariationalSolver(u_forcing_problem)
+        solver_parameters = {}
+        if self.state.output.Verbose:
+            solver_parameters["ksp_monitor_true_residual"] = True
+        self.u_forcing_solver = LinearVariationalSolver(
+            u_forcing_problem,
+            solver_parameters=solver_parameters,
+            options_prefix="UForcingSolver"
+        )
 
     def apply(self, scaling, x_in, x_nl, x_out, **kwargs):
         """
@@ -207,7 +214,14 @@ class CompressibleForcing(Forcing):
 
             theta_problem = LinearVariationalProblem(a, L, self.thetaF)
 
-            self.theta_solver = LinearVariationalSolver(theta_problem)
+            solver_parameters = {}
+            if self.state.output.Verbose:
+                solver_parameters["ksp_monitor_true_residual"] = True
+            self.theta_solver = LinearVariationalSolver(
+                theta_problem,
+                solver_parameters=solver_parameters,
+                option_prefix="ThetaForcingSolver"
+            )
 
     def apply(self, scaling, x_in, x_nl, x_out, **kwargs):
 
@@ -275,7 +289,14 @@ class IncompressibleForcing(Forcing):
         divergence_problem = LinearVariationalProblem(
             a, L, self.divu)
 
-        self.divergence_solver = LinearVariationalSolver(divergence_problem)
+        solver_parameters = {}
+        if self.state.output.Verbose:
+            solver_parameters["ksp_monitor_true_residual"] = True
+        self.divergence_solver = LinearVariationalSolver(
+            divergence_problem,
+            solver_parameters=solver_parameters,
+            options_prefix="DivergenceSolver"
+        )
 
     def apply(self, scaling, x_in, x_nl, x_out, **kwargs):
 
@@ -322,7 +343,14 @@ class EadyForcing(IncompressibleForcing):
             a, L, self.bF
         )
 
-        self.b_forcing_solver = LinearVariationalSolver(b_forcing_problem)
+        solver_parameters = {}
+        if self.state.output.Verbose:
+            solver_parameters["ksp_monitor_true_residual"] = True
+        self.b_forcing_solver = LinearVariationalSolver(
+            b_forcing_problem,
+            solver_parameters=solver_parameters,
+            options_prefix="BForcingSolver"
+        )
 
     def apply(self, scaling, x_in, x_nl, x_out, **kwargs):
 
@@ -370,7 +398,14 @@ class CompressibleEadyForcing(CompressibleForcing):
             a, L, self.thetaF
         )
 
-        self.theta_forcing_solver = LinearVariationalSolver(theta_forcing_problem)
+        solver_parameters = {}
+        if self.state.output.Verbose:
+            solver_parameters["ksp_monitor_true_residual"] = True
+        self.theta_forcing_solver = LinearVariationalSolver(
+            theta_forcing_problem,
+            solver_parameters=solver_parameters,
+            options_prefix="ThetaForcingSolver"
+        )
 
     def apply(self, scaling, x_in, x_nl, x_out, **kwargs):
 

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -2,7 +2,7 @@ from abc import ABCMeta, abstractmethod
 from firedrake import Function, split, TrialFunction, TestFunction, \
     FacetNormal, inner, dx, cross, div, jump, avg, dS_v, \
     DirichletBC, LinearVariationalProblem, LinearVariationalSolver, \
-    dot, dS, Constant, warning, as_vector, SpatialCoordinate
+    dot, dS, Constant, as_vector, SpatialCoordinate
 
 
 __all__ = ["CompressibleForcing", "IncompressibleForcing", "EadyForcing", "CompressibleEadyForcing", "ShallowWaterForcing", "exner", "exner_rho", "exner_theta"]
@@ -26,7 +26,7 @@ class Forcing(object, metaclass=ABCMeta):
         self.state = state
         if linear:
             self.euler_poincare = False
-            warning('Setting euler_poincare to False because you have set linear=True')
+            state.logger.info('Setting euler_poincare to False because you have set linear=True')
         else:
             self.euler_poincare = euler_poincare
 

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -3,7 +3,7 @@ from firedrake import Function, split, TrialFunction, TestFunction, \
     FacetNormal, inner, dx, cross, div, jump, avg, dS_v, \
     DirichletBC, LinearVariationalProblem, LinearVariationalSolver, \
     dot, dS, Constant, as_vector, SpatialCoordinate
-from gusto.configuration import logger
+from gusto.configuration import logger, DEBUG
 
 
 __all__ = ["CompressibleForcing", "IncompressibleForcing", "EadyForcing", "CompressibleEadyForcing", "ShallowWaterForcing", "exner", "exner_rho", "exner_theta"]
@@ -27,7 +27,7 @@ class Forcing(object, metaclass=ABCMeta):
         self.state = state
         if linear:
             self.euler_poincare = False
-            logger.info('Setting euler_poincare to False because you have set linear=True')
+            logger.warning('Setting euler_poincare to False because you have set linear=True')
         else:
             self.euler_poincare = euler_poincare
 
@@ -107,7 +107,7 @@ class Forcing(object, metaclass=ABCMeta):
         )
 
         solver_parameters = {}
-        if self.state.output.log_level == "debug":
+        if self.state.output.log_level == DEBUG:
             solver_parameters["ksp_monitor_true_residual"] = True
         self.u_forcing_solver = LinearVariationalSolver(
             u_forcing_problem,
@@ -216,7 +216,7 @@ class CompressibleForcing(Forcing):
             theta_problem = LinearVariationalProblem(a, L, self.thetaF)
 
             solver_parameters = {}
-            if self.state.output.log_level == "debug":
+            if self.state.output.log_level == DEBUG:
                 solver_parameters["ksp_monitor_true_residual"] = True
             self.theta_solver = LinearVariationalSolver(
                 theta_problem,
@@ -291,7 +291,7 @@ class IncompressibleForcing(Forcing):
             a, L, self.divu)
 
         solver_parameters = {}
-        if self.state.output.log_level == "debug":
+        if self.state.output.log_level == DEBUG:
             solver_parameters["ksp_monitor_true_residual"] = True
         self.divergence_solver = LinearVariationalSolver(
             divergence_problem,
@@ -345,7 +345,7 @@ class EadyForcing(IncompressibleForcing):
         )
 
         solver_parameters = {}
-        if self.state.output.log_level == "debug":
+        if self.state.output.log_level == DEBUG:
             solver_parameters["ksp_monitor_true_residual"] = True
         self.b_forcing_solver = LinearVariationalSolver(
             b_forcing_problem,
@@ -400,7 +400,7 @@ class CompressibleEadyForcing(CompressibleForcing):
         )
 
         solver_parameters = {}
-        if self.state.output.log_level == "debug":
+        if self.state.output.log_level == DEBUG:
             solver_parameters["ksp_monitor_true_residual"] = True
         self.theta_forcing_solver = LinearVariationalSolver(
             theta_forcing_problem,

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -106,7 +106,7 @@ class Forcing(object, metaclass=ABCMeta):
         )
 
         solver_parameters = {}
-        if self.state.output.Verbose:
+        if self.state.output.log_level == "debug":
             solver_parameters["ksp_monitor_true_residual"] = True
         self.u_forcing_solver = LinearVariationalSolver(
             u_forcing_problem,
@@ -215,7 +215,7 @@ class CompressibleForcing(Forcing):
             theta_problem = LinearVariationalProblem(a, L, self.thetaF)
 
             solver_parameters = {}
-            if self.state.output.Verbose:
+            if self.state.output.log_level == "debug":
                 solver_parameters["ksp_monitor_true_residual"] = True
             self.theta_solver = LinearVariationalSolver(
                 theta_problem,
@@ -290,7 +290,7 @@ class IncompressibleForcing(Forcing):
             a, L, self.divu)
 
         solver_parameters = {}
-        if self.state.output.Verbose:
+        if self.state.output.log_level == "debug":
             solver_parameters["ksp_monitor_true_residual"] = True
         self.divergence_solver = LinearVariationalSolver(
             divergence_problem,
@@ -344,7 +344,7 @@ class EadyForcing(IncompressibleForcing):
         )
 
         solver_parameters = {}
-        if self.state.output.Verbose:
+        if self.state.output.log_level == "debug":
             solver_parameters["ksp_monitor_true_residual"] = True
         self.b_forcing_solver = LinearVariationalSolver(
             b_forcing_problem,
@@ -399,7 +399,7 @@ class CompressibleEadyForcing(CompressibleForcing):
         )
 
         solver_parameters = {}
-        if self.state.output.Verbose:
+        if self.state.output.log_level == "debug":
             solver_parameters["ksp_monitor_true_residual"] = True
         self.theta_forcing_solver = LinearVariationalSolver(
             theta_forcing_problem,

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -9,7 +9,7 @@ from firedrake import MixedFunctionSpace, TrialFunctions, TestFunctions, \
     Function, Constant, assemble, \
     LinearVariationalProblem, LinearVariationalSolver, \
     NonlinearVariationalProblem, NonlinearVariationalSolver, split, solve, \
-    sin, cos, sqrt, asin, atan_2, as_vector, Min, Max, exp, warning
+    sin, cos, sqrt, asin, atan_2, as_vector, Min, Max, exp
 from gusto.forcing import exner
 
 
@@ -321,7 +321,7 @@ def moist_hydrostatic_balance(state, theta_e, water_t, pi_boundary=Constant(1.0)
 
     VDG = state.spaces("DG")
     if any(deg > 2 for deg in VDG.ufl_element().degree()):
-        warning("default quadrature degree most likely not sufficient for this degree element")
+        state.logger.warning("default quadrature degree most likely not sufficient for this degree element")
     quadrature_degree = (5, 5)
 
     params = {'ksp_type': 'preonly',

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division
+from gusto.configuration import logger
 from firedrake import dx
 from firedrake.function import Function
 from firedrake.functionspace import FunctionSpace
@@ -50,7 +51,7 @@ class ThetaLimiter(object):
     the central nodes to prevent new maxima or minima forming.
     """
 
-    def __init__(self, state, equation):
+    def __init__(self, equation):
         """
         Initialise limiter
 
@@ -70,7 +71,7 @@ class ThetaLimiter(object):
                self.Vt.ufl_element()._element.sobolev_space()[1].name is not 'H1':
                 raise ValueError('This is not the right limiter for this space.')
         else:
-            state.logger.warning('This limiter may not work for the space you are using.')
+            logger.warning('This limiter may not work for the space you are using.')
 
         self.Q1DG = FunctionSpace(self.Vt.mesh(), 'DG', 1)  # space with only vertex DOFs
         self.vertex_limiter = VertexBasedLimiter(self.Q1DG)

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -50,7 +50,7 @@ class ThetaLimiter(object):
     the central nodes to prevent new maxima or minima forming.
     """
 
-    def __init__(self, equation):
+    def __init__(self, state, equation):
         """
         Initialise limiter
 
@@ -70,7 +70,7 @@ class ThetaLimiter(object):
                self.Vt.ufl_element()._element.sobolev_space()[1].name is not 'H1':
                 raise ValueError('This is not the right limiter for this space.')
         else:
-            print('This limiter may not work for the space you are using.')
+            state.logger.warning('This limiter may not work for the space you are using.')
 
         self.Q1DG = FunctionSpace(self.Vt.mesh(), 'DG', 1)  # space with only vertex DOFs
         self.vertex_limiter = VertexBasedLimiter(self.Q1DG)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -37,6 +37,9 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
                 solver_parameters = p
             self.solver_parameters = solver_parameters
 
+        if state.output.Verbose:
+            self.solver_parameters["ksp_monitor_true_residual"] = True
+
         # setup the solver
         self._setup_solver()
 

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -2,7 +2,7 @@ from firedrake import split, LinearVariationalProblem, \
     LinearVariationalSolver, TestFunctions, TrialFunctions, \
     TestFunction, TrialFunction, lhs, rhs, DirichletBC, FacetNormal, \
     div, dx, jump, avg, dS_v, dS_h, inner, MixedFunctionSpace, dot, grad, \
-    Function, MixedVectorSpaceBasis, VectorSpaceBasis, warning
+    Function, MixedVectorSpaceBasis, VectorSpaceBasis
 from firedrake.solving_utils import flatten_parameters
 
 from gusto.forcing import exner, exner_rho, exner_theta
@@ -104,7 +104,7 @@ class CompressibleSolver(TimesteppingSolver):
         else:
             dgspace = state.spaces("DG")
             if any(deg > 2 for deg in dgspace.ufl_element().degree()):
-                warning("default quadrature degree most likely not sufficient for this degree element")
+                state.logger.warning("default quadrature degree most likely not sufficient for this degree element")
             self.quadrature_degree = (5, 5)
 
         super().__init__(state, solver_parameters, overwrite_solver_parameters)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -37,7 +37,7 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
                 solver_parameters = p
             self.solver_parameters = solver_parameters
 
-        if state.output.Verbose:
+        if state.output.log_level == "debug":
             self.solver_parameters["ksp_monitor_true_residual"] = True
 
         # setup the solver

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -5,6 +5,7 @@ from firedrake import split, LinearVariationalProblem, \
     Function, MixedVectorSpaceBasis, VectorSpaceBasis
 from firedrake.solving_utils import flatten_parameters
 
+from gusto.configuration import DEBUG
 from gusto.forcing import exner, exner_rho, exner_theta
 from abc import ABCMeta, abstractmethod, abstractproperty
 
@@ -37,7 +38,7 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
                 solver_parameters = p
             self.solver_parameters = solver_parameters
 
-        if state.output.log_level == "debug":
+        if state.output.log_level == DEBUG:
             self.solver_parameters["ksp_monitor_true_residual"] = True
 
         # setup the solver

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -12,6 +12,7 @@ from firedrake import FiniteElement, TensorProductElement, HDiv, \
     FILE_CREATE, FILE_READ, interpolate, CellNormal, cross, as_vector
 import numpy as np
 import logging
+from gusto.configuration import logger
 
 __all__ = ["State"]
 
@@ -252,7 +253,7 @@ class State(object):
         #  Constant to hold current time
         self.t = Constant(0.0)
 
-        logger = logging.getLogger("gusto")
+        # setup logger
         if output.log_level == "debug":
             logger.setLevel(logging.DEBUG)
         elif output.log_level == "info":
@@ -272,7 +273,6 @@ class State(object):
         if parameters is not None:
             logger.info("Physical parameters that take non-default values:")
             logger.info(", ".join("%s: %s" % item for item in vars(parameters).items()))
-        self.logger = logger
 
     def setup_diagnostics(self):
         # add special case diagnostic fields

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -11,8 +11,7 @@ from firedrake import FiniteElement, TensorProductElement, HDiv, \
     dx, op2, par_loop, READ, WRITE, DumbCheckpoint, \
     FILE_CREATE, FILE_READ, interpolate, CellNormal, cross, as_vector
 import numpy as np
-import logging
-from gusto.configuration import logger
+from gusto.configuration import logger, set_log_handler
 
 __all__ = ["State"]
 
@@ -254,20 +253,8 @@ class State(object):
         self.t = Constant(0.0)
 
         # setup logger
-        if output.log_level == "debug":
-            logger.setLevel(logging.DEBUG)
-        elif output.log_level == "info":
-            logger.setLevel(logging.INFO)
-        elif output.log_level == "warning":
-            logger.setLevel(logging.WARNING)
-        else:
-            raise ValueError("log_level must be one of: %s, %s, %s, not %s" % ("info", "debug", "warning", output.log_level))
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter(fmt="%(name)s:%(levelname)s %(message)s"))
-        if self.mesh.comm.rank == 0:
-            logger.addHandler(handler)
-        else:
-            logger.addHandler(logging.NullHandler())
+        logger.setLevel(output.log_level)
+        set_log_handler(mesh.comm)
         logger.info("Timestepping parameters that take non-default values:")
         logger.info(", ".join("%s: %s" % item for item in vars(timestepping).items()))
         if parameters is not None:

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -11,7 +11,7 @@ from firedrake import FiniteElement, TensorProductElement, HDiv, \
     dx, op2, par_loop, READ, WRITE, DumbCheckpoint, \
     FILE_CREATE, FILE_READ, interpolate, CellNormal, cross, as_vector
 import numpy as np
-
+import logging
 
 __all__ = ["State"]
 
@@ -251,6 +251,22 @@ class State(object):
 
         #  Constant to hold current time
         self.t = Constant(0.0)
+
+        logger = logging.getLogger("gusto")
+        if output.Verbose:
+            logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(fmt="%(name)s:%(levelname)s %(message)s"))
+        if self.mesh.comm.rank == 0:
+            logger.addHandler(handler)
+        else:
+            logger.addHandler(logging.NullHandler())
+        logger.info("Timestepping parameters that take non-default values:")
+        logger.info(", ".join("%s: %s" % item for item in vars(timestepping).items()))
+        if parameters is not None:
+            logger.info("Physical parameters that take non-default values:")
+            logger.info(", ".join("%s: %s" % item for item in vars(parameters).items()))
+        self.logger = logger
 
     def setup_diagnostics(self):
         # add special case diagnostic fields

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -253,8 +253,14 @@ class State(object):
         self.t = Constant(0.0)
 
         logger = logging.getLogger("gusto")
-        if output.Verbose:
+        if output.log_level == "debug":
             logger.setLevel(logging.DEBUG)
+        elif output.log_level == "info":
+            logger.setLevel(logging.INFO)
+        elif output.log_level == "warning":
+            logger.setLevel(logging.WARNING)
+        else:
+            raise ValueError("log_level must be one of: %s, %s, %s, not %s" % ("info", "debug", "warning", output.log_level))
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter(fmt="%(name)s:%(levelname)s %(message)s"))
         if self.mesh.comm.rank == 0:

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from pyop2.profiling import timed_stage
+from gusto.configuration import logger
 from gusto.linear_solvers import IncompressibleSolver
 from firedrake import DirichletBC
 
@@ -87,7 +88,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         dt = state.timestepping.dt
 
         while t < tmax - 0.5*dt:
-            state.logger.info("at start of timestep, t=%s, dt=%s" % (t, dt))
+            logger.info("at start of timestep, t=%s, dt=%s" % (t, dt))
 
             t += dt
             state.t.assign(t)
@@ -118,7 +119,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             with timed_stage("Dump output"):
                 state.dump(t, pickup=False)
 
-        state.logger.info("TIMELOOP complete. t=%s, tmax=%s" % (t, tmax))
+        logger.info("TIMELOOP complete. t=%s, tmax=%s" % (t, tmax))
 
 
 class CrankNicolson(BaseTimestepper):

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -3,7 +3,6 @@ from pyop2.profiling import timed_stage
 from gusto.linear_solvers import IncompressibleSolver
 from firedrake import DirichletBC
 
-
 __all__ = ["CrankNicolson", "AdvectionDiffusion"]
 
 
@@ -88,8 +87,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         dt = state.timestepping.dt
 
         while t < tmax - 0.5*dt:
-            if state.output.Verbose:
-                print("STEP", t, dt)
+            state.logger.info("at start of timestep, t=%s, dt=%s" % (t, dt))
 
             t += dt
             state.t.assign(t)
@@ -120,7 +118,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             with timed_stage("Dump output"):
                 state.dump(t, pickup=False)
 
-        print("TIMELOOP complete. t= " + str(t) + " tmax=" + str(tmax))
+        state.logger.info("TIMELOOP complete. t=%s, tmax=%s" % (t, tmax))
 
 
 class CrankNicolson(BaseTimestepper):

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -67,6 +67,8 @@ class TransportEquation(object, metaclass=ABCMeta):
             self.solver_parameters = {'ksp_type': 'cg',
                                       'pc_type': 'bjacobi',
                                       'sub_pc_type': 'ilu'}
+        if state.output.Verbose:
+            self.solver_parameters["ksp_monitor_true_residual"] = True
 
     def mass_term(self, q):
         return inner(self.test, q)*dx

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -67,7 +67,7 @@ class TransportEquation(object, metaclass=ABCMeta):
             self.solver_parameters = {'ksp_type': 'cg',
                                       'pc_type': 'bjacobi',
                                       'sub_pc_type': 'ilu'}
-        if state.output.Verbose:
+        if state.output.log_level == "debug":
             self.solver_parameters["ksp_monitor_true_residual"] = True
 
     def mass_term(self, q):

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -4,6 +4,7 @@ from firedrake import Function, TestFunction, TrialFunction, \
     dx, dot, grad, div, jump, avg, dS, dS_v, dS_h, inner, \
     outer, sign, cross, CellNormal, sqrt, Constant, \
     curl, BrokenElement, FunctionSpace
+from gusto.configuration import DEBUG
 
 
 __all__ = ["LinearAdvection", "AdvectionEquation", "EmbeddedDGAdvection", "SUPGAdvection", "VectorInvariant", "EulerPoincare"]
@@ -67,7 +68,7 @@ class TransportEquation(object, metaclass=ABCMeta):
             self.solver_parameters = {'ksp_type': 'cg',
                                       'pc_type': 'bjacobi',
                                       'sub_pc_type': 'ilu'}
-        if state.output.log_level == "debug":
+        if state.output.log_level == DEBUG:
             self.solver_parameters["ksp_monitor_true_residual"] = True
 
     def mass_term(self, q):

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -17,7 +17,7 @@ def setup_sk(dirname):
 
     fieldlist = ['u', 'rho', 'theta']
     timestepping = TimesteppingParameters(dt=dt)
-    output = OutputParameters(dirname=dirname+"/sk_nonlinear", dumplist=['u'], dumpfreq=5, log_level="info")
+    output = OutputParameters(dirname=dirname+"/sk_nonlinear", dumplist=['u'], dumpfreq=5, log_level=INFO)
     parameters = CompressibleParameters()
     diagnostic_fields = [CourantNumber()]
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -17,7 +17,7 @@ def setup_sk(dirname):
 
     fieldlist = ['u', 'rho', 'theta']
     timestepping = TimesteppingParameters(dt=dt)
-    output = OutputParameters(dirname=dirname+"/sk_nonlinear", dumplist=['u'], dumpfreq=5, Verbose=True)
+    output = OutputParameters(dirname=dirname+"/sk_nonlinear", dumplist=['u'], dumpfreq=5, log_level="info")
     parameters = CompressibleParameters()
     diagnostic_fields = [CourantNumber()]
 

--- a/tests/test_theta_limiter.py
+++ b/tests/test_theta_limiter.py
@@ -80,7 +80,7 @@ def setup_theta_limiter(dirname):
     # build advection dictionary
     advected_fields = []
     advected_fields.append(('u', NoAdvection(state, u0, None)))
-    advected_fields.append(('theta', SSPRK3(state, theta0, thetaeqn, limiter=ThetaLimiter(state, thetaeqn))))
+    advected_fields.append(('theta', SSPRK3(state, theta0, thetaeqn, limiter=ThetaLimiter(thetaeqn))))
 
     # build time stepper
     stepper = AdvectionDiffusion(state, advected_fields)

--- a/tests/test_theta_limiter.py
+++ b/tests/test_theta_limiter.py
@@ -80,7 +80,7 @@ def setup_theta_limiter(dirname):
     # build advection dictionary
     advected_fields = []
     advected_fields.append(('u', NoAdvection(state, u0, None)))
-    advected_fields.append(('theta', SSPRK3(state, theta0, thetaeqn, limiter=ThetaLimiter(thetaeqn))))
+    advected_fields.append(('theta', SSPRK3(state, theta0, thetaeqn, limiter=ThetaLimiter(state, thetaeqn))))
 
     # build time stepper
     stepper = AdvectionDiffusion(state, advected_fields)


### PR DESCRIPTION
This PR does 2 things:

1) creates a logger so that we can have different levels of output, and so that we only print on one processor when running in parallel.

2) rename `Verbose` in `OutputParameters` class to `log_level` for more flexibility. `log_level` can be `warning` (the default), `info` or `debug`. When set to `info`, basic information on the user defined inputs in printed out. When set to `debug`, `ksp_monitor_true_residual` is set to `True`.

Things I don't like about this code:

1) the output from the solvers is not controlled by the logger - does that matter?

2) I have passed `state` in to the `Limiter` class - it's a bit annoying to do this just to get the logger, but I'd rather users didn't have to think about passing the logger around. I could get the logger via `equation.state.logger` but that seems a bit convoluted. Advice?