### PR TITLE
Implicit midpoint2

### DIFF
--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -26,7 +26,7 @@ for delta, dt in res_dt.items():
     mesh = ExtrudedMesh(m, layers=nlayers, layer_height=H/nlayers)
 
     fieldlist = ['u', 'rho', 'theta']
-    timestepping = TimesteppingParameters(dt=dt, maxk=4, maxi=1)
+    timestepping = TimesteppingParameters(dt=dt)
     output = OutputParameters(dirname=dirname, dumpfreq=5, dumplist=['u'], perturbation_fields=['theta', 'rho'])
     parameters = CompressibleParameters()
     diagnostics = Diagnostics(*fieldlist)

--- a/examples/moist_bf_bubble.py
+++ b/examples/moist_bf_bubble.py
@@ -23,7 +23,7 @@ mesh = ExtrudedMesh(m, layers=nlayers, layer_height=H/nlayers)
 diffusion = True
 
 fieldlist = ['u', 'rho', 'theta']
-timestepping = TimesteppingParameters(dt=dt, maxk=4, maxi=1)
+timestepping = TimesteppingParameters(dt=dt)
 output = OutputParameters(dirname='moist_bf', dumpfreq=20, dumplist=['u'], perturbation_fields=[])
 params = CompressibleParameters()
 diagnostics = Diagnostics(*fieldlist)

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -18,7 +18,7 @@ m = PeriodicIntervalMesh(ncolumns, L)
 mesh = ExtrudedMesh(m, layers=nlayers, layer_height=H/nlayers)
 
 fieldlist = ['u', 'rho', 'theta']
-timestepping = TimesteppingParameters(dt=dt, maxk=4, maxi=1)
+timestepping = TimesteppingParameters(dt=dt)
 output = OutputParameters(dirname='rb', dumpfreq=10, dumplist=['u'], perturbation_fields=['theta', 'rho'])
 parameters = CompressibleParameters()
 diagnostics = Diagnostics(*fieldlist)

--- a/examples/sk_nonlinear_im.py
+++ b/examples/sk_nonlinear_im.py
@@ -1,0 +1,112 @@
+from gusto import *
+import itertools
+from firedrake import as_vector, SpatialCoordinate, PeriodicIntervalMesh, \
+    ExtrudedMesh, exp, sin, Function
+import numpy as np
+import sys
+
+dt = 6.
+if '--running-tests' in sys.argv:
+    tmax = dt
+else:
+    tmax = 3600.
+
+nlayers = 10  # horizontal layers
+columns = 150  # number of columns
+L = 3.0e5
+m = PeriodicIntervalMesh(columns, L)
+
+# build volume mesh
+H = 1.0e4  # Height position of the model top
+mesh = ExtrudedMesh(m, layers=nlayers, layer_height=H/nlayers)
+
+points_x = np.linspace(0., L, 100)
+points_z = [H/2.]
+points = np.array([p for p in itertools.product(points_x, points_z)])
+
+fieldlist = ['u', 'rho', 'theta']
+timestepping = TimesteppingParameters(dt=dt)
+output = OutputParameters(dirname='sk_nonlinear_im', dumpfreq=1, dumplist=['u'],
+                          perturbation_fields=['theta', 'rho'],
+                          point_data=[('theta_perturbation', points)])
+parameters = CompressibleParameters()
+diagnostics = Diagnostics(*fieldlist)
+diagnostic_fields = [CourantNumber()]
+
+state = State(mesh, vertical_degree=1, horizontal_degree=1,
+              family="CG",
+              timestepping=timestepping,
+              output=output,
+              parameters=parameters,
+              diagnostics=diagnostics,
+              fieldlist=fieldlist,
+              diagnostic_fields=diagnostic_fields)
+
+# Initial conditions
+u0 = state.fields("u")
+rho0 = state.fields("rho")
+theta0 = state.fields("theta")
+
+# spaces
+Vu = u0.function_space()
+Vt = theta0.function_space()
+Vr = rho0.function_space()
+
+# Thermodynamic constants required for setting initial conditions
+# and reference profiles
+g = parameters.g
+N = parameters.N
+p_0 = parameters.p_0
+c_p = parameters.cp
+R_d = parameters.R_d
+kappa = parameters.kappa
+
+x, z = SpatialCoordinate(mesh)
+
+# N^2 = (g/theta)dtheta/dz => dtheta/dz = theta N^2g => theta=theta_0exp(N^2gz)
+Tsurf = 300.
+thetab = Tsurf*exp(N**2*z/g)
+
+theta_b = Function(Vt).interpolate(thetab)
+rho_b = Function(Vr)
+
+# Calculate hydrostatic Pi
+compressible_hydrostatic_balance(state, theta_b, rho_b)
+
+a = 5.0e3
+deltaTheta = 1.0e-2
+theta_pert = deltaTheta*sin(np.pi*z/H)/(1 + (x - L/2)**2/a**2)
+theta0.interpolate(theta_b + theta_pert)
+rho0.assign(rho_b)
+u0.project(as_vector([20.0, 0.0]))
+
+state.initialise([('u', u0),
+                  ('rho', rho0),
+                  ('theta', theta0)])
+state.set_reference_profiles([('rho', rho_b),
+                              ('theta', theta_b)])
+
+# Set up forcing
+compressible_forcing = CompressibleForcing(state, euler_poincare=False)
+
+# Set up advection schemes
+ueqn = VectorInvariant(state, state.spaces("HDiv"))
+rhoeqn = AdvectionEquation(state, Vr, equation_form="continuity")
+supg = True
+if supg:
+    thetaeqn = SUPGAdvection(state, Vt, supg_params={"dg_direction": "horizontal"}, equation_form="advective")
+else:
+    thetaeqn = EmbeddedDGAdvection(state, Vt, equation_form="advective")
+advected_fields = []
+advected_fields.append(("u", SSPRK3(state, u0, ueqn,
+                                    forcing=compressible_forcing)))
+advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn)))
+advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
+
+# Set up linear solver
+linear_solver = CompressibleSolver(state)
+
+# build time stepper
+stepper = ImplicitMidpoint(state, advected_fields, linear_solver)
+
+stepper.run(t=0, tmax=tmax)

--- a/examples/sw_williamson2_triangle_im.py
+++ b/examples/sw_williamson2_triangle_im.py
@@ -1,0 +1,80 @@
+from gusto import *
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, \
+    FunctionSpace
+from math import pi
+import sys
+
+day = 24.*60.*60.
+if '--running-tests' in sys.argv:
+    ref_dt = {3: 3000.}
+    tmax = 3000.
+else:
+    # setup resolution and timestepping parameters for convergence test
+    ref_dt = {3: 3000., 4: 1500., 5: 750., 6: 375.}
+    tmax = 5*day
+
+# setup shallow water parameters
+R = 6371220.
+H = 5960.
+
+# setup input that doesn't change with ref level or dt
+fieldlist = ['u', 'D']
+parameters = ShallowWaterParameters(H=H)
+diagnostics = Diagnostics(*fieldlist)
+
+for ref_level, dt in ref_dt.items():
+
+    dirname = "sw_W2_IM_ref%s_dt%s" % (ref_level, dt)
+    mesh = IcosahedralSphereMesh(radius=R,
+                                 refinement_level=ref_level, degree=3)
+    x = SpatialCoordinate(mesh)
+    global_normal = x
+    mesh.init_cell_orientations(x)
+
+    timestepping = TimesteppingParameters(dt=dt)
+    output = OutputParameters(dirname=dirname, dumplist_latlon=['D', 'D_error'], steady_state_error_fields=['D', 'u'])
+
+    state = State(mesh, horizontal_degree=1,
+                  family="BDM",
+                  timestepping=timestepping,
+                  output=output,
+                  parameters=parameters,
+                  diagnostics=diagnostics,
+                  fieldlist=fieldlist)
+
+    # interpolate initial conditions
+    u0 = state.fields("u")
+    D0 = state.fields("D")
+    x = SpatialCoordinate(mesh)
+    u_max = 2*pi*R/(12*day)  # Maximum amplitude of the zonal wind (m/s)
+    uexpr = as_vector([-u_max*x[1]/R, u_max*x[0]/R, 0.0])
+    Omega = parameters.Omega
+    g = parameters.g
+    Dexpr = H - ((R * Omega * u_max + u_max*u_max/2.0)*(x[2]*x[2]/(R*R)))/g
+    # Coriolis expression
+    fexpr = 2*Omega*x[2]/R
+    V = FunctionSpace(mesh, "CG", 1)
+    f = state.fields("coriolis", V)
+    f.interpolate(fexpr)  # Coriolis frequency (1/s)
+
+    u0.project(uexpr)
+    D0.interpolate(Dexpr)
+    state.initialise([('u', u0),
+                      ('D', D0)])
+
+    ueqn = VectorInvariant(state, state.spaces("HDiv"))
+    Deqn = AdvectionEquation(state, state.spaces("DG"), equation_form="continuity")
+
+    # Set up forcing
+    sw_forcing = ShallowWaterForcing(state, euler_poincare=False)
+
+    advected_fields = []
+    advected_fields.append(("u", SSPRK3(state, u0, ueqn, forcing=sw_forcing)))
+    advected_fields.append(("D", SSPRK3(state, D0, Deqn)))
+
+    linear_solver = ShallowWaterSolver(state)
+
+    # build time stepper
+    stepper = ImplicitMidpoint(state, advected_fields, linear_solver)
+
+    stepper.run(t=0, tmax=tmax)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -26,7 +26,7 @@ for delta, dt in res_dt.items():
     mesh = ExtrudedMesh(m, layers=nlayers, layer_height=H/nlayers)
 
     fieldlist = ['u', 'rho', 'theta']
-    timestepping = TimesteppingParameters(dt=dt, maxk=4, maxi=1)
+    timestepping = TimesteppingParameters(dt=dt)
     output = OutputParameters(dirname=dirname, dumpfreq=5, dumplist=['u'], perturbation_fields=['theta', 'rho'])
     parameters = CompressibleParameters()
     diagnostics = Diagnostics(*fieldlist)

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -55,14 +55,14 @@ class Advection(object, metaclass=ABCMeta):
             else:
                 self.solver_parameters = solver_params
 
+        self.bcs = []
         if forcing is not None:
             self.xbar = forcing.x0
             self.forcing_term = forcing.forcing_term
             fs = equation.V
-            self.bcs = [DirichletBC(fs, 0.0, "bottom"),
-                        DirichletBC(fs, 0.0, "top")]
-        else:
-            self.bcs = []
+            if fs.extruded:
+                self.bcs = [DirichletBC(fs, 0.0, "bottom"),
+                            DirichletBC(fs, 0.0, "top")]
 
         # check to see if we are using an embedded DG method - is we are then
         # the projector and output function will have been set up in the

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -108,6 +108,10 @@ class Advection(object, metaclass=ABCMeta):
         if hasattr(self, "xbar"):
             self.xbar.assign(xn + alpha*(xnp1-xn))
 
+    def update_xbar(self, xn, xnp1, alpha):
+        self.xbar.assign(xn + alpha*(xnp1-xn))
+        self.ubar = self.xbar.split()[0]
+
     @cached_property
     def solver(self):
         # setup solver using lhs and rhs defined in derived class

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -29,8 +29,6 @@ class TimesteppingParameters(Configuration):
     """
     dt = None
     alpha = 0.5
-    maxk = 4
-    maxi = 1
 
 
 class OutputParameters(Configuration):

--- a/gusto/eady_diagnostics.py
+++ b/gusto/eady_diagnostics.py
@@ -103,7 +103,8 @@ class TrueResidualV(DiagnosticField):
     def setup(self, state):
         super(TrueResidualV, self).setup(state)
         unew, pnew, bnew = state.xn.split()
-        uold, pold, bold = state.xb.split()
+        self.xold = Function(state.W).assign(state.xn)
+        uold, pold, bold = self.xold.split()
         ubar = 0.5*(unew+uold)
         H = state.parameters.H
         f = state.parameters.f
@@ -126,6 +127,7 @@ class TrueResidualV(DiagnosticField):
     def compute(self, state):
         self.v_residual_solver.solve()
         v_residual = self.vtres
+        self.xold.assign(state.xn)
         return self.field.interpolate(v_residual)
 
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -219,13 +219,17 @@ class State(object):
         # Build the spaces
         self._build_spaces(mesh, vertical_degree, horizontal_degree, family)
 
-        # Allocate state
+        # Create function on mixed function space to hold field values
+        # at current time level
         self.xn = Function(self.W)
+
+        # If user hasn't specified which fields to dump, assume they
+        # would like all prognostic fields
         if self.output.dumplist is None:
             self.output.dumplist = fieldlist
-        self.fields = FieldCreator(fieldlist, self.xn, self.output.dumplist)
 
-        self.dumpfile = None
+        # set up fields
+        self.fields = FieldCreator(fieldlist, self.xn, self.output.dumplist)
 
         # figure out if we're on a sphere
         try:

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -220,7 +220,7 @@ class State(object):
         self._build_spaces(mesh, vertical_degree, horizontal_degree, family)
 
         # Allocate state
-        self._allocate_state()
+        self.xn = Function(self.W)
         if self.output.dumplist is None:
             self.output.dumplist = fieldlist
         self.fields = FieldCreator(fieldlist, self.xn, self.output.dumplist)
@@ -438,20 +438,6 @@ class State(object):
             V1 = self.spaces("DG", mesh, "DG", horizontal_degree)
 
             self.W = MixedFunctionSpace((V0, V1))
-
-    def _allocate_state(self):
-        """
-        Construct Functions to store the state variables.
-        """
-
-        W = self.W
-        self.xn = Function(W)
-        self.xstar = Function(W)
-        self.xp = Function(W)
-        self.xnp1 = Function(W)
-        self.xrhs = Function(W)
-        self.xb = Function(W)  # store the old state for diagnostics
-        self.dy = Function(W)
 
 
 def get_latlon_mesh(mesh):

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from pyop2.profiling import timed_stage
 from gusto.linear_solvers import IncompressibleSolver
-from firedrake import DirichletBC
+from firedrake import DirichletBC, Function
 
 
 __all__ = ["CrankNicolson", "ImplicitMidpoint", "AdvectionDiffusion"]
@@ -25,6 +25,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
                  physics_list=None):
 
         self.state = state
+        self.xnp1 = Function(state.W)
         if advected_fields is None:
             self.advected_fields = ()
         else:
@@ -47,7 +48,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         """
         Set the zero boundary conditions in the velocity.
         """
-        unp1 = self.state.xnp1.split()[0]
+        unp1 = self.xnp1.split()[0]
 
         if unp1.function_space().extruded:
             M = unp1.function_space()
@@ -94,19 +95,18 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             t += dt
             state.t.assign(t)
 
-            state.xnp1.assign(state.xn)
+            self.xnp1.assign(state.xn)
 
             self.semi_implicit_step()
 
             for name, advection in self.passive_advection:
                 field = getattr(state.fields, name)
                 # first computes ubar from state.xn and state.xnp1
-                advection.update_ubar(state.xn, state.xnp1, state.timestepping.alpha)
+                advection.update_ubar(state.xn, self.xnp1, state.timestepping.alpha)
                 # advects a field from xn and puts result in xnp1
                 advection.apply(field, field)
 
-            state.xb.assign(state.xn)
-            state.xn.assign(state.xnp1)
+            state.xn.assign(self.xnp1)
 
             with timed_stage("Diffusion"):
                 for name, diffusion in self.diffused_fields:
@@ -158,6 +158,9 @@ class SemiImplicitTimestepper(BaseTimestepper):
         # list of fields that are advected as part of the nonlinear iteration
         self.active_advection = [(name, scheme) for name, scheme in advected_fields if name in state.fieldlist]
 
+        self.xrhs = Function(state.W)
+        self.dy = Function(state.W)
+
     @property
     def passive_advection(self):
         """
@@ -192,27 +195,29 @@ class ImplicitMidpoint(SemiImplicitTimestepper):
         self.xn_fields = {name: func for (name, func) in
                           zip(self.state.fieldlist, self.state.xn.split())}
         self.xrhs_fields = {name: func for (name, func) in
-                            zip(self.state.fieldlist, self.state.xrhs.split())}
+                            zip(self.state.fieldlist, self.xrhs.split())}
         return t
 
     def semi_implicit_step(self):
         state = self.state
 
-        state.xrhs.assign(0.)  # xrhs is the residual which goes in the linear solve
+        self.xrhs.assign(0.)  # xrhs is the residual which goes in the linear solve
         for k in range(self.maxk):
 
-            for name, advection in self.active_advection:
-                # first computes ubar from state.xn and state.xnp1
-                advection.update_ubar(state.xn, state.xnp1, state.timestepping.alpha)
-                # advects a field from xn and puts result in xp
-                advection.apply(self.xn_fields[name], self.xrhs_fields[name])
+            with timed_stage("Advection"):
+                for name, advection in self.active_advection:
+                    # first computes ubar from state.xn and state.xnp1
+                    advection.update_ubar(state.xn, self.xnp1, state.timestepping.alpha)
+                    # advects a field from xn and puts result in xp
+                    advection.apply(self.xn_fields[name], self.xrhs_fields[name])
 
-            state.xrhs -= state.xnp1
+            self.xrhs -= self.xnp1
 
             with timed_stage("Implicit solve"):
-                self.linear_solver.solve()  # solves linear system and places result in state.dy
+                # solves linear system and places result in state.dy
+                self.linear_solver.solve(self.xrhs, self.dy)
 
-            state.xnp1 += state.dy
+            self.xnp1 += self.dy
 
 
 class CrankNicolson(SemiImplicitTimestepper):
@@ -238,10 +243,12 @@ class CrankNicolson(SemiImplicitTimestepper):
 
         t = super().setup_timeloop(t, tmax, pickup)
 
+        self.xstar = Function(self.state.W)
         self.xstar_fields = {name: func for (name, func) in
-                             zip(self.state.fieldlist, self.state.xstar.split())}
+                             zip(self.state.fieldlist, self.xstar.split())}
+        self.xp = Function(self.state.W)
         self.xp_fields = {name: func for (name, func) in
-                          zip(self.state.fieldlist, self.state.xp.split())}
+                          zip(self.state.fieldlist, self.xp.split())}
         return t
 
     def semi_implicit_step(self):
@@ -251,32 +258,33 @@ class CrankNicolson(SemiImplicitTimestepper):
 
         with timed_stage("Apply forcing terms"):
             self.forcing.apply((1-alpha)*dt, state.xn, state.xn,
-                               state.xstar, mu_alpha=self.mu_alpha[0])
+                               self.xstar, mu_alpha=self.mu_alpha[0])
 
         for k in range(self.maxk):
 
             with timed_stage("Advection"):
                 for name, advection in self.active_advection:
                     # first computes ubar from state.xn and state.xnp1
-                    advection.update_ubar(state.xn, state.xnp1, alpha)
+                    advection.update_ubar(state.xn, self.xnp1, alpha)
                     # advects a field from xstar and puts result in xp
                     advection.apply(self.xstar_fields[name], self.xp_fields[name])
 
-            state.xrhs.assign(0.)  # xrhs is the residual which goes in the linear solve
+            self.xrhs.assign(0.)  # xrhs is the residual which goes in the linear solve
 
             for i in range(self.maxi):
 
                 with timed_stage("Apply forcing terms"):
-                    self.forcing.apply(alpha*dt, state.xp, state.xnp1,
-                                       state.xrhs, mu_alpha=self.mu_alpha[1],
+                    self.forcing.apply(alpha*dt, self.xp, self.xnp1,
+                                       self.xrhs, mu_alpha=self.mu_alpha[1],
                                        incompressible=self.incompressible)
 
-                state.xrhs -= state.xnp1
+                self.xrhs -= self.xnp1
 
                 with timed_stage("Implicit solve"):
-                    self.linear_solver.solve()  # solves linear system and places result in state.dy
+                    # solves linear system and places result in state.dy
+                    self.linear_solver.solve(self.xrhs, self.dy)
 
-                state.xnp1 += state.dy
+                self.xnp1 += self.dy
 
             self._apply_bcs()
 

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -223,7 +223,6 @@ class ImplicitMidpoint(SemiImplicitTimestepper):
                         advection.update_xbar(state.xn, self.xnp1, state.timestepping.alpha)
                     else:
                         advection.update_ubar(state.xn, self.xnp1, state.timestepping.alpha)
-                        
                     # advects a field from xn and puts result in xrhs
                     advection.apply(self.xn_fields[name], self.xrhs_fields[name])
 

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -123,9 +123,9 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         print("TIMELOOP complete. t= " + str(t) + " tmax=" + str(tmax))
 
 
-class NonlinearTimestepper(BaseTimestepper):
+class SemiImplicitTimestepper(BaseTimestepper):
     """
-    This is a base class for nonlinear timestepping schemes.
+    This is a base class for semi-implicit timestepping schemes.
 
     :arg state: a :class:`.State` object
     :arg advected_fields: iterable of ``(field_name, scheme)`` pairs

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -168,7 +168,21 @@ class SemiImplicitTimestepper(BaseTimestepper):
                 self.advected_fields if name not in self.state.fieldlist]
 
 
-class ImplicitMidpoint(NonlinearTimestepper):
+class ImplicitMidpoint(SemiImplicitTimestepper):
+    """
+    This class implements an implicit midpoint timestepper.
+
+    :arg state: a :class:`.State` object
+    :arg advected_fields: iterable of ``(field_name, scheme)`` pairs
+        indicating the fields to advect, and the
+        :class:`~.Advection` to use.
+    :arg linear_solver: a :class:`.TimesteppingSolver` object
+    :arg forcing: a :class:`.Forcing` object
+    :arg diffused_fields: optional iterable of ``(field_name, scheme)``
+        pairs indictaing the fields to diffusion, and the
+        :class:`~.Diffusion` to use.
+    :arg physics_list: optional list of classes that implement `physics` schemes
+    """
 
     def setup_timeloop(self, t, tmax, pickup, **kwargs):
         self.maxk = kwargs.get("maxk", 4)
@@ -201,7 +215,7 @@ class ImplicitMidpoint(NonlinearTimestepper):
             state.xnp1 += state.dy
 
 
-class CrankNicolson(NonlinearTimestepper):
+class CrankNicolson(SemiImplicitTimestepper):
     """
     This class implements a Crank-Nicolson discretisation, with Strang
     splitting and auxilliary semi-Lagrangian advection.

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -217,8 +217,13 @@ class ImplicitMidpoint(SemiImplicitTimestepper):
 
             with timed_stage("Advection"):
                 for name, advection in self.active_advection:
-                    # first computes ubar from state.xn and xnp1
-                    advection.update_ubar(state.xn, self.xnp1, state.timestepping.alpha)
+                    # update xbar for evaluating forcing terms and
+                    # advecting velocity, or just update ubar
+                    if hasattr(advection, "forcing"):
+                        advection.update_xbar(state.xn, self.xnp1, state.timestepping.alpha)
+                    else:
+                        advection.update_ubar(state.xn, self.xnp1, state.timestepping.alpha)
+                        
                     # advects a field from xn and puts result in xrhs
                     advection.apply(self.xn_fields[name], self.xrhs_fields[name])
 

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -25,7 +25,7 @@ def setup_condens(dirname):
     x = SpatialCoordinate(mesh)
 
     fieldlist = ['u', 'rho', 'theta']
-    timestepping = TimesteppingParameters(dt=1.0, maxk=4, maxi=1)
+    timestepping = TimesteppingParameters(dt=1.0)
     output = OutputParameters(dirname=dirname+"/condens",
                               dumpfreq=1,
                               dumplist=['u'],

--- a/tests/test_theta_limiter.py
+++ b/tests/test_theta_limiter.py
@@ -23,7 +23,7 @@ def setup_theta_limiter(dirname):
     x, z = SpatialCoordinate(mesh)
 
     fieldlist = ['u', 'rho', 'theta']
-    timestepping = TimesteppingParameters(dt=1.0, maxk=4, maxi=1)
+    timestepping = TimesteppingParameters(dt=1.0)
     output = OutputParameters(dirname=dirname+"/theta_limiter",
                               dumpfreq=5,
                               dumplist=['u'],

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -18,7 +18,7 @@ def setup_tracer(dirname):
     mesh = ExtrudedMesh(m, layers=nlayers, layer_height=(H / nlayers))
 
     fieldlist = ['u', 'rho', 'theta']
-    timestepping = TimesteppingParameters(dt=10.0, maxk=4, maxi=1)
+    timestepping = TimesteppingParameters(dt=10.0)
     output = OutputParameters(dirname=dirname+"/tracer",
                               dumpfreq=1,
                               dumplist=['u'],


### PR DESCRIPTION
This PR implements an implicit midpoint timestepping scheme, with the forcing terms evaluated as part of the rhs of the advection scheme (i.e. there is no Strang splitting).

As there are now 2 semi implicit timestepping classes and some of the timestepping options and functions setup in state don't apply to both, I have moved things around a little:

1) I have removed the `maxi` and `maxk` options from `TimesteppingParameters` - these were used to set the maximum number of inner and outer iterations in the `CrankNicolson` timestepping class, but the `ImplicitMidpoint` class only requires one iteration loop. Instead, these parameters can be passed in to the `run` method of the timestepping class. They are given sensible default values (which no one seems to change anyway).

2) Since the two semi implicit time steppers have different numbers of intermediate function evaluations, I have removed the `_allocate_state` method from the `State` class. Instead the functions are set up in their respective timestepping classes. For example, all time steppers require an `xnp1` function to hold the values at the next time level, but only `CrankNicolson` requires an `xstar` function to hold the values after the first application of the forcing term.

There is also a bit of general tidying - e.g. removing the class name from the brackets after `super` in line with new Python 3 coding.