### PR TITLE
Avoid duplication with logger

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -14,6 +14,8 @@ logger = logging.getLogger("gusto")
 def set_log_handler(comm):
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter(fmt="%(name)s:%(levelname)s %(message)s"))
+    if logger.hasHandlers():
+        logger.handlers.clear()
     if comm.rank == 0:
         logger.addHandler(handler)
     else:


### PR DESCRIPTION
I noticed an odd quirk of the new logger: when running several simulations in one file with the `INFO` option to the logger (as you might when doing a convergence test), then the output gets duplicated as the logging handlers for the previous test still exist.

e.g. if you were to do something like:
`for res in resolution:`
`    new_output = OutputParameters(log_level='INFO')`
`    new_state = State(output=new_output)`
`    stepper = AdvectionDiffusion(state, advected_fields).run(t=0, t=1)`

the output would look like:
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`

`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`

`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`

`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO at start of timestep, t=0, dt=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`
`gusto:INFO TIMELOOP complete. t=1.0, tmax=1.0`

and so on!

So this very short pull request proposes clearing the logger of any handlers when a new `state` is set up. I'm not sure whether might cause problems in parallel though?
