### PR TITLE
Advection diffusion bug

### DIFF
--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -222,16 +222,16 @@ class AdvectionDiffusion(BaseTimestepper):
 
         super(AdvectionDiffusion, self).__init__(state, advected_fields, diffused_fields, physics_list)
 
-        # build a lists to contain the fields that should be advected from state.fieldlist
-        # i.e. these are the active fields to be advected
-        self.active_advection = [(name, scheme) for name, scheme in self.advected_fields if name in state.fieldlist]
-
-        # we need these fields to have two states: xn and xnp1.
+        # we need active fields to have two states: xn and xnp1.
         # for active fields, the advected state is in xnp1
         self.xn_fields = {name: func for (name, func) in
-                             zip(state.fieldlist, state.xn.split())}
+                          zip(state.fieldlist, state.xn.split())}
         self.xnp1_fields = {name: func for (name, func) in
-                          zip(state.fieldlist, state.xnp1.split())}
+                            zip(state.fieldlist, state.xnp1.split())}
+
+        # build a lists to contain the fields that should be advected from state.fieldlist
+        # i.e. these are the active fields to be advected
+        self.active_advection = [(name, scheme) for name, scheme in self.advected_fields if name in self.xn_fields]
 
     @property
     def passive_advection(self):

--- a/tests/test_advectiondiffusion.py
+++ b/tests/test_advectiondiffusion.py
@@ -1,0 +1,116 @@
+from os import path
+from gusto import *
+from firedrake import as_vector, Constant, PeriodicIntervalMesh, \
+    SpatialCoordinate, ExtrudedMesh, FunctionSpace, Function, \
+    conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement, interval, cos, sin
+from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
+from netCDF4 import Dataset
+from math import pi
+
+# This tests the AdvectionDiffusion timestepper, by checking that
+# profiles are actually advected by it.
+
+def setup_advection_diffusion(dirname):
+
+    # declare grid shape
+    L = 800.
+    H = 800.
+    ncolumns = int(L / 20.)
+    nlayers = int(H / 20.)
+
+    # make mesh
+    m = PeriodicIntervalMesh(ncolumns, L)
+    mesh = ExtrudedMesh(m, layers=nlayers, layer_height=(H / nlayers))
+    x, z = SpatialCoordinate(mesh)
+
+    fieldlist = ['u','rho']
+    timestepping = TimesteppingParameters(dt=1.0, maxk=4, maxi=1)
+    output = OutputParameters(dirname=dirname+"/advection_diffusion",
+                              dumpfreq=5,
+                              dumplist=['u', 'rho', 'tracer'],
+                              perturbation_fields=['rho', 'tracer'])
+    parameters = CompressibleParameters()
+
+    state = State(mesh, vertical_degree=1, horizontal_degree=1,
+                  family="CG",
+                  timestepping=timestepping,
+                  output=output,
+                  parameters=parameters,
+                  fieldlist=fieldlist)
+
+
+    # declare initial fields
+    u0 = state.fields("u")
+    rho0 = state.fields("rho")
+    tracer0 = state.fields("tracer", rho0.function_space())
+
+    Vu = u0.function_space()
+    Vr = rho0.function_space()
+    Vpsi = FunctionSpace(mesh, "CG", 2)
+
+    # Isentropic background state
+    xc = Constant(L / 2)
+    zc = Constant(H / 2)
+    rc = Constant(L / 5)
+    r = sqrt((x - xc) ** 2 + (z - zc) ** 2)
+    expr = conditional(r < rc, Constant(1.0) + 0.1 * (cos(pi * r / (2 * rc))) ** 2, Constant(1.0))
+    
+    rho0.interpolate(expr)
+    tracer0.interpolate(expr)
+    rho_b = Function(Vr).interpolate(Constant(1.0))
+    tracer_b = Function(Vr).interpolate(Constant(1.0))
+
+    # set up velocity field
+    u_max = Constant(5.0)
+    psi_expr = (-u_max * L / pi) * sin(2 * pi * x / L) * sin(pi * z / L)
+
+    psi0 = Function(Vpsi).interpolate(psi_expr)
+    gradperp = lambda u: as_vector([-u.dx(1), u.dx(0)])
+    u0.project(gradperp(psi0))
+
+    state.initialise([('u', u0), ('rho', rho0), ('tracer', tracer0)])
+    state.set_reference_profiles([('rho', rho0), ('tracer', tracer0)])
+
+    # set up advection schemes
+    rhoeqn = EmbeddedDGAdvection(state, Vr, equation_form="continuity")
+    tracereqn = EmbeddedDGAdvection(state, Vr, equation_form="advective")
+
+    # build advection dictionary
+    advected_fields = []
+    advected_fields.append(('u', NoAdvection(state, u0, None)))
+    advected_fields.append(('rho', SSPRK3(state, rho0, rhoeqn)))
+    advected_fields.append(('tracer', SSPRK3(state, tracer0, tracereqn)))
+
+    # build time stepper
+    stepper = AdvectionDiffusion(state, advected_fields)
+
+    return stepper, 40.0
+
+
+def run_advection_diffusion(dirname):
+
+    stepper, tmax = setup_advection_diffusion(dirname)
+    stepper.run(t=0, tmax=tmax)
+
+
+def test_advection_diffusion_setup(tmpdir):
+
+    dirname = str(tmpdir)
+    run_advection_diffusion(dirname)
+    filename = path.join(dirname, "advection_diffusion/diagnostics.nc")
+    data = Dataset(filename, "r")
+
+    tracer = data.groups["tracer_perturbation"]
+    l2_tracer = tracer.variables["l2"]
+
+    rho = data.groups["rho_perturbation"]
+    l2_rho = rho.variables["l2"]
+
+    tolerance = 1e-5
+
+    # check that the fields have indeed been advected
+    # tracer represents a passive tracer
+    assert l2_tracer[-1] >= tolerance
+    # rho represents an "active" field
+    assert l2_rho[-1] >= tolerance
+

--- a/tests/test_limiters_horizontal.py
+++ b/tests/test_limiters_horizontal.py
@@ -2,7 +2,7 @@ from os import path
 from gusto import *
 from firedrake import as_vector, Constant, PeriodicIntervalMesh, \
     SpatialCoordinate, ExtrudedMesh, FunctionSpace, Function, \
-    conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement
+    conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement, interval
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from netCDF4 import Dataset
 
@@ -42,9 +42,9 @@ def setup_hori_limiters(dirname):
     # v is continuous in vertical, h is horizontal
     cell = mesh._base_mesh.ufl_cell().cellname()
     DG0_element = FiniteElement("DG", cell, 0)
-    CG1_element = FiniteElement("CG", cell, 1)
+    CG1_element = FiniteElement("CG", interval, 1)
     DG1_element = FiniteElement("DG", cell, 1)
-    CG2_element = FiniteElement("CG", cell, 2)
+    CG2_element = FiniteElement("CG", interval, 2)
     V0_element = TensorProductElement(DG0_element, CG1_element)
     V1_element = TensorProductElement(DG1_element, CG2_element)
 

--- a/tests/test_limiters_vertical.py
+++ b/tests/test_limiters_vertical.py
@@ -2,7 +2,7 @@ from os import path
 from gusto import *
 from firedrake import as_vector, Constant, PeriodicIntervalMesh, \
     SpatialCoordinate, ExtrudedMesh, FunctionSpace, Function, \
-    conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement
+    conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement, interval
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from netCDF4 import Dataset
 
@@ -42,9 +42,9 @@ def setup_vert_limiters(dirname):
     # v is continuous in vertical, h is horizontal
     cell = mesh._base_mesh.ufl_cell().cellname()
     DG0_element = FiniteElement("DG", cell, 0)
-    CG1_element = FiniteElement("CG", cell, 1)
+    CG1_element = FiniteElement("CG", interval, 1)
     DG1_element = FiniteElement("DG", cell, 1)
-    CG2_element = FiniteElement("CG", cell, 2)
+    CG2_element = FiniteElement("CG", interval, 2)
     V0_element = TensorProductElement(DG0_element, CG1_element)
     V1_element = TensorProductElement(DG1_element, CG2_element)
 


### PR DESCRIPTION
This pull request is intended to address the problem I raised in issue 158
[](https://github.com/firedrakeproject/gusto/issues/158)

The problem is that the "active fields" `u`, `rho` and `theta` don't get advected by the `AdvectionDiffusion` timestepper.

I'm aware that the timesteppers might change fairly soon but I thought it would be better to get the bug fixed in the meanwhile. My solution isn't particularly elegant though so I'd be very happy to hear better ways to fix this.

I've also added a brief test to highlight the issue.