### PR TITLE
Time Varying Prescribed Fields

### DIFF
--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -19,6 +19,8 @@ def setup_condens(dirname):
     nlayers = int(H / 100.)
     ncolumns = int(L / 100.)
 
+    tmax = 10.0
+
     # make mesh
     m = PeriodicIntervalMesh(ncolumns, L)
     mesh = ExtrudedMesh(m, layers=nlayers, layer_height=(H / nlayers))
@@ -75,14 +77,18 @@ def setup_condens(dirname):
     w_expr = conditional(r > rc, 0., 0.25*(1. + cos((pi/rc)*r)))
 
     # set up velocity field
-    u_max = 10.0
+    u_max = 20.0
 
-    psi_expr = ((-u_max * L / pi) *
-                sin(2 * pi * x[0] / L) *
-                sin(pi * x[1] / L))
+    def u_evaluation(t):
+        psi_expr = ((-u_max * L / pi) *
+                    sin(2 * pi * x[0] / L) *
+                    sin(pi * x[1] / L)) * sin(2 * pi * t / tmax)
 
-    psi0 = Function(Vpsi).interpolate(psi_expr)
-    u0.project(gradperp(psi0))
+        psi0 = Function(Vpsi).interpolate(psi_expr)
+
+        return gradperp(psi0)
+
+    u0.project(u_evaluation(0))
     theta0.interpolate(theta_b)
     rho0.interpolate(rho_b)
     water_v0.interpolate(w_expr)
@@ -109,12 +115,13 @@ def setup_condens(dirname):
     advected_fields.append(("water_v", SSPRK3(state, water_v0, thetaeqn)))
     advected_fields.append(("water_c", SSPRK3(state, water_c0, thetaeqn)))
 
+    prescribed_fields = [('u', u_evaluation)]
     physics_list = [Condensation(state)]
 
     # build time stepper
-    stepper = AdvectionDiffusion(state, advected_fields, physics_list=physics_list)
+    stepper = AdvectionDiffusion(state, advected_fields, physics_list=physics_list, prescribed_fields=prescribed_fields)
 
-    return stepper, 5.0
+    return stepper, tmax
 
 
 def run_condens(dirname):


### PR DESCRIPTION
This pull request adds a new type of field to the time stepper. I've called these fields `prescribed_fields`, as they are set by the user and not solved for -- but crucially they are functions of time. These fields are very useful in tests for physical processes, or even advection tests in which the velocity might be a known function of time.

I've also updated one of the tests to use this to ensure that it's also tested.

@jshipton I know you're updating the timestepper so I'm happy for this to wait as well if you'd rather!