### PR TITLE
Use ILU for CompressibleHybridizedSolver default

### DIFF
--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -164,9 +164,27 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn, subcycles=2)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn, subcycles=2)))
 
 # Set up linear solver
-solver_parameters = {
-    'ksp_monitor': True}
-overwrite = True
+# if not gamg then use basic ilu
+gamg = False
+if gamg:
+    solver_parameters = {
+        'ksp_type': 'fgmres',
+        'ksp_monitor': True,
+        'ksp_rtol': 1.0e-6,
+        'ksp_max_it': 100,
+        'pc_type': 'gamg',
+        'pc_gamg_sym_graph': True,
+        'mg_levels': {'ksp_type': 'gmres',
+                      'ksp_max_its': 8,
+                      'pc_type': 'bjacobi',
+                      'sub_pc_type': 'ilu'}
+    }
+    overwrite = True
+else:
+    solver_parameters = {
+        'ksp_monitor': True
+    }
+    overwrite = False
 
 linear_solver = HybridizedCompressibleSolver(state,
                                              solver_parameters=solver_parameters,

--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -165,18 +165,12 @@ advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn, subcycles=2)))
 
 # Set up linear solver
 solver_parameters = {
-    'ksp_type': 'fgmres',
-    'ksp_rtol': 1.0e-6,
-    'ksp_max_it': 100,
-    'pc_type': 'gamg',
-    'mg_levels': {'ksp_type': 'gmres',
-                  'ksp_max_it': 8,
-                  'pc_type': 'bjacobi',
-                  'sub_pc_type': 'ilu'}
-}
+    'ksp_monitor': True}
+overwrite = True
+
 linear_solver = HybridizedCompressibleSolver(state,
                                              solver_parameters=solver_parameters,
-                                             overwrite_solver_parameters=True)
+                                             overwrite_solver_parameters=overwrite)
 
 # Set up forcing
 compressible_forcing = CompressibleForcing(state)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -287,12 +287,9 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
     # Solver parameters for the Lagrange multiplier system
     # NOTE: The reduced operator is not symmetric
     solver_parameters = {'ksp_type': 'gmres',
-                         'pc_type': 'gamg',
-                         'ksp_rtol': 1.0e-8,
-                         'mg_levels': {'ksp_type': 'richardson',
-                                       'ksp_max_it': 2,
-                                       'pc_type': 'bjacobi',
-                                       'sub_pc_type': 'ilu'}}
+                         'pc_type': 'bjacobi',
+                         'sub_pc_type': 'ilu',
+                         'ksp_rtol': 1.0e-8}
 
     def __init__(self, state, quadrature_degree=None, solver_parameters=None,
                  overwrite_solver_parameters=False, moisture=None):


### PR DESCRIPTION
Given the lack of understanding we have of AMG with hybridized compressible right now,
and given that ILU works quite well for thin domains, I'm suggesting this as the default for now.