### PR TITLE
Fix netCDF crash

### DIFF
--- a/gusto/state.py
+++ b/gusto/state.py
@@ -165,6 +165,7 @@ class DiagnosticsOutput(object):
                     diagnostic = getattr(self.diagnostics, dname)
                     diagnostic(field)
 
+
 class State(object):
     """
     Build a model state to keep the variables in, and specify parameters.


### PR DESCRIPTION
Fix for crash when writing diagnostics.nc with >=16 MPI processes. The fix ensures that only the rank 0 process in the mesh communicator access the file, whilst all processes in the communicator participate in calculating the diagnostics.