### PR TITLE
Fix dump data false

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -57,7 +57,7 @@ class OutputParameters(Configuration):
     #: log_level for logger, can be DEBUG, INFO or WARNING. Takes
     #: default value "warning"
     log_level = WARNING
-    dump_data = True
+    dump_vtus = True
     dumpfreq = 1
     dumplist = None
     dumplist_latlon = []

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -424,11 +424,11 @@ class State(object):
         output = self.output
 
         # Diagnostics:
-        if output.dump_diagnostics:
-            # Compute diagnostic fields
-            for field in self.diagnostic_fields:
-                field(self)
+        # Compute diagnostic fields
+        for field in self.diagnostic_fields:
+            field(self)
 
+        if output.dump_diagnostics:
             # Output diagnostic data
             self.diagnostic_output.dump(self, t)
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -1,4 +1,4 @@
-from os import path
+from os import path, mkdir
 import itertools
 from netCDF4 import Dataset
 import time
@@ -320,7 +320,8 @@ class State(object):
         """
 
         if any([self.output.dump_data, self.output.dumplist_latlon,
-                self.output.dump_diagnostics, self.output.point_data]):
+                self.output.dump_diagnostics, self.output.point_data,
+                self.output.checkpoint and not pickup]):
             # setup output directory and check that it does not already exist
             self.dumpdir = path.join("results", self.output.dirname)
             if self.mesh.comm.rank == 0 \
@@ -328,6 +329,8 @@ class State(object):
                and path.exists(self.dumpdir) and not pickup:
                 raise IOError("results directory '%s' already exists"
                               % self.dumpdir)
+            else:
+                mkdir(self.dumpdir)
 
         if self.output.dump_data:
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -319,7 +319,8 @@ class State(object):
         otherwise dump and checkpoint to disk. (default is False).
         """
 
-        if self.output.dump_data:
+        if any([self.output.dump_data, self.output.dumplist_latlon,
+                self.output.dump_diagnostics, self.output.point_data]):
             # setup output directory and check that it does not already exist
             self.dumpdir = path.join("results", self.output.dirname)
             if self.mesh.comm.rank == 0 \
@@ -327,6 +328,8 @@ class State(object):
                and path.exists(self.dumpdir) and not pickup:
                 raise IOError("results directory '%s' already exists"
                               % self.dumpdir)
+
+        if self.output.dump_data:
 
             # setup pvd output file
             outfile = path.join(self.dumpdir, "field_output.pvd")

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -319,7 +319,7 @@ class State(object):
         otherwise dump and checkpoint to disk. (default is False).
         """
 
-        if any([self.output.dump_data, self.output.dumplist_latlon,
+        if any([self.output.dump_vtus, self.output.dumplist_latlon,
                 self.output.dump_diagnostics, self.output.point_data,
                 self.output.checkpoint and not pickup]):
             # setup output directory and check that it does not already exist
@@ -332,7 +332,7 @@ class State(object):
             else:
                 mkdir(self.dumpdir)
 
-        if self.output.dump_data:
+        if self.output.dump_vtus:
 
             # setup pvd output file
             outfile = path.join(self.dumpdir, "field_output.pvd")
@@ -442,7 +442,7 @@ class State(object):
                 self.chkpt.store(field)
             self.chkpt.write_attribute("/", "time", t)
 
-        if output.dump_data and (next(self.dumpcount) % output.dumpfreq) == 0:
+        if output.dump_vtus and (next(self.dumpcount) % output.dumpfreq) == 0:
             # dump fields
             self.dumpfile.write(*self.to_dump)
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -330,7 +330,8 @@ class State(object):
                 raise IOError("results directory '%s' already exists"
                               % self.dumpdir)
             else:
-                mkdir(self.dumpdir)
+                if "pytest" not in self.output.dirname:
+                    mkdir(self.dumpdir)
 
         if self.output.dump_vtus:
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -1,6 +1,7 @@
 from os import path, mkdir
 import itertools
 from netCDF4 import Dataset
+import sys
 import time
 from gusto.diagnostics import Diagnostics, Perturbation, SteadyStateError
 from firedrake import (FiniteElement, TensorProductElement, HDiv,
@@ -324,13 +325,14 @@ class State(object):
                 self.output.checkpoint and not pickup]):
             # setup output directory and check that it does not already exist
             self.dumpdir = path.join("results", self.output.dirname)
+            running_tests = '--running-tests' in sys.argv or "pytest" in self.output.dirname
             if self.mesh.comm.rank == 0 \
-               and "pytest" not in self.output.dirname \
+               and not running_tests \
                and path.exists(self.dumpdir) and not pickup:
                 raise IOError("results directory '%s' already exists"
                               % self.dumpdir)
             else:
-                if "pytest" not in self.output.dirname:
+                if not running_tests:
                     mkdir(self.dumpdir)
 
         if self.output.dump_vtus:


### PR DESCRIPTION
Setting the `dump_data` option to `False` caused issues with other types of output because the dump directory was not created. This PR fixes that by creating the directory when any output is expected (netCDF, checkpointing, diagnostics etc). Also, the name `dump_data` has been changed to `dump_vtus` which is more descriptive of what it controls.