### PR TITLE
Use Firedrake's static condensation preconditioner in the hybridized solver

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -194,19 +194,8 @@ advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 ##############################################################################
 # Set up linear solver for the timestepping scheme
 ##############################################################################
-# Set up linear solver
 if hybridization:
-    linear_solver_params = {'ksp_type': 'gmres',
-                            'ksp_rtol': 1.0e-8,
-                            'pc_type': 'gamg',
-                            'pc_gamg_sym_graph': True,
-                            'mg_levels': {'ksp_type': 'richardson',
-                                          'ksp_max_it': 5,
-                                          'pc_type': 'bjacobi',
-                                          'sub_pc_type': 'ilu'}}
-    linear_solver = HybridizedCompressibleSolver(state, solver_parameters=linear_solver_params,
-                                                 overwrite_solver_parameters=True)
-
+    linear_solver = HybridizedCompressibleSolver(state)
 else:
     linear_solver_params = {'pc_type': 'fieldsplit',
                             'pc_fieldsplit_type': 'schur',

--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -142,50 +142,7 @@ advected_fields.append(("rho", SSPRK3(state, rho0, rhoeqn, subcycles=2)))
 advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn, subcycles=2)))
 
 # Set up linear solver
-# if not gamg then use basic ilu
-gamg = False
-if gamg:
-    inner_solver_parameters = {
-        'ksp_type': 'fgmres',
-        'ksp_monitor': True,
-        'ksp_rtol': 1.0e-6,
-        'ksp_atol': 1.0e-8,
-        'ksp_max_it': 100,
-        'pc_type': 'gamg',
-        'pc_gamg_sym_graph': True,
-        'mg_levels': {'ksp_type': 'gmres',
-                      'ksp_max_its': 8,
-                      'pc_type': 'bjacobi',
-                      'sub_pc_type': 'ilu'}
-    }
-    solver_parameters = {'mat_type': 'matfree',
-                         'pmat_type': 'matfree',
-                         'ksp_type': 'preonly',
-                         'pc_type': 'python',
-                         'pc_python_type': 'firedrake.SCPC',
-                         'pc_sc_eliminate_fields': '0, 1',
-                         'condensed_field': inner_solver_parameters}
-    overwrite = True
-else:
-    solver_parameters = {
-        'ksp_monitor': True,
-        'mat_type': 'matfree',
-        'pmat_type': 'matfree',
-        'ksp_type': 'preonly',
-        'pc_type': 'python',
-        'pc_python_type': 'firedrake.SCPC',
-        'pc_sc_eliminate_fields': '0, 1',
-        'condensed_field': {'ksp_type': 'gmres',
-                            'pc_type': 'bjacobi',
-                            'sub_pc_type': 'ilu',
-                            'ksp_rtol': 1.0e-6,
-                            'ksp_atol': 1.0e-8}
-    }
-    overwrite = False
-
-linear_solver = HybridizedCompressibleSolver(state,
-                                             solver_parameters=solver_parameters,
-                                             overwrite_solver_parameters=overwrite)
+linear_solver = HybridizedCompressibleSolver(state)
 
 # Set up forcing
 compressible_forcing = CompressibleForcing(state)

--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -145,10 +145,11 @@ advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn, subcycles=2)))
 # if not gamg then use basic ilu
 gamg = False
 if gamg:
-    solver_parameters = {
+    inner_solver_parameters = {
         'ksp_type': 'fgmres',
         'ksp_monitor': True,
         'ksp_rtol': 1.0e-6,
+        'ksp_atol': 1.0e-8,
         'ksp_max_it': 100,
         'pc_type': 'gamg',
         'pc_gamg_sym_graph': True,
@@ -157,10 +158,28 @@ if gamg:
                       'pc_type': 'bjacobi',
                       'sub_pc_type': 'ilu'}
     }
+    solver_parameters = {'mat_type': 'matfree',
+                         'pmat_type': 'matfree',
+                         'ksp_type': 'preonly',
+                         'pc_type': 'python',
+                         'pc_python_type': 'firedrake.SCPC',
+                         'pc_sc_eliminate_fields': '0, 1',
+                         'condensed_field': inner_solver_parameters}
     overwrite = True
 else:
     solver_parameters = {
-        'ksp_monitor': True
+        'ksp_monitor': True,
+        'mat_type': 'matfree',
+        'pmat_type': 'matfree',
+        'ksp_type': 'preonly',
+        'pc_type': 'python',
+        'pc_python_type': 'firedrake.SCPC',
+        'pc_sc_eliminate_fields': '0, 1',
+        'condensed_field': {'ksp_type': 'gmres',
+                            'pc_type': 'bjacobi',
+                            'sub_pc_type': 'ilu',
+                            'ksp_rtol': 1.0e-6,
+                            'ksp_atol': 1.0e-8}
     }
     overwrite = False
 

--- a/examples/h_mountain.py
+++ b/examples/h_mountain.py
@@ -157,16 +157,7 @@ advected_fields.append(("theta", SSPRK3(state, theta0, thetaeqn)))
 
 # Set up linear solver
 if hybridization:
-    params = {'ksp_type': 'gmres',
-              'ksp_rtol': 1.0e-8,
-              'pc_type': 'gamg',
-              'pc_gamg_sym_graph': True,
-              'mg_levels': {'ksp_type': 'richardson',
-                            'ksp_max_it': 5,
-                            'pc_type': 'bjacobi',
-                            'sub_pc_type': 'ilu'}}
-    linear_solver = HybridizedCompressibleSolver(state, solver_parameters=params,
-                                                 overwrite_solver_parameters=True)
+    linear_solver = HybridizedCompressibleSolver(state)
 else:
     # LU parameters
     params = {'pc_type': 'lu',

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -64,7 +64,7 @@ def incompressible_hydrostatic_balance(state, b0, p0, top=False, params=None):
     v, pprime = TrialFunctions(WV)
     w, phi = TestFunctions(WV)
 
-    bcs = [DirichletBC(WV[0], 0.0, bstring)]
+    bcs = [DirichletBC(WV[0], Constant(0.0), bstring)]
 
     a = (
         inner(w, v) + div(w)*pprime + div(v)*phi
@@ -122,7 +122,7 @@ def compressible_hydrostatic_balance(state, theta0, rho0, pi0=None,
 
     n = FacetNormal(state.mesh)
 
-    cp = state.parameters.cp
+    cp = Constant(state.parameters.cp)
 
     # add effect of density of water upon theta
     theta = theta0
@@ -143,10 +143,13 @@ def compressible_hydrostatic_balance(state, theta0, rho0, pi0=None,
         bstring = "top"
 
     arhs = -cp*inner(dv, n)*theta*pi_boundary*bmeasure
-    g = state.parameters.g
+
+    # Possibly make g vary with spatial coordinates?
+    g = Constant(state.parameters.g)
+
     arhs -= g*inner(dv, state.k)*dx
 
-    bcs = [DirichletBC(W.sub(0), 0.0, bstring)]
+    bcs = [DirichletBC(W.sub(0), Constant(0.0), bstring)]
 
     w = Function(W)
     PiProblem = LinearVariationalProblem(alhs, arhs, w, bcs=bcs)

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -123,7 +123,7 @@ def compressible_hydrostatic_balance(state, theta0, rho0, pi0=None,
 
     n = FacetNormal(state.mesh)
 
-    cp = Constant(state.parameters.cp)
+    cp = state.parameters.cp
 
     # add effect of density of water upon theta
     theta = theta0
@@ -146,7 +146,7 @@ def compressible_hydrostatic_balance(state, theta0, rho0, pi0=None,
     arhs = -cp*inner(dv, n)*theta*pi_boundary*bmeasure
 
     # Possibly make g vary with spatial coordinates?
-    g = Constant(state.parameters.g)
+    g = state.parameters.g
 
     arhs -= g*inner(dv, state.k)*dx
 
@@ -160,13 +160,13 @@ def compressible_hydrostatic_balance(state, theta0, rho0, pi0=None,
                   'pc_type': 'python',
                   'mat_type': 'matfree',
                   'pc_python_type': 'gusto.VerticalHybridizationPC',
-                  'vert_hybridization': {'ksp_type': 'bcgs',
+                  'vert_hybridization': {'ksp_type': 'gmres',
                                          'pc_type': 'gamg',
                                          'pc_gamg_sym_graph': True,
                                          'ksp_rtol': 1e-8,
                                          'ksp_atol': 1e-8,
                                          'mg_levels': {'ksp_type': 'richardson',
-                                                       'ksp_max_it': 3,
+                                                       'ksp_max_it': 5,
                                                        'pc_type': 'bjacobi',
                                                        'sub_pc_type': 'ilu'}}}
 

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -298,7 +298,6 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
                          'pc_python_type': 'firedrake.SCPC',
                          'pc_sc_eliminate_fields': '0, 1',
                          'condensed_field': {'ksp_type': 'fgmres',
-                                             'ksp_monitor_true_residual': True,
                                              'ksp_rtol': 1.0e-8,
                                              'ksp_atol': 1.0e-8,
                                              'ksp_max_it': 100,
@@ -323,6 +322,10 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
             if any(deg > 2 for deg in dgspace.ufl_element().degree()):
                 state.logger.warning("default quadrature degree most likely not sufficient for this degree element")
             self.quadrature_degree = (5, 5)
+
+        # Turn monitor on for the trace system when running in debug mode
+        if state.output.log_level == DEBUG:
+            self.solver_parameters["condensed_field"]["ksp_monitor_true_residual"] = True
 
         super().__init__(state, solver_parameters, overwrite_solver_parameters)
 

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -324,7 +324,7 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
             self.quadrature_degree = (5, 5)
 
         # Turn monitor on for the trace system when running in debug mode
-        if state.output.log_level == DEBUG:
+        if logger.isEnabledFor(DEBUG):
             self.solver_parameters["condensed_field"]["ksp_monitor_true_residual"] = True
 
         super().__init__(state, solver_parameters, overwrite_solver_parameters)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -297,12 +297,17 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
                          'pc_type': 'python',
                          'pc_python_type': 'firedrake.SCPC',
                          'pc_sc_eliminate_fields': '0, 1',
-                         'condensed_field': {'ksp_type': 'gmres',
+                         'condensed_field': {'ksp_type': 'fgmres',
                                              'ksp_monitor_true_residual': True,
-                                             'pc_type': 'bjacobi',
-                                             'sub_pc_type': 'ilu',
                                              'ksp_rtol': 1.0e-8,
-                                             'ksp_atol': 1.0e-8}}
+                                             'ksp_atol': 1.0e-8,
+                                             'ksp_max_it': 100,
+                                             'pc_type': 'gamg',
+                                             'pc_gamg_sym_graph': True,
+                                             'mg_levels': {'ksp_type': 'gmres',
+                                                           'ksp_max_its': 5,
+                                                           'pc_type': 'bjacobi',
+                                                           'sub_pc_type': 'ilu'}}}
 
     def __init__(self, state, quadrature_degree=None, solver_parameters=None,
                  overwrite_solver_parameters=False, moisture=None):
@@ -460,7 +465,6 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
         hybridized_solver = LinearVariationalSolver(hybridized_prb,
                                                     solver_parameters=self.solver_parameters,
                                                     options_prefix='ImplicitSolver')
-        # import ipdb; ipdb.set_trace()
         self.hybridized_solver = hybridized_solver
 
         # Project broken u into the HDiv space using facet averaging.

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -451,7 +451,7 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
                # constraint equation to enforce continuity of the velocity
                # (coefficients added to make the trace coupling symmetric
                # with the terms picked up in the momentum equation)
-               + beta_cp*dl('+')*jump(u, n=n)*(dS_vp + dS_hp)
+               + beta_cp*dl('+')*jump(thetabar_w*u, n=n)*(dS_vp + dS_hp)
                + beta_cp*dl*dot(thetabar_w*u, n)*ds_vp
                + beta_cp*dl*dot(thetabar_w*u, n)*ds_tbp)
 

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -3,7 +3,7 @@ from firedrake import (split, LinearVariationalProblem, Constant,
                        TestFunction, TrialFunction, lhs, rhs, DirichletBC, FacetNormal,
                        div, dx, jump, avg, dS_v, dS_h, ds_v, ds_t, ds_b, inner, dot, grad,
                        Function, VectorSpaceBasis, BrokenElement, FunctionSpace, MixedFunctionSpace,
-                       assemble, LinearSolver, Tensor, AssembledVector)
+                       assemble, LinearSolver)
 from firedrake.petsc import flatten_parameters
 from firedrake.parloops import par_loop, READ, INC
 from pyop2.profiling import timed_function, timed_region

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -510,8 +510,8 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
 
         # Store boundary conditions for the div-conforming velocity to apply
         # post-solve
-        self.bcs = [DirichletBC(Vu, 0.0, "bottom"),
-                    DirichletBC(Vu, 0.0, "top")]
+        self.bcs = [DirichletBC(Vu, Constant(0.0), "bottom"),
+                    DirichletBC(Vu, Constant(0.0), "top")]
 
     @timed_function("Gusto:LinearSolve")
     def solve(self):

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -326,14 +326,13 @@ class State(object):
             # setup output directory and check that it does not already exist
             self.dumpdir = path.join("results", self.output.dirname)
             running_tests = '--running-tests' in sys.argv or "pytest" in self.output.dirname
-            if self.mesh.comm.rank == 0 \
-               and not running_tests \
-               and path.exists(self.dumpdir) and not pickup:
-                raise IOError("results directory '%s' already exists"
-                              % self.dumpdir)
-            else:
-                if not running_tests:
-                    makedirs(self.dumpdir)
+            if self.mesh.comm.rank == 0:
+                if not running_tests and path.exists(self.dumpdir) and not pickup:
+                    raise IOError("results directory '%s' already exists"
+                                  % self.dumpdir)
+                else:
+                    if not running_tests:
+                        makedirs(self.dumpdir)
 
         if self.output.dump_vtus:
 


### PR DESCRIPTION
This PR updates the linear solvers in Gusto. This includes a small QOL change that makes all time-stepping coefficients `ufl.Constant`s. This avoids repeated code-generation when all you want to do is change the time-step parameter.

More importantly, the hybridized compressible solver has a been refactored and organized. Rather than hand-coding the Slate expressions in the solver, we can do the static condensation directly via Firedrake's tested preconditioner `firedrake.SCPC`. This avoids a lot of potential mistakes that could be made when writing out the condensation operators by hand.

In fact, it turns out using `SCPC` has resolved some issues previously encountered by @tommbendall. Most notably, it appears that #169 has been fixed when using this branch.

Also, the code is much simpler to read I think.