### PR TITLE
Stop grandmas falling from the sky

### DIFF
--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -294,17 +294,17 @@ class Coalescence(Physics):
         coalesce_rate = Function(Vt)
 
         # adjust coalesce rate using min_value so negative cloud concentration doesn't occur
-        self.lim_coalesce_rate = Interpolator(conditional(self.rain < 0.0, # if rain is negative do only accretion
+        self.lim_coalesce_rate = Interpolator(conditional(self.rain < 0.0,  # if rain is negative do only accretion
                                                           conditional(accr_rate < 0.0,
                                                                       0.0,
                                                                       min_value(accr_rate, self.water_c / dt)),
-                                                                      # don't turn rain back into cloud
-                                                                      conditional(accr_rate + accu_rate < 0.0,
-                                                                                  0.0,
-                                                                                  # if accretion rate is negative do only accumulation
-                                                                                  conditional(accr_rate < 0.0,
-                                                                                              min_value(accu_rate, self.water_c / dt),
-                                                                                              min_value(accr_rate + accu_rate, self.water_c / dt)))),
+                                                          # don't turn rain back into cloud
+                                                          conditional(accr_rate + accu_rate < 0.0,
+                                                                      0.0,
+                                                                      # if accretion rate is negative do only accumulation
+                                                                      conditional(accr_rate < 0.0,
+                                                                                  min_value(accu_rate, self.water_c / dt),
+                                                                                  min_value(accr_rate + accu_rate, self.water_c / dt)))),
                                               coalesce_rate)
 
         # tell the prognostic fields what to update to

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -290,14 +290,21 @@ class Coalescence(Physics):
         if accumulation:
             accu_rate = k_2 * self.water_c * self.rain ** b
 
-        # make appropriate coalescence rate by combining two processes
-        dot_r = accr_rate + accu_rate
-
         # make coalescence rate function, that needs to be the same for all updates in one time step
         coalesce_rate = Function(Vt)
 
-        # adjust coalesce rate so negative concentration doesn't occur
-        self.lim_coalesce_rate = Interpolator(min_value(dot_r, self.water_c / dt),
+        # adjust coalesce rate using min_value so negative cloud concentration doesn't occur
+        self.lim_coalesce_rate = Interpolator(conditional(self.rain < 0.0, # if rain is negative do only accretion
+                                                          conditional(accr_rate < 0.0,
+                                                                      0.0,
+                                                                      min_value(accr_rate, self.water_c / dt)),
+                                                                      # don't turn rain back into cloud
+                                                                      conditional(accr_rate + accu_rate < 0.0,
+                                                                                  0.0,
+                                                                                  # if accretion rate is negative do only accumulation
+                                                                                  conditional(accr_rate < 0.0,
+                                                                                              min_value(accu_rate, self.water_c / dt),
+                                                                                              min_value(accr_rate + accu_rate, self.water_c / dt)))),
                                               coalesce_rate)
 
         # tell the prognostic fields what to update to
@@ -386,8 +393,10 @@ class Evaporation(Physics):
 
         # adjust evap rate so negative rain doesn't occur
         self.lim_evap_rate = Interpolator(conditional(dot_r_evap < 0,
-                                                      Constant(0.0),
-                                                      min_value(dot_r_evap, self.rain / dt)),
+                                                      0.0,
+                                                      conditional(self.rain < 0.0,
+                                                                  0.0,
+                                                                  min_value(dot_r_evap, self.rain / dt))),
                                           evap_rate)
 
         # tell the prognostic fields what to update to


### PR DESCRIPTION
If negative some negative moisture concentrations formed (possibly through advection) this could cause nans in the `Coalescence` and `Evaporation` schemes (it turns out you shouldn't raise negative numbers to non-integer powers!)

This very short pull request fixes this, adding some `conditionals` to the limiting step.

PS: sorry for the terrible name...