### PR TITLE
Non periodic domains

### DIFF
--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -69,7 +69,7 @@ state = State(mesh, vertical_degree=degree, horizontal_degree=degree,
               diagnostics=diagnostics,
               fieldlist=fieldlist,
               diagnostic_fields=diagnostic_fields,
-              u_bc_ids=[1,2])
+              u_bc_ids=[1, 2])
 
 # Initial conditions
 u0 = state.fields("u")

--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -1,5 +1,5 @@
 from gusto import *
-from firedrake import (PeriodicIntervalMesh, ExtrudedMesh,
+from firedrake import (IntervalMesh, ExtrudedMesh,
                        SpatialCoordinate, conditional, cos, pi, sqrt,
                        TestFunction, dx, TrialFunction, Constant, Function,
                        LinearVariationalProblem, LinearVariationalSolver, DirichletBC,
@@ -33,7 +33,7 @@ L = 10000.
 H = 10000.
 nlayers = int(H/deltax)
 ncolumns = int(L/deltax)
-m = PeriodicIntervalMesh(ncolumns, L)
+m = IntervalMesh(ncolumns, L)
 mesh = ExtrudedMesh(m, layers=nlayers, layer_height=H/nlayers)
 
 # options
@@ -80,6 +80,11 @@ Vu = u0.function_space()
 Vt = theta0.function_space()
 Vr = rho0.function_space()
 x, z = SpatialCoordinate(mesh)
+
+# set bcs
+state.bcs.append(DirichletBC(Vu, 0.0, 1))
+state.bcs.append(DirichletBC(Vu, 0.0, 2))
+
 
 # Define constant theta_e and water_t
 Tsurf = 300.0

--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -68,7 +68,8 @@ state = State(mesh, vertical_degree=degree, horizontal_degree=degree,
               parameters=params,
               diagnostics=diagnostics,
               fieldlist=fieldlist,
-              diagnostic_fields=diagnostic_fields)
+              diagnostic_fields=diagnostic_fields,
+              u_bc_ids=[1,2])
 
 # Initial conditions
 u0 = state.fields("u")
@@ -80,11 +81,6 @@ Vu = u0.function_space()
 Vt = theta0.function_space()
 Vr = rho0.function_space()
 x, z = SpatialCoordinate(mesh)
-
-# set bcs
-state.bcs.append(DirichletBC(Vu, 0.0, 1))
-state.bcs.append(DirichletBC(Vu, 0.0, 2))
-
 
 # Define constant theta_e and water_t
 Tsurf = 300.0

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from firedrake import (Function, split, TrialFunction, TestFunction,
                        FacetNormal, inner, dx, cross, div, jump, avg, dS_v,
-                       DirichletBC, LinearVariationalProblem, LinearVariationalSolver,
+                       LinearVariationalProblem, LinearVariationalSolver,
                        dot, dS, Constant, as_vector, SpatialCoordinate)
 from gusto.configuration import logger, DEBUG
 from gusto import thermodynamics
@@ -105,11 +105,7 @@ class Forcing(object, metaclass=ABCMeta):
     def _build_forcing_solvers(self):
         a = self.mass_term()
         L = self.forcing_term()
-        if self.Vu.extruded:
-            bcs = [DirichletBC(self.Vu, 0.0, "bottom"),
-                   DirichletBC(self.Vu, 0.0, "top")]
-        else:
-            bcs = None
+        bcs = None if len(self.state.bcs) == 0 else self.state.bcs
 
         u_forcing_problem = LinearVariationalProblem(
             a, L, self.uF, bcs=bcs

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -452,17 +452,17 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
             - beta_cp*div(thetabar_w*w)*pi*dxp
             # trace terms appearing after integrating momentum equation
             + beta_cp*jump(thetabar_w*w, n=n)*l0('+')*(dS_vp + dS_hp)
-            + beta_cp*dot(thetabar_w*w, n)*l0*(ds_tbp+ds_vp)
+            + beta_cp*dot(thetabar_w*w, n)*l0*(ds_tbp + ds_vp)
             # mass continuity equation
             + (phi*(rho - rho_in) - beta*inner(grad(phi), u)*rhobar)*dx
             + beta*jump(phi*u, n=n)*rhobar_avg('+')*(dS_v + dS_h)
             # term added because u.n=0 is enforced weakly via the traces
-            + beta*phi*dot(u, n)*rhobar_avg*(ds_tb+ds_v)
+            + beta*phi*dot(u, n)*rhobar_avg*(ds_tb + ds_v)
             # constraint equation to enforce continuity of the velocity
             # through the interior facets and weakly impose the no-slip
             # condition
             + dl('+')*jump(u, n=n)*(dS_vp + dS_hp)
-            + dl*dot(u, n)*(ds_tbp+ds_vp)
+            + dl*dot(u, n)*(ds_tbp + ds_vp)
         )
 
         # contribution of the sponge term

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -1,6 +1,6 @@
 from firedrake import (split, LinearVariationalProblem, Constant,
                        LinearVariationalSolver, TestFunctions, TrialFunctions,
-                       TestFunction, TrialFunction, lhs, rhs, DirichletBC, FacetNormal,
+                       TestFunction, TrialFunction, lhs, rhs, FacetNormal,
                        div, dx, jump, avg, dS_v, dS_h, ds_v, ds_t, ds_b, ds_tb, inner,
                        dot, grad, Function, VectorSpaceBasis, BrokenElement,
                        FunctionSpace, MixedFunctionSpace)
@@ -199,8 +199,7 @@ class CompressibleSolver(TimesteppingSolver):
         self.urho = Function(M)
 
         # Boundary conditions (assumes extruded mesh)
-        bcs = [DirichletBC(M.sub(0), 0.0, "bottom"),
-               DirichletBC(M.sub(0), 0.0, "top")]
+        bcs = None if len(self.state.bcs) == 0 else self.state.bcs
 
         # Solver for u, rho
         urho_problem = LinearVariationalProblem(
@@ -520,8 +519,7 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
 
         # Store boundary conditions for the div-conforming velocity to apply
         # post-solve
-        self.bcs = [DirichletBC(Vu, Constant(0.0), "bottom"),
-                    DirichletBC(Vu, Constant(0.0), "top")]
+        self.bcs = self.state.bcs
 
     @timed_function("Gusto:LinearSolve")
     def solve(self):
@@ -645,8 +643,7 @@ class IncompressibleSolver(TimesteppingSolver):
         self.up = Function(M)
 
         # Boundary conditions (assumes extruded mesh)
-        bcs = [DirichletBC(M.sub(0), 0.0, "bottom"),
-               DirichletBC(M.sub(0), 0.0, "top")]
+        bcs = None if len(self.state.bcs) == 0 else self.state.bcs
 
         # Solver for u, p
         up_problem = LinearVariationalProblem(aeqn, Leqn, self.up, bcs=bcs)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -453,17 +453,17 @@ class HybridizedCompressibleSolver(TimesteppingSolver):
             - beta_cp*div(thetabar_w*w)*pi*dxp
             # trace terms appearing after integrating momentum equation
             + beta_cp*jump(thetabar_w*w, n=n)*l0('+')*(dS_vp + dS_hp)
-            + beta_cp*dot(thetabar_w*w, n)*l0*ds_tbp
+            + beta_cp*dot(thetabar_w*w, n)*l0*(ds_tbp+ds_vp)
             # mass continuity equation
             + (phi*(rho - rho_in) - beta*inner(grad(phi), u)*rhobar)*dx
             + beta*jump(phi*u, n=n)*rhobar_avg('+')*(dS_v + dS_h)
             # term added because u.n=0 is enforced weakly via the traces
-            + beta*phi*dot(u, n)*rhobar_avg*ds_tb
+            + beta*phi*dot(u, n)*rhobar_avg*(ds_tb+ds_v)
             # constraint equation to enforce continuity of the velocity
             # through the interior facets and weakly impose the no-slip
             # condition
             + dl('+')*jump(u, n=n)*(dS_vp + dS_hp)
-            + dl*dot(u, n)*ds_tbp
+            + dl*dot(u, n)*(ds_tbp+ds_vp)
         )
 
         # contribution of the sponge term

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -260,7 +260,7 @@ class State(object):
             self.bcs.append(DirichletBC(V, 0.0, "bottom"))
             self.bcs.append(DirichletBC(V, 0.0, "top"))
         for id in self.u_bc_ids:
-            self.bcs.append(DichletBC(V, 0.0, id))
+            self.bcs.append(DirichletBC(V, 0.0, id))
 
         self.dumpfile = None
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -4,7 +4,7 @@ from netCDF4 import Dataset
 import sys
 import time
 from gusto.diagnostics import Diagnostics, Perturbation, SteadyStateError
-from firedrake import (FiniteElement, TensorProductElement, HDiv,
+from firedrake import (FiniteElement, TensorProductElement, HDiv, DirichletBC,
                        FunctionSpace, MixedFunctionSpace, VectorFunctionSpace,
                        interval, Function, Mesh, functionspaceimpl,
                        File, SpatialCoordinate, sqrt, Constant, inner,
@@ -245,6 +245,13 @@ class State(object):
         if self.output.dumplist is None:
             self.output.dumplist = fieldlist
         self.fields = FieldCreator(fieldlist, self.xn, self.output.dumplist)
+
+        # set up bcs
+        V = self.fields('u').function_space()
+        self.bcs = []
+        if V.extruded:
+            self.bcs.append(DirichletBC(V, 0.0, "bottom"))
+            self.bcs.append(DirichletBC(V, 0.0, "top"))
 
         self.dumpfile = None
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -197,7 +197,8 @@ class State(object):
     :arg fieldlist: list of prognostic field names
     :arg diagnostic_fields: list of diagnostic field classes
     :arg u_bc_ids: a list containing the ids of boundaries for velocity
-                   to be 0 at, to be applied as boundary conditions.
+                   to be 0 at, to be applied as boundary conditions. For
+                   extruded meshes, top and bottom are added automatically.
     """
 
     def __init__(self, mesh, vertical_degree=None, horizontal_degree=1,

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -196,8 +196,8 @@ class State(object):
     :arg diagnostics: class containing diagnostic methods
     :arg fieldlist: list of prognostic field names
     :arg diagnostic_fields: list of diagnostic field classes
-    :arg u_bc_ids: a list containing the ids of boundaries for velocity
-                   to be 0 at, to be applied as boundary conditions. For
+    :arg u_bc_ids: a list containing the ids of boundaries with no normal
+                   component of velocity. These ids are passed to `DirichletBC`s. For
                    extruded meshes, top and bottom are added automatically.
     """
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -196,6 +196,8 @@ class State(object):
     :arg diagnostics: class containing diagnostic methods
     :arg fieldlist: list of prognostic field names
     :arg diagnostic_fields: list of diagnostic field classes
+    :arg u_bc_ids: a list containing the ids of boundaries for velocity
+                   to be 0 at, to be applied as boundary conditions.
     """
 
     def __init__(self, mesh, vertical_degree=None, horizontal_degree=1,
@@ -207,7 +209,8 @@ class State(object):
                  parameters=None,
                  diagnostics=None,
                  fieldlist=None,
-                 diagnostic_fields=None):
+                 diagnostic_fields=None,
+                 u_bc_ids=None):
 
         self.family = family
         self.vertical_degree = vertical_degree
@@ -233,6 +236,10 @@ class State(object):
             self.diagnostic_fields = diagnostic_fields
         else:
             self.diagnostic_fields = []
+        if u_bc_ids is not None:
+            self.u_bc_ids = u_bc_ids
+        else:
+            self.u_bc_ids = []
 
         # The mesh
         self.mesh = mesh
@@ -252,6 +259,8 @@ class State(object):
         if V.extruded:
             self.bcs.append(DirichletBC(V, 0.0, "bottom"))
             self.bcs.append(DirichletBC(V, 0.0, "top"))
+        for id in self.u_bc_ids:
+            self.bcs.append(DichletBC(V, 0.0, id))
 
         self.dumpfile = None
 

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -2,7 +2,6 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from pyop2.profiling import timed_stage
 from gusto.configuration import logger
 from gusto.linear_solvers import IncompressibleSolver
-from firedrake import DirichletBC
 
 __all__ = ["CrankNicolson", "AdvectionDiffusion"]
 
@@ -55,13 +54,10 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         """
         unp1 = self.state.xnp1.split()[0]
 
-        if unp1.function_space().extruded:
-            M = unp1.function_space()
-            bcs = [DirichletBC(M, 0.0, "bottom"),
-                   DirichletBC(M, 0.0, "top")]
+        bcs = self.state.bcs
 
-            for bc in bcs:
-                bc.apply(unp1)
+        for bc in bcs:
+            bc.apply(unp1)
 
     def setup_timeloop(self, state, t, tmax, pickup):
         """


### PR DESCRIPTION
The intention of this pull request is to enable Gusto to run in non-periodic domains, such as 3D channels that are only periodic in one direction.

This involves two aspects:
1) Adding extra measures for vertical side-walls to the linear solver (it was already done for outflow in the advection step)
2) Changing the way that boundary conditions are called. They are now a property of `state`, which has an argument `u_bc_ids` in which you can list the ids of additional boundaries that need zero-velocity boundary conditions. I have changed the `dry_bf_bubble` to demonstrate how this is done (the test in their paper isn't on a periodic domain). The intention is that when the code is rewritten using form labelling, boundary conditions will be taken away from `state`.