### PR TITLE
Ensure Vorticity in Cartesian Geometries

### DIFF
--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -705,7 +705,7 @@ class Vorticity(DiagnosticField):
                 gradperp = lambda psi: cross(cell_normals, grad(psi))
                 L = (- inner(gradperp(gamma), u))*dx
             else:
-                raise NotImplementedError("The vorticity diagnostics have only been implemented for 2D spherical geometries.")
+                L = (- inner(state.perp(grad(gamma)), u))*dx
 
             if vorticity_type != "relative":
                 f = state.fields("coriolis")

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -700,12 +700,7 @@ class Vorticity(DiagnosticField):
             else:
                 a = q*gamma*dx
 
-            if state.on_sphere:
-                cell_normals = CellNormal(state.mesh)
-                gradperp = lambda psi: cross(cell_normals, grad(psi))
-                L = (- inner(gradperp(gamma), u))*dx
-            else:
-                L = (- inner(state.perp(grad(gamma)), u))*dx
+            L = (- inner(state.perp(grad(gamma)), u))*dx
 
             if vorticity_type != "relative":
                 f = state.fields("coriolis")

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -1,5 +1,5 @@
 from firedrake import op2, assemble, dot, dx, FunctionSpace, Function, sqrt, \
-    TestFunction, TrialFunction, CellNormal, Constant, cross, grad, inner, \
+    TestFunction, TrialFunction, Constant, grad, inner, \
     LinearVariationalProblem, LinearVariationalSolver, FacetNormal, \
     ds, ds_b, ds_v, ds_t, dS_v, div, avg, jump, DirichletBC, BrokenElement, \
     TensorFunctionSpace, SpatialCoordinate, VectorFunctionSpace, as_vector
@@ -701,7 +701,6 @@ class Vorticity(DiagnosticField):
                 a = q*gamma*dx
 
             L = (- inner(state.perp(grad(gamma)), u))*dx
-
             if vorticity_type != "relative":
                 f = state.fields("coriolis")
                 L += gamma*f*dx


### PR DESCRIPTION
Needed Vorticity for geometries other than 2D spherical. I believe this is correct and general enough to work for other geometries as well. Placing instead of NotImplementedError for now such that the 2D spherical geometry computation is unaffected.

- Jonathan Tessier