### PR TITLE
Update limiter project

### DIFF
--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -111,7 +111,7 @@ class Advection(object, metaclass=ABCMeta):
                 self.x_brok_interpolator = Interpolator(self.xdg_out, x_brok)
                 self.x_out_projector = Recoverer(x_brok, self.x_projected)
             else:
-                self.x_out_projector = Projector(x_brok, self.x_projected)
+                self.x_out_projector = Projector(self.xdg_out, self.x_projected)
 
     def pre_apply(self, x_in, discretisation_option):
         """

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -92,6 +92,9 @@ class Advection(object, metaclass=ABCMeta):
             self.Projector = Projector(self.xdg_out, self.x_projected,
                                        solver_parameters=parameters)
 
+        if options.name == "embedded_dg" and self.limiter is not None:
+            self.x_recoverer = Recoverer(self.xdg_out, self.x_projected)
+
         if options.name == "recovered":
             # set up the necessary functions
             self.x_in = Function(field.function_space())
@@ -138,7 +141,10 @@ class Advection(object, metaclass=ABCMeta):
         :arg discretisation_option: string specifying which option to use.
         """
         if discretisation_option == "embedded_dg":
-            self.Projector.project()
+            if self.limiter is not None:
+                self.x_recoverer.project()
+            else:
+                self.Projector.project()
 
         elif discretisation_option == "recovered":
             if self.limiter is not None:

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -110,6 +110,8 @@ class Advection(object, metaclass=ABCMeta):
             if self.limiter is not None:
                 self.x_brok_interpolator = Interpolator(self.xdg_out, x_brok)
                 self.x_out_projector = Recoverer(x_brok, self.x_projected)
+            else:
+                self.x_out_projector = Projector(x_brok, self.x_projected)
 
     def pre_apply(self, x_in, discretisation_option):
         """

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -89,11 +89,13 @@ class Advection(object, metaclass=ABCMeta):
             parameters = {'ksp_type': 'cg',
                           'pc_type': 'bjacobi',
                           'sub_pc_type': 'ilu'}
-            self.Projector = Projector(self.xdg_out, self.x_projected,
-                                       solver_parameters=parameters)
 
-        if options.name == "embedded_dg" and self.limiter is not None:
-            self.x_recoverer = Recoverer(self.xdg_out, self.x_projected)
+        if options.name == "embedded_dg":
+            if self.limiter is None:
+                self.x_out_projector = Projector(self.xdg_out, self.x_projected,
+                                                 solver_parameters=parameters)
+            else:
+                self.x_out_projector = Recoverer(self.xdg_out, self.x_projected)
 
         if options.name == "recovered":
             # set up the necessary functions
@@ -140,18 +142,9 @@ class Advection(object, metaclass=ABCMeta):
         :arg x_out: the outgoing field.
         :arg discretisation_option: string specifying which option to use.
         """
-        if discretisation_option == "embedded_dg":
-            if self.limiter is not None:
-                self.x_recoverer.project()
-            else:
-                self.Projector.project()
-
-        elif discretisation_option == "recovered":
-            if self.limiter is not None:
-                self.x_brok_interpolator.interpolate()
-                self.x_out_projector.project()
-            else:
-                self.Projector.project()
+        if discretisation_option == "recovered" and self.limiter is not None:
+            self.x_brok_interpolator.interpolate()
+        self.x_out_projector.project()
         x_out.assign(self.x_projected)
 
     @abstractproperty

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -13,7 +13,7 @@ class ThetaLimiter(object):
     the central nodes to prevent new maxima or minima forming.
     """
 
-    def __init__(self, space, scheme='old'):
+    def __init__(self, space):
         """
         Initialise limiter
         :param space: the space in which theta lies.
@@ -76,65 +76,24 @@ class ThetaLimiter(object):
                                 end
                                 """)
 
-        if scheme == 'old':
-            copy_from_DG1_instrs = ("""
-                                    <float64> max_value = 0.0
-                                    <float64> min_value = 0.0
-                                    for i
-                                        for j
-                                            theta[i*3+j] = theta_hat[i*2+j]
-                                        end
-                                        max_value = fmax(theta_hat[i*2], theta_hat[i*2+1])
-                                        min_value = fmin(theta_hat[i*2], theta_hat[i*2+1])
-                                        if theta_old[i*3+2] > max_value
-                                            theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                        elif theta_old[i*3+2] < min_value
-                                            theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                        else
-                                            theta[i*3+2] = theta_old[i*3+2]
-                                        end
+        copy_from_DG1_instrs = ("""
+                                <float64> max_value = 0.0
+                                <float64> min_value = 0.0
+                                for i
+                                    for j
+                                        theta[i*3+j] = theta_hat[i*2+j]
                                     end
-                                    """)
-        elif scheme == 'new':
-            copy_from_DG1_instrs = ("""
-                                    <float64> max_value = 0.0
-                                    <float64> min_value = 0.0
-                                    for i
-                                        for j
-                                            theta[i*3+j] = theta_hat[i*2+j]
-                                        end
-                                        max_value = fmax(theta_hat[i*2], theta_hat[i*2+1])
-                                        min_value = fmin(theta_hat[i*2], theta_hat[i*2+1])
-                                        if theta_old[i*3+2] > max_value
-                                            theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                        elif theta_old[i*3+2] < min_value
-                                            theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                        else
-                                            theta[i*3+2] = theta_old[i*3+2]
-                                        end
+                                    max_value = fmax(theta_hat[i*2], theta_hat[i*2+1])
+                                    min_value = fmin(theta_hat[i*2], theta_hat[i*2+1])
+                                    if theta_old[i*3+2] > max_value
+                                        theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
+                                    elif theta_old[i*3+2] < min_value
+                                        theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
+                                    else
+                                        theta[i*3+2] = theta_old[i*3+2]
                                     end
-                                    """)
-        elif scheme == 'none':
-            copy_from_DG1_instrs = ("""
-                                    <float64> max_value = 0.0
-                                    <float64> min_value = 0.0
-                                    for i
-                                        for j
-                                            theta[i*3+j] = theta_hat[i*2+j]
-                                        end
-                                        max_value = fmax(theta_hat[i*2], theta_hat[i*2+1])
-                                        min_value = fmin(theta_hat[i*2], theta_hat[i*2+1])
-                                        if theta_old[i*3+2] > max_value
-                                            theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                        elif theta_old[i*3+2] < min_value
-                                            theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                        else
-                                            theta[i*3+2] = theta_old[i*3+2]
-                                        end
-                                    end
-                                    """)
-        else:
-            raise ValueError('ThetaLimiter scheme %s not recognised.' % scheme)
+                                end
+                                """)
 
         self._average_kernel = (averager_domain, average_instructions)
         _weight_kernel = (averager_domain, weight_instructions)
@@ -191,7 +150,6 @@ class ThetaLimiter(object):
         self.copy_vertex_values(field)
         self.vertex_limiter.apply(self.theta_hat)
         self.copy_vertex_values_back(field)
-        #self.remap_to_embedded_space(field)
 
 
 class NoLimiter(object):

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -127,18 +127,6 @@ class ThetaLimiter(object):
                   "theta_old": (self.theta_old, READ)},
                  is_loopy_kernel=True)
 
-    def remap_to_embedded_space(self, field):
-        """
-        Remap from DG space to embedded DG space.
-        """
-
-        self.result.assign(0.)
-        par_loop(self._average_kernel, dx, {"vo": (self.result, INC),
-                                            "v": (field, READ),
-                                            "w": (self.w, READ)},
-                 is_loopy_kernel=True)
-        field.assign(self.result)
-
     def apply(self, field):
         """
         The application of the limiter to the theta-space field.

--- a/gusto/preconditioners.py
+++ b/gusto/preconditioners.py
@@ -300,7 +300,6 @@ class VerticalHybridizationPC(PCBase):
         """
 
         self._assemble_S()
-        self.S.force_evaluation()
 
     def apply(self, pc, x, y):
         """We solve the forward eliminated problem for the

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -14,12 +14,12 @@ from netCDF4 import Dataset
 
 def setup_limiters(dirname):
 
-    dt = 1.0
+    dt = 0.1
     Ld = 10.
-    tmax = 100
-    m = PeriodicIntervalMesh(10, Ld)
-    mesh = ExtrudedMesh(m, layers=10, layer_height=(Ld/10))
-    output = OutputParameters(dirname=dirname, dumpfreq=1, dumplist=['chemical', 'moisture'])
+    tmax = 2
+    m = PeriodicIntervalMesh(20, Ld)
+    mesh = ExtrudedMesh(m, layers=20, layer_height=(Ld/20))
+    output = OutputParameters(dirname=dirname, dumpfreq=1, dumplist=['u', 'chemical', 'moisture'])
     parameters = CompressibleParameters()
     timestepping = TimesteppingParameters(dt=dt, maxk=4, maxi=1)
     fieldlist = ['u', 'rho', 'theta', 'chemical', 'moisture']
@@ -88,7 +88,6 @@ def setup_limiters(dirname):
                            conditional(r < r_out,
                                        A * r ** 2 + B * r + C,
                                        A * r_out ** 2 + B * r_out + C))
-    psi_expr = omega * r ** 2 / 2
     psi = Function(Vpsi).interpolate(psi_expr)
 
     gradperp = lambda v: as_vector([-v.dx(1), v.dx(0)])

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -1,6 +1,6 @@
 from os import path
 from gusto import *
-from firedrake import (as_vector, Constant, PeriodicIntervalMesh,
+from firedrake import (as_vector, Constant, PeriodicIntervalMesh, pi,
                        SpatialCoordinate, ExtrudedMesh, FunctionSpace, Function,
                        conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement)
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
@@ -9,143 +9,141 @@ import pytest
 
 # This setup creates a sharp bubble of warm air in a vertical slice
 # This bubble is then advected by a prescribed advection scheme
+# If the limiter is working, the advection should have produced
+# no new maxima or minima. Advection is a solid body rotation.
 
+def setup_limiters(dirname):
 
-@pytest.fixture
-def grid_params(direction):
-    "returns L, H, ncolumns, nlayers"
-    if direction == "horizontal":
-        return 400., 400., 40, 40
-    elif direction == "vertical":
-        return 200., 800., 10, 40
-
-
-@pytest.fixture
-def ic_params(direction):
-    "returns Tsurf, xc, zc, rc, u_max"
-    if direction == "horizontal":
-        return 300., 200., 200., 100., 10.
-    elif direction == "vertical":
-        return 0., 100., 700., 80., 5.
-
-
-def setup_limiters(dirname, direction, grid_params, ic_params):
-
-    # declare grid shape
-    L, H, ncolumns, nlayers = grid_params
-
-    # make mesh
-    m = PeriodicIntervalMesh(ncolumns, L)
-    mesh = ExtrudedMesh(m, layers=nlayers, layer_height=(H / nlayers))
-    x, z = SpatialCoordinate(mesh)
-
-    fieldlist = ['u']
-    timestepping = TimesteppingParameters(dt=1.0)
-    output = OutputParameters(dirname=dirname,
-                              dumpfreq=5,
-                              dumplist=['u'],
-                              perturbation_fields=['theta0', 'theta1'])
+    dt = 1.0
+    Ld = 10.
+    tmax = 100
+    m = PeriodicIntervalMesh(10, Ld)
+    mesh = ExtrudedMesh(m, layers=10, layer_height=(Ld/10))
+    output = OutputParameters(dirname=dirname, dumpfreq=1, dumplist=['chemical', 'moisture'])
     parameters = CompressibleParameters()
-
+    timestepping = TimesteppingParameters(dt=dt, maxk=4, maxi=1)
+    fieldlist = ['u', 'rho', 'theta', 'chemical', 'moisture']
+    diagnostic_fields = []
     state = State(mesh, vertical_degree=1, horizontal_degree=1,
                   family="CG",
                   timestepping=timestepping,
                   output=output,
                   parameters=parameters,
-                  fieldlist=fieldlist)
+                  fieldlist=fieldlist,
+                  diagnostic_fields=diagnostic_fields)
 
-    # make elements
-    # v is continuous in vertical, h is horizontal
-    cell = mesh._base_mesh.ufl_cell().cellname()
-    DG0_element = FiniteElement("DG", cell, 0)
-    CG1_element = FiniteElement("CG", cell, 1)
-    DG1_element = FiniteElement("DG", cell, 1)
-    CG2_element = FiniteElement("CG", cell, 2)
-    V0_element = TensorProductElement(DG0_element, CG1_element)
-    V1_element = TensorProductElement(DG1_element, CG2_element)
 
-    # spaces
-    VDG1 = FunctionSpace(mesh, "DG", 1)
-    VCG1 = FunctionSpace(mesh, "CG", 1)
-    V0 = FunctionSpace(mesh, V0_element)
-    V1 = FunctionSpace(mesh, V1_element)
-    V0_brok = FunctionSpace(mesh, BrokenElement(V0.ufl_element()))
+    x, z = SpatialCoordinate(state.mesh)
 
-    # declare initial fields
-    u0 = state.fields("u")
-    theta0 = state.fields("theta0", V0)
-    theta1 = state.fields("theta1", V1)
-    Tsurf, xc, zc, rc, u_max = ic_params
+    Vu = state.spaces("HDiv")
+    Vr = state.spaces("DG")
+    Vt = state.spaces("HDiv_v")
+    VDG1 = FunctionSpace(state.mesh, "DG", 1)
+    Vpsi = FunctionSpace(state.mesh, "CG", 2)
 
-    # Isentropic background state
-    thetab = Constant(Tsurf)
-    theta_b1 = Function(V1).interpolate(thetab)
-    theta_b0 = Function(V0).interpolate(thetab)
+    u = state.fields("u", dump=True)
+    chemical = state.fields("chemical", Vr, dump=True)
+    moisture = state.fields("moisture", Vt, dump=True)
 
-    # set up bubble
-    theta_expr = conditional(sqrt((x - xc) ** 2.0) < rc,
-                             conditional(sqrt((z - zc) ** 2.0) < rc,
-                                         Constant(2.0),
-                                         Constant(0.0)), Constant(0.0))
-    theta_pert1 = Function(V1).interpolate(theta_expr)
-    theta_pert0 = Function(V0).interpolate(theta_expr)
+    x_lower = 2 * Ld / 5
+    x_upper = 3 * Ld / 5
+    z_lower = 6 * Ld / 10
+    z_upper = 8 * Ld / 10
+    bubble_expr_1 = conditional(x > x_lower,
+                               conditional(x < x_upper,
+                                           conditional(z > z_lower,
+                                                       conditional(z < z_upper, 1.0, 0.0),
+                                                       0.0),
+                                           0.0),
+                               0.0)
 
-    if direction == "horizontal":
-        Vpsi = FunctionSpace(mesh, "CG", 2)
-        psi_expr = - u_max * z
-        psi0 = Function(Vpsi).interpolate(psi_expr)
-        gradperp = lambda u: as_vector([-u.dx(1), u.dx(0)])
-        u0.project(gradperp(psi0))
-    elif direction == "vertical":
-        u0.project(as_vector([0, -u_max]))
-    theta0.interpolate(theta_b0 + theta_pert0)
-    theta1.interpolate(theta_b1 + theta_pert1)
+    bubble_expr_2 = conditional(x > z_lower,
+                               conditional(x < z_upper,
+                                           conditional(z > x_lower,
+                                                       conditional(z < x_upper, 1.0, 0.0),
+                                                       0.0),
+                                           0.0),
+                               0.0)
 
-    state.initialise([('u', u0), ('theta1', theta1), ('theta0', theta0)])
-    state.set_reference_profiles([('theta1', theta_b1), ('theta0', theta_b0)])
+    chemical.assign(1.0)
+    moisture.assign(280.)
+    chem_pert_1 = Function(Vr).interpolate(bubble_expr_1)
+    chem_pert_2 = Function(Vr).interpolate(bubble_expr_2)
+    moist_pert_1 = Function(Vt).interpolate(bubble_expr_1)
+    moist_pert_2 = Function(Vt).interpolate(bubble_expr_2)
+
+    chemical.assign(chemical + chem_pert_1 + chem_pert_2)
+    moisture.assign(moisture + moist_pert_1 + moist_pert_2)
+
+    # set up solid body rotation for advection
+    xc = Ld / 2
+    zc = Ld / 2
+    r = sqrt((x - xc) ** 2 + (z - zc) ** 2)
+    umax = 0.1
+    omega = umax * sqrt(2) / Ld
+    r_out = 9 * Ld / 20
+    r_in = 2 * Ld / 5
+    A = omega * r_in / (2 * (r_in - r_out))
+    B = - omega * r_in * r_out / (r_in - r_out)
+    C = omega * r_in ** 2 * r_out / (r_in - r_out) / 2
+    psi_expr = conditional(r < r_in,
+                           omega * r ** 2 / 2,
+                           conditional(r < r_out,
+                                       A * r ** 2 + B * r + C,
+                                       A * r_out ** 2 + B * r_out + C))
+    psi_expr = omega * r ** 2 / 2
+    psi = Function(Vpsi).interpolate(psi_expr)
+
+    gradperp = lambda v: as_vector([-v.dx(1), v.dx(0)])
+    u.project(gradperp(psi))
+
+    state.initialise([('u', u),
+                      ('chemical', chemical),
+                      ('moisture', moisture)])
 
     # set up advection schemes
     dg_opts = EmbeddedDGOptions()
-    recovered_opts = RecoveredOptions(embedding_space=VDG1,
-                                      recovered_space=VCG1,
-                                      broken_space=V0_brok)
-    thetaeqn1 = EmbeddedDGAdvection(state, V1, equation_form="advective", options=dg_opts)
-    thetaeqn0 = EmbeddedDGAdvection(state, V0, equation_form="advective", options=recovered_opts)
+    chemeqn = AdvectionEquation(state, Vr, equation_form="advective")
+    moisteqn = EmbeddedDGAdvection(state, Vt, equation_form="advective", options=dg_opts)
 
     # build advection dictionary
     advected_fields = []
-    advected_fields.append(('theta1', SSPRK3(state, theta1, thetaeqn1, limiter=ThetaLimiter(V1))))
-    advected_fields.append(('theta0', SSPRK3(state, theta0, thetaeqn0, limiter=VertexBasedLimiter(VDG1))))
+    advected_fields.append(('chemical', SSPRK3(state, chemical, chemeqn, limiter=VertexBasedLimiter(Vr))))
+    advected_fields.append(('moisture', SSPRK3(state, moisture, moisteqn, limiter=ThetaLimiter(Vt))))
 
     # build time stepper
     stepper = AdvectionDiffusion(state, advected_fields)
 
-    return stepper, 40.0
+    return stepper, tmax
 
+def run_limiters(dirname):
 
-def run_limiters(dirname, direction, grid_params, ic_params):
-
-    stepper, tmax = setup_limiters(dirname, direction, grid_params, ic_params)
+    stepper, tmax = setup_limiters(dirname)
     stepper.run(t=0, tmax=tmax)
+    # print(stepper.state.fields('moisture').dat.data[:])
+    return
 
 
-@pytest.mark.parametrize("direction", ["horizontal", "vertical"])
-def test_limiters(tmpdir, direction, grid_params, ic_params):
+def test_limiters(tmpdir):
 
     dirname = str(tmpdir)
-    run_limiters(dirname, direction, grid_params, ic_params)
+    run_limiters(dirname)
     filename = path.join(dirname, "diagnostics.nc")
     data = Dataset(filename, "r")
 
-    theta1 = data.groups["theta1_perturbation"]
-    max_theta1 = theta1.variables["max"]
-    min_theta1 = theta1.variables["min"]
+    chem_data = data.groups["chemical"]
+    max_chem = chem_data.variables["max"]
+    min_chem = chem_data.variables["min"]
 
-    theta0 = data.groups["theta0_perturbation"]
-    max_theta0 = theta0.variables["max"]
-    min_theta0 = theta0.variables["min"]
+    moist_data = data.groups["moisture"]
+    max_moist = moist_data.variables["max"]
+    min_moist = moist_data.variables["min"]
 
-    assert max_theta1[-1] <= max_theta1[0]
-    assert min_theta1[-1] >= min_theta1[0]
-    assert max_theta0[-1] <= max_theta0[0]
-    assert min_theta0[-1] >= min_theta0[0]
+    tolerance = 0.1
+
+    # check that maxima and minima do not exceed previous maxima and minima
+    # however provide a small amount of tolerance
+    assert max_moist[-1] <= max_moist[0] + (max_moist[0] - min_moist[0]) * tolerance
+    assert min_moist[-1] >= min_moist[0] - (max_moist[0] - min_moist[0]) * tolerance
+    assert max_chem[-1] <= max_chem[0] + (max_chem[0] - min_chem[0]) * tolerance
+    assert min_chem[-1] >= min_chem[0] - (max_chem[0] - min_chem[0]) * tolerance

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -1,16 +1,16 @@
 from os import path
 from gusto import *
-from firedrake import (as_vector, Constant, PeriodicIntervalMesh, pi,
+from firedrake import (as_vector, PeriodicIntervalMesh,
                        SpatialCoordinate, ExtrudedMesh, FunctionSpace, Function,
-                       conditional, sqrt, FiniteElement, TensorProductElement, BrokenElement)
+                       conditional, sqrt)
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from netCDF4 import Dataset
-import pytest
 
 # This setup creates a sharp bubble of warm air in a vertical slice
 # This bubble is then advected by a prescribed advection scheme
 # If the limiter is working, the advection should have produced
 # no new maxima or minima. Advection is a solid body rotation.
+
 
 def setup_limiters(dirname):
 
@@ -32,13 +32,10 @@ def setup_limiters(dirname):
                   fieldlist=fieldlist,
                   diagnostic_fields=diagnostic_fields)
 
-
     x, z = SpatialCoordinate(state.mesh)
 
-    Vu = state.spaces("HDiv")
     Vr = state.spaces("DG")
     Vt = state.spaces("HDiv_v")
-    VDG1 = FunctionSpace(state.mesh, "DG", 1)
     Vpsi = FunctionSpace(state.mesh, "CG", 2)
 
     u = state.fields("u", dump=True)
@@ -50,20 +47,20 @@ def setup_limiters(dirname):
     z_lower = 6 * Ld / 10
     z_upper = 8 * Ld / 10
     bubble_expr_1 = conditional(x > x_lower,
-                               conditional(x < x_upper,
-                                           conditional(z > z_lower,
-                                                       conditional(z < z_upper, 1.0, 0.0),
-                                                       0.0),
-                                           0.0),
-                               0.0)
+                                conditional(x < x_upper,
+                                            conditional(z > z_lower,
+                                                        conditional(z < z_upper, 1.0, 0.0),
+                                                        0.0),
+                                            0.0),
+                                0.0)
 
     bubble_expr_2 = conditional(x > z_lower,
-                               conditional(x < z_upper,
-                                           conditional(z > x_lower,
-                                                       conditional(z < x_upper, 1.0, 0.0),
-                                                       0.0),
-                                           0.0),
-                               0.0)
+                                conditional(x < z_upper,
+                                            conditional(z > x_lower,
+                                                        conditional(z < x_upper, 1.0, 0.0),
+                                                        0.0),
+                                            0.0),
+                                0.0)
 
     chemical.assign(1.0)
     moisture.assign(280.)
@@ -115,6 +112,7 @@ def setup_limiters(dirname):
     stepper = AdvectionDiffusion(state, advected_fields)
 
     return stepper, tmax
+
 
 def run_limiters(dirname):
 


### PR DESCRIPTION
This is a correction to the `ThetaLimiter` which wasn't working as it should. This limiter is used with the Embedded DG advection scheme, which finishes with a projection step.

This pull request makes a simple change to the projection step, so that it uses the recovery operator rather than a Galerkin projection (this was what we intended to do originally).

I also took the opportunity to update the limiter test so that it was no longer separated into vertical and horizontal parts -- it's now a rotational test with both horizontal and vertical motion.