### PR TITLE
mark the failing recovery tests with an xfail

### DIFF
--- a/tests/kernel_tests/test_average_kernel.py
+++ b/tests/kernel_tests/test_average_kernel.py
@@ -75,6 +75,7 @@ def setup_values(geometry, DG_field, weights):
 
 
 @pytest.mark.parametrize("geometry", ["1D", "2D"])
+@pytest.mark.xfail
 def test_average(geometry, mesh):
 
     cell = mesh.ufl_cell().cellname()

--- a/tests/kernel_tests/test_gauss_elim_kernel.py
+++ b/tests/kernel_tests/test_gauss_elim_kernel.py
@@ -70,6 +70,7 @@ def setup_values(geometry, field_init, field_true,
 
 
 @pytest.mark.parametrize("geometry", ["1D", "2D"])
+@pytest.mark.xfail
 def test_gaussian_elimination(geometry, mesh):
 
     cell = mesh.ufl_cell().cellname()

--- a/tests/recovery_tests/test_recovery_1d.py
+++ b/tests/recovery_tests/test_recovery_1d.py
@@ -46,6 +46,7 @@ def expr(geometry, mesh):
 
 
 @pytest.mark.parametrize("geometry", ["periodic", "non-periodic"])
+@pytest.mark.xfail
 def test_1D_recovery(geometry, mesh, expr):
 
     # horizontal base spaces

--- a/tests/recovery_tests/test_recovery_2d_cart.py
+++ b/tests/recovery_tests/test_recovery_2d_cart.py
@@ -66,6 +66,7 @@ def expr(geometry, mesh):
 @pytest.mark.parametrize("geometry", ["periodic-in-both", "periodic-in-x",
                                       "periodic-in-y", "non-periodic"])
 @pytest.mark.parametrize("element", ["quadrilateral", "triangular"])
+@pytest.mark.xfail
 def test_2D_cartesian_recovery(geometry, element, mesh, expr):
 
     family = "RTCF" if element == "quadrilateral" else "BDM"

--- a/tests/recovery_tests/test_recovery_2d_vert_slice.py
+++ b/tests/recovery_tests/test_recovery_2d_vert_slice.py
@@ -55,6 +55,7 @@ def expr(geometry, mesh):
 
 
 @pytest.mark.parametrize("geometry", ["periodic", "non-periodic"])
+@pytest.mark.xfail
 def test_vertical_slice_recovery(geometry, mesh, expr):
 
     # horizontal base spaces

--- a/tests/recovery_tests/test_recovery_3d_cart.py
+++ b/tests/recovery_tests/test_recovery_3d_cart.py
@@ -73,6 +73,7 @@ def expr(geometry, mesh):
 @pytest.mark.parametrize("geometry", ["periodic-in-both", "periodic-in-x",
                                       "periodic-in-y", "non-periodic"])
 @pytest.mark.parametrize("element", ["quadrilateral", "triangular"])
+@pytest.mark.xfail
 def test_3D_cartesian_recovery(geometry, element, mesh, expr):
 
     family = "RTCF" if element == "quadrilateral" else "BDM"

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -5,7 +5,6 @@ from firedrake import (as_vector, PeriodicIntervalMesh, interval, FiniteElement,
                        conditional, sqrt, BrokenElement, TensorProductElement)
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from netCDF4 import Dataset
-import pytest
 
 # This setup creates a sharp bubble of warm air in a vertical slice
 # This bubble is then advected by a prescribed advection scheme

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -5,6 +5,7 @@ from firedrake import (as_vector, PeriodicIntervalMesh, interval, FiniteElement,
                        conditional, sqrt, BrokenElement, TensorProductElement)
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from netCDF4 import Dataset
+import pytest
 
 # This setup creates a sharp bubble of warm air in a vertical slice
 # This bubble is then advected by a prescribed advection scheme

--- a/tests/test_recovered_space.py
+++ b/tests/test_recovered_space.py
@@ -2,6 +2,7 @@ from gusto import *
 from firedrake import (as_vector, Constant, PeriodicIntervalMesh,
                        SpatialCoordinate, ExtrudedMesh, FunctionSpace,
                        Function, conditional, sqrt)
+import pytest
 
 # This setup creates a sharp bubble of warm air in a vertical slice
 # This bubble is then advected by a prescribed advection scheme
@@ -91,6 +92,7 @@ def run_recovered_space(dirname):
     stepper.run(t=0, tmax=tmax)
 
 
+@pytest.mark.xfail
 def test_recovered_space_setup(tmpdir):
 
     dirname = str(tmpdir)

--- a/tests/test_saturated_balance.py
+++ b/tests/test_saturated_balance.py
@@ -3,6 +3,7 @@ from firedrake import (PeriodicIntervalMesh, ExtrudedMesh, Constant, Function,
                        FunctionSpace, BrokenElement, VectorFunctionSpace)
 from os import path
 from netCDF4 import Dataset
+import pytest
 
 # this tests the moist-saturated hydrostatic balance, by setting up a vertical slice
 # with this initial procedure, before taking a few time steps and ensuring that
@@ -134,6 +135,7 @@ def run_saturated(dirname):
     stepper.run(t=0, tmax=tmax)
 
 
+@pytest.mark.xfail
 def test_saturated_setup(tmpdir):
 
     dirname = str(tmpdir)

--- a/tests/test_unsaturated_balance.py
+++ b/tests/test_unsaturated_balance.py
@@ -3,6 +3,7 @@ from firedrake import (PeriodicIntervalMesh, ExtrudedMesh, Constant, Function,
                        FunctionSpace, BrokenElement, VectorFunctionSpace)
 from os import path
 from netCDF4 import Dataset
+import pytest
 
 # this tests the moist-unsaturated hydrostatic balance, by setting up a vertical slice
 # with this initial procedure, before taking a few time steps and ensuring that
@@ -133,6 +134,7 @@ def run_unsaturated(dirname):
     stepper.run(t=0, tmax=tmax)
 
 
+@pytest.mark.xfail
 def test_unsaturated_setup(tmpdir):
 
     dirname = str(tmpdir)


### PR DESCRIPTION
As mentioned in Issue #233, this PR is just to mark the currently failing recovery tests with `xfail` as these tests are no longer up-to-date with Firedrake and its dependencies.

We'll separately work to understand why this is but in the meantime show that we know that the tests are failing!