### PR TITLE
Improve kernel tests and fix broken recovery tests

### DIFF
--- a/gusto/kernels.py
+++ b/gusto/kernels.py
@@ -139,6 +139,7 @@ class GaussianElimination(object):
             # fill f with the original field values and A with the effective coordinate values
             """
                     f[i] = DG1_OLD[i]
+                    a[i] = 0.0
                     {eff_coord_expr}
                 end
             """

--- a/tests/kernel_tests/test_average_kernel.py
+++ b/tests/kernel_tests/test_average_kernel.py
@@ -84,7 +84,6 @@ def set_val_at_point(coord_field, coords, field=None, new_value=None):
 
 
 @pytest.mark.parametrize("geometry", ["1D", "2D"])
-@pytest.mark.xfail
 def test_average(geometry, mesh):
 
     cell = mesh.ufl_cell().cellname()

--- a/tests/kernel_tests/test_average_kernel.py
+++ b/tests/kernel_tests/test_average_kernel.py
@@ -46,11 +46,11 @@ def setup_values(geometry, DG0_field, weights):
         # We do it for both components of the vector field
 
         CG_index = set_val_at_point(coords_CG1, [1.0, 1.0])
-        set_val_at_point(coords_CG1, [1.0,1.0], weights, [4.0,4.0])
-        set_val_at_point(coords_DG0, [0.5,0.5], DG0_field, [6.0, -3.0])
-        set_val_at_point(coords_DG0, [1.5,0.5], DG0_field, [-7.0, -6.0])
-        set_val_at_point(coords_DG0, [0.5,1.5], DG0_field, [0.0, 3.0])
-        set_val_at_point(coords_DG0, [1.5,1.5], DG0_field, [-9.0, -1.0])
+        set_val_at_point(coords_CG1, [1.0, 1.0], weights, [4.0, 4.0])
+        set_val_at_point(coords_DG0, [0.5, 0.5], DG0_field, [6.0, -3.0])
+        set_val_at_point(coords_DG0, [1.5, 0.5], DG0_field, [-7.0, -6.0])
+        set_val_at_point(coords_DG0, [0.5, 1.5], DG0_field, [0.0, 3.0])
+        set_val_at_point(coords_DG0, [1.5, 1.5], DG0_field, [-9.0, -1.0])
 
         true_values = [0.25 * (6.0 - 7.0 + 0.0 - 9.0),
                        0.25 * (-3.0 - 6.0 + 3.0 - 1.0)]

--- a/tests/kernel_tests/test_average_kernel.py
+++ b/tests/kernel_tests/test_average_kernel.py
@@ -2,10 +2,11 @@
 A test of the Average kernel used for the Averager.
 """
 
-from firedrake import (IntervalMesh, Function, RectangleMesh,
+from firedrake import (IntervalMesh, Function, RectangleMesh, SpatialCoordinate,
                        VectorFunctionSpace, FiniteElement)
 
 from gusto import kernels
+import numpy as np
 import pytest
 
 
@@ -23,55 +24,63 @@ def mesh(geometry):
     return m
 
 
-def setup_values(geometry, DG_field, weights):
+def setup_values(geometry, DG0_field, weights):
+
+    x = SpatialCoordinate(weights.function_space().mesh())
+    coords_CG1 = Function(weights.function_space()).interpolate(x)
+    coords_DG0 = Function(DG0_field.function_space()).interpolate(x)
 
     if geometry == "1D":
-        # The numbering of DoFs for DG1 and CG1 near the origin in this mesh is
-        #  |      DG1                |      |      |
-        #  |1-----0|3----2|--        0------1------2
-
-        # Let us focus on the point at (1,1)
-        # For DG1 this is the DoFs numbered 0 and 3
-        # For CG1 this is the DoF numbered 1
-        # The test is if at CG_field[1] we get the average of the corresponding DG_field values
-
-        DG_field.dat.data[0] = 6.0
-        DG_field.dat.data[3] = -10.0
+        # Let us focus on the point at x = 1.0
+        # The test is if at CG_field[CG_index] we get the average of the corresponding DG_field values
+        CG_index = set_val_at_point(coords_CG1, 1.0)
+        set_val_at_point(coords_DG0, 0.5, DG0_field, 6.0)
+        set_val_at_point(coords_DG0, 1.5, DG0_field, -10.0)
+        set_val_at_point(coords_CG1, 1.0, weights, 2.0)
 
         true_values = 0.5 * (6.0 - 10.0)
 
-        weights.dat.data[1] = 2.0
-
     elif geometry == "2D":
-        # The numbering of DoFs for DG1 and CG1 near the origin in this mesh is
-        #  |      DG1                |     CG1     |
-        #  |-------|------|--        6------7------10
-        #  |10   11|18  19|          |      |      |
-        #  |       |      |          |      |      |
-        #  |8     9|16  17|          |      |      |
-        #  |-------|------|--        1------2------4
-        #  |1     3|5    7|          |      |      |
-        #  |       |      |          |      |      |
-        #  |0     2|4    6|          |      |      |
-        #  |-------|------|--        0------3------5---
-
         # Let us focus on the point at (1,1)
-        # For DG1 this is the DoFs numbered 3, 5, 9 and 16
-        # For CG1 this is the DoF numbered 2
-        # The test is if at CG_field[2] we get the average of the corresponding DG_field values
+        # The test is if at CG_field[CG_index] we get the average of the corresponding DG_field values
         # We do it for both components of the vector field
 
-        DG_field.dat.data[3] = [6.0, -3.0]
-        DG_field.dat.data[5] = [-7.0, -6.0]
-        DG_field.dat.data[9] = [0.0, 3.0]
-        DG_field.dat.data[16] = [-9.0, -1.0]
+        CG_index = set_val_at_point(coords_CG1, [1.0, 1.0])
+        set_val_at_point(coords_CG1, [1.0,1.0], weights, [4.0,4.0])
+        set_val_at_point(coords_DG0, [0.5,0.5], DG0_field, [6.0, -3.0])
+        set_val_at_point(coords_DG0, [1.5,0.5], DG0_field, [-7.0, -6.0])
+        set_val_at_point(coords_DG0, [0.5,1.5], DG0_field, [0.0, 3.0])
+        set_val_at_point(coords_DG0, [1.5,1.5], DG0_field, [-9.0, -1.0])
 
         true_values = [0.25 * (6.0 - 7.0 + 0.0 - 9.0),
                        0.25 * (-3.0 - 6.0 + 3.0 - 1.0)]
 
-        weights.dat.data[2] = [4.0, 4.0]
+    return DG0_field, weights, true_values, CG_index
 
-    return DG_field, weights, true_values
+
+def set_val_at_point(coord_field, coords, field=None, new_value=None):
+    """
+    Finds the DoF of a field at a particular coordinate. If new_value is
+    provided then it also assigns the coefficient for the field there to be
+    new_value. Otherwise the DoF index is returned.
+    """
+    num_points = len(coord_field.dat.data[:])
+    point_found = False
+
+    for i in range(num_points):
+        # Do the coordinates at the ith point match our desired coords?
+        if np.allclose(coord_field.dat.data[i], coords, rtol=1e-14):
+            point_found = True
+            point_index = i
+            if field is not None and new_value is not None:
+                field.dat.data[i] = new_value
+            break
+
+    if not point_found:
+        raise ValueError('Your coordinates do not appear to match the coordinates of a DoF')
+
+    if field is None or new_value is None:
+        return point_index
 
 
 @pytest.mark.parametrize("geometry", ["1D", "2D"])
@@ -80,21 +89,25 @@ def test_average(geometry, mesh):
     cell = mesh.ufl_cell().cellname()
     DG1_elt = FiniteElement("DG", cell, 1, variant="equispaced")
     vec_DG1 = VectorFunctionSpace(mesh, DG1_elt)
+    vec_DG0 = VectorFunctionSpace(mesh, "DG", 0)
     vec_CG1 = VectorFunctionSpace(mesh, "CG", 1)
 
-    # We will fill DG_field with values, and average them to CG_field
-    DG_field = Function(vec_DG1)
+    # We will fill DG1_field with values, and average them to CG_field
+    # First need to put the values into DG0 and then interpolate
+    DG0_field = Function(vec_DG0)
+    DG1_field = Function(vec_DG1)
     CG_field = Function(vec_CG1)
     weights = Function(vec_CG1)
 
-    DG_field, weights, true_values = setup_values(geometry, DG_field, weights)
+    DG0_field, weights, true_values, CG_index = setup_values(geometry, DG0_field, weights)
 
+    DG1_field.interpolate(DG0_field)
     kernel = kernels.Average(vec_CG1)
-    kernel.apply(CG_field, weights, DG_field)
+    kernel.apply(CG_field, weights, DG1_field)
 
     tolerance = 1e-12
     if geometry == "1D":
-        assert abs(CG_field.dat.data[1] - true_values) < tolerance
+        assert abs(CG_field.dat.data[CG_index] - true_values) < tolerance
     elif geometry == "2D":
-        assert abs(CG_field.dat.data[2][0] - true_values[0]) < tolerance
-        assert abs(CG_field.dat.data[2][1] - true_values[1]) < tolerance
+        assert abs(CG_field.dat.data[CG_index][0] - true_values[0]) < tolerance
+        assert abs(CG_field.dat.data[CG_index][1] - true_values[1]) < tolerance

--- a/tests/kernel_tests/test_gauss_elim_kernel.py
+++ b/tests/kernel_tests/test_gauss_elim_kernel.py
@@ -89,7 +89,6 @@ def set_val_at_point_DG(coord_field, coords, field=None, new_value=None):
 
 
 @pytest.mark.parametrize("geometry", ["1D", "2D"])
-@pytest.mark.xfail
 def test_gaussian_elimination(geometry, mesh):
 
     cell = mesh.ufl_cell().cellname()

--- a/tests/kernel_tests/test_gauss_elim_kernel.py
+++ b/tests/kernel_tests/test_gauss_elim_kernel.py
@@ -3,9 +3,10 @@ A test of the Gaussian elimination kernel used for the BoundaryRecoverer.
 """
 
 from firedrake import (IntervalMesh, FunctionSpace, Function, RectangleMesh,
-                       VectorFunctionSpace, FiniteElement)
+                       VectorFunctionSpace, FiniteElement, SpatialCoordinate)
 
 from gusto import kernels
+import numpy as np
 import pytest
 
 
@@ -23,8 +24,10 @@ def mesh(geometry):
     return m
 
 
-def setup_values(geometry, field_init, field_true,
-                 act_coords, eff_coords):
+def setup_values(geometry, field_init, field_true, act_coords, eff_coords):
+
+    x = SpatialCoordinate(field_init.function_space().mesh())
+    act_coords.interpolate(x)
 
     if geometry == "1D":
         # We consider the cell on the left boundary: with act coords (0) and (1)
@@ -33,14 +36,12 @@ def setup_values(geometry, field_init, field_true,
         # This would be described by a field with f = 2 - 3*x
         # The initial values at the eff coords would then be 0.5 and -1
 
-        field_init.dat.data[0] = 0.5
-        field_init.dat.data[1] = -1.0
-        field_true.dat.data[0] = 2.0
-        field_true.dat.data[1] = -1.0
-        act_coords.dat.data[0] = 0.0
-        act_coords.dat.data[1] = 1.0
-        eff_coords.dat.data[0] = 0.5
-        eff_coords.dat.data[1] = 1.0
+        set_val_at_point(act_coords, 0.0, field_init, 0.5)
+        set_val_at_point(act_coords, 1.0, field_init, -1.0)
+        set_val_at_point(act_coords, 0.0, field_true, 2.0)
+        set_val_at_point(act_coords, 1.0, field_true, -1.0)
+        set_val_at_point(act_coords, 0.0, eff_coords, 0.5)
+        set_val_at_point(act_coords, 1.0, eff_coords, 1.0)
 
     elif geometry == "2D":
         # We consider the unit-square cell: with act coords (0,0), (1,0), (0,1) and (1,1)
@@ -49,27 +50,45 @@ def setup_values(geometry, field_init, field_true,
         # This would be described by a field with f = 2 - 3*x - 5*y + 7*x*y
         # The initial values at the eff coords would then be -0.25, 0, -1, 1
 
-        field_init.dat.data[0] = -0.25
-        field_init.dat.data[1] = 0.0
-        field_init.dat.data[2] = -1.0
-        field_init.dat.data[3] = 1.0
-        field_true.dat.data[0] = 2.0
-        field_true.dat.data[1] = -1.0
-        field_true.dat.data[2] = -3.0
-        field_true.dat.data[3] = 1.0
-        act_coords.dat.data[0, :] = [0.0, 0.0]
-        act_coords.dat.data[1, :] = [1.0, 0.0]
-        act_coords.dat.data[2, :] = [0.0, 1.0]
-        act_coords.dat.data[3, :] = [1.0, 1.0]
-        eff_coords.dat.data[0, :] = [0.5, 0.5]
-        eff_coords.dat.data[1, :] = [1.0, 0.5]
-        eff_coords.dat.data[2, :] = [0.5, 1.0]
-        eff_coords.dat.data[3, :] = [1.0, 1.0]
+        set_val_at_point(act_coords, [0.0, 0.0], field_init, -0.25)
+        set_val_at_point(act_coords, [1.0, 0.0], field_init, 0.0)
+        set_val_at_point(act_coords, [0.0, 1.0], field_init, -1.0)
+        set_val_at_point(act_coords, [1.0, 1.0], field_init, 1.0)
+        set_val_at_point(act_coords, [0.0, 0.0], field_true, 2.0)
+        set_val_at_point(act_coords, [1.0, 0.0], field_true, -1.0)
+        set_val_at_point(act_coords, [0.0, 1.0], field_true, -3.0)
+        set_val_at_point(act_coords, [1.0, 1.0], field_true, 1.0)
+        set_val_at_point(act_coords, [0.0, 0.0], eff_coords, [0.5, 0.5])
+        set_val_at_point(act_coords, [1.0, 0.0], eff_coords, [1.0, 0.5])
+        set_val_at_point(act_coords, [0.0, 1.0], eff_coords, [0.5, 1.0])
+        set_val_at_point(act_coords, [1.0, 1.0], eff_coords, [1.0, 1.0])
 
     return field_init, field_true, act_coords, eff_coords
 
 
-@pytest.mark.parametrize("geometry", ["1D", "2D"])
+def set_val_at_point(coord_field, coords, field=None, new_value=None):
+    """
+    Finds the DoF of a field at a particular coordinate. If new_value is
+    provided then it also assigns the coefficient for the field there to be
+    new_value. Otherwise the DoF index is returned.
+    """
+    num_points = len(coord_field.dat.data[:])
+    point_indices = []
+    for i in range(num_points):
+        # Do the coordinates at the ith point match our desired coords?
+        if np.allclose(coord_field.dat.data[i], coords, rtol=1e-14):
+            point_indices.append(i)
+            if field is not None and new_value is not None:
+                field.dat.data[i] = new_value
+
+    if len(point_indices) == 0:
+        raise ValueError('Your coordinates do not appear to match the coordinates of a DoF')
+
+    if field is None or new_value is None:
+        return point_indices
+
+
+@pytest.mark.parametrize("geometry", ["1D"])
 def test_gaussian_elimination(geometry, mesh):
 
     cell = mesh.ufl_cell().cellname()

--- a/tests/kernel_tests/test_gauss_elim_kernel.py
+++ b/tests/kernel_tests/test_gauss_elim_kernel.py
@@ -36,12 +36,12 @@ def setup_values(geometry, field_init, field_true, act_coords, eff_coords):
         # This would be described by a field with f = 2 - 3*x
         # The initial values at the eff coords would then be 0.5 and -1
 
-        set_val_at_point(act_coords, 0.0, field_init, 0.5)
-        set_val_at_point(act_coords, 1.0, field_init, -1.0)
-        set_val_at_point(act_coords, 0.0, field_true, 2.0)
-        set_val_at_point(act_coords, 1.0, field_true, -1.0)
-        set_val_at_point(act_coords, 0.0, eff_coords, 0.5)
-        set_val_at_point(act_coords, 1.0, eff_coords, 1.0)
+        set_val_at_point_DG(act_coords, 0.0, field_init, 0.5)
+        set_val_at_point_DG(act_coords, 1.0, field_init, -1.0)
+        set_val_at_point_DG(act_coords, 0.0, field_true, 2.0)
+        set_val_at_point_DG(act_coords, 1.0, field_true, -1.0)
+        set_val_at_point_DG(act_coords, 0.0, eff_coords, 0.5)
+        set_val_at_point_DG(act_coords, 1.0, eff_coords, 1.0)
 
     elif geometry == "2D":
         # We consider the unit-square cell: with act coords (0,0), (1,0), (0,1) and (1,1)
@@ -50,27 +50,27 @@ def setup_values(geometry, field_init, field_true, act_coords, eff_coords):
         # This would be described by a field with f = 2 - 3*x - 5*y + 7*x*y
         # The initial values at the eff coords would then be -0.25, 0, -1, 1
 
-        set_val_at_point(act_coords, [0.0, 0.0], field_init, -0.25)
-        set_val_at_point(act_coords, [1.0, 0.0], field_init, 0.0)
-        set_val_at_point(act_coords, [0.0, 1.0], field_init, -1.0)
-        set_val_at_point(act_coords, [1.0, 1.0], field_init, 1.0)
-        set_val_at_point(act_coords, [0.0, 0.0], field_true, 2.0)
-        set_val_at_point(act_coords, [1.0, 0.0], field_true, -1.0)
-        set_val_at_point(act_coords, [0.0, 1.0], field_true, -3.0)
-        set_val_at_point(act_coords, [1.0, 1.0], field_true, 1.0)
-        set_val_at_point(act_coords, [0.0, 0.0], eff_coords, [0.5, 0.5])
-        set_val_at_point(act_coords, [1.0, 0.0], eff_coords, [1.0, 0.5])
-        set_val_at_point(act_coords, [0.0, 1.0], eff_coords, [0.5, 1.0])
-        set_val_at_point(act_coords, [1.0, 1.0], eff_coords, [1.0, 1.0])
+        set_val_at_point_DG(act_coords, [0.0, 0.0], field_init, -0.25)
+        set_val_at_point_DG(act_coords, [1.0, 0.0], field_init, 0.0)
+        set_val_at_point_DG(act_coords, [0.0, 1.0], field_init, -1.0)
+        set_val_at_point_DG(act_coords, [1.0, 1.0], field_init, 1.0)
+        set_val_at_point_DG(act_coords, [0.0, 0.0], field_true, 2.0)
+        set_val_at_point_DG(act_coords, [1.0, 0.0], field_true, -1.0)
+        set_val_at_point_DG(act_coords, [0.0, 1.0], field_true, -3.0)
+        set_val_at_point_DG(act_coords, [1.0, 1.0], field_true, 1.0)
+        set_val_at_point_DG(act_coords, [0.0, 0.0], eff_coords, [0.5, 0.5])
+        set_val_at_point_DG(act_coords, [1.0, 0.0], eff_coords, [1.0, 0.5])
+        set_val_at_point_DG(act_coords, [0.0, 1.0], eff_coords, [0.5, 1.0])
+        set_val_at_point_DG(act_coords, [1.0, 1.0], eff_coords, [1.0, 1.0])
 
     return field_init, field_true, act_coords, eff_coords
 
 
-def set_val_at_point(coord_field, coords, field=None, new_value=None):
+def set_val_at_point_DG(coord_field, coords, field=None, new_value=None):
     """
-    Finds the DoF of a field at a particular coordinate. If new_value is
-    provided then it also assigns the coefficient for the field there to be
-    new_value. Otherwise the DoF index is returned.
+    Finds the DoFs of a field at a particular coordinate. If new_value is
+    provided then it also assigns all the coefficients for the field at this
+    coordinate to be new_value. Otherwise the list of DoF indices is returned.
     """
     num_points = len(coord_field.dat.data[:])
     point_indices = []
@@ -88,7 +88,7 @@ def set_val_at_point(coord_field, coords, field=None, new_value=None):
         return point_indices
 
 
-@pytest.mark.parametrize("geometry", ["1D"])
+@pytest.mark.parametrize("geometry", ["1D", "2D"])
 def test_gaussian_elimination(geometry, mesh):
 
     cell = mesh.ufl_cell().cellname()

--- a/tests/recovery_tests/test_recovery_1d.py
+++ b/tests/recovery_tests/test_recovery_1d.py
@@ -46,7 +46,6 @@ def expr(geometry, mesh):
 
 
 @pytest.mark.parametrize("geometry", ["periodic", "non-periodic"])
-@pytest.mark.xfail
 def test_1D_recovery(geometry, mesh, expr):
 
     # horizontal base spaces

--- a/tests/recovery_tests/test_recovery_2d_cart.py
+++ b/tests/recovery_tests/test_recovery_2d_cart.py
@@ -66,7 +66,6 @@ def expr(geometry, mesh):
 @pytest.mark.parametrize("geometry", ["periodic-in-both", "periodic-in-x",
                                       "periodic-in-y", "non-periodic"])
 @pytest.mark.parametrize("element", ["quadrilateral", "triangular"])
-@pytest.mark.xfail
 def test_2D_cartesian_recovery(geometry, element, mesh, expr):
 
     family = "RTCF" if element == "quadrilateral" else "BDM"

--- a/tests/recovery_tests/test_recovery_2d_vert_slice.py
+++ b/tests/recovery_tests/test_recovery_2d_vert_slice.py
@@ -55,7 +55,6 @@ def expr(geometry, mesh):
 
 
 @pytest.mark.parametrize("geometry", ["periodic", "non-periodic"])
-@pytest.mark.xfail
 def test_vertical_slice_recovery(geometry, mesh, expr):
 
     # horizontal base spaces

--- a/tests/recovery_tests/test_recovery_3d_cart.py
+++ b/tests/recovery_tests/test_recovery_3d_cart.py
@@ -73,7 +73,6 @@ def expr(geometry, mesh):
 @pytest.mark.parametrize("geometry", ["periodic-in-both", "periodic-in-x",
                                       "periodic-in-y", "non-periodic"])
 @pytest.mark.parametrize("element", ["quadrilateral", "triangular"])
-@pytest.mark.xfail
 def test_3D_cartesian_recovery(geometry, element, mesh, expr):
 
     family = "RTCF" if element == "quadrilateral" else "BDM"

--- a/tests/test_recovered_space.py
+++ b/tests/test_recovered_space.py
@@ -2,7 +2,6 @@ from gusto import *
 from firedrake import (as_vector, Constant, PeriodicIntervalMesh,
                        SpatialCoordinate, ExtrudedMesh, FunctionSpace,
                        Function, conditional, sqrt)
-import pytest
 
 # This setup creates a sharp bubble of warm air in a vertical slice
 # This bubble is then advected by a prescribed advection scheme
@@ -92,7 +91,6 @@ def run_recovered_space(dirname):
     stepper.run(t=0, tmax=tmax)
 
 
-@pytest.mark.xfail
 def test_recovered_space_setup(tmpdir):
 
     dirname = str(tmpdir)

--- a/tests/test_saturated_balance.py
+++ b/tests/test_saturated_balance.py
@@ -3,7 +3,6 @@ from firedrake import (PeriodicIntervalMesh, ExtrudedMesh, Constant, Function,
                        FunctionSpace, BrokenElement, VectorFunctionSpace)
 from os import path
 from netCDF4 import Dataset
-import pytest
 
 # this tests the moist-saturated hydrostatic balance, by setting up a vertical slice
 # with this initial procedure, before taking a few time steps and ensuring that
@@ -135,7 +134,6 @@ def run_saturated(dirname):
     stepper.run(t=0, tmax=tmax)
 
 
-@pytest.mark.xfail
 def test_saturated_setup(tmpdir):
 
     dirname = str(tmpdir)

--- a/tests/test_unsaturated_balance.py
+++ b/tests/test_unsaturated_balance.py
@@ -3,7 +3,6 @@ from firedrake import (PeriodicIntervalMesh, ExtrudedMesh, Constant, Function,
                        FunctionSpace, BrokenElement, VectorFunctionSpace)
 from os import path
 from netCDF4 import Dataset
-import pytest
 
 # this tests the moist-unsaturated hydrostatic balance, by setting up a vertical slice
 # with this initial procedure, before taking a few time steps and ensuring that
@@ -134,7 +133,6 @@ def run_unsaturated(dirname):
     stepper.run(t=0, tmax=tmax)
 
 
-@pytest.mark.xfail
 def test_unsaturated_setup(tmpdir):
 
     dirname = str(tmpdir)


### PR DESCRIPTION
This PR does three things:
- rewrites the kernel tests, so that they do not assume specific a specific numbering of the DoFs in a function space. I do this by introducing a new function, `set_val_at_point`, which takes the coordinate and returns the number of the DoF at that coordinate.
- fixes the Gaussian elimination kernel, by ensuring that the array of Taylor expansion coefficients is initialised
- since all the tests are now passing, removes the `xfail` markings