### PR TITLE
Small fix to keep up-to-date with Firedrake

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -101,9 +101,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # first setup the background buoyancy profile
 # z.grad(bref) = N**2

--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -80,9 +80,9 @@ theta0 = state.fields.theta
 rho0 = state.fields.rho
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Initial conditions with u0
 uexpr = as_vector([-u_max*x[1]/a, u_max*x[0]/a, 0.0])

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -54,9 +54,9 @@ for delta, dt in res_dt.items():
     theta0 = state.fields("theta")
 
     # spaces
-    Vu = u0.function_space()
-    Vt = theta0.function_space()
-    Vr = rho0.function_space()
+    Vu = state.spaces("HDiv")
+    Vt = state.spaces("HDiv_v")
+    Vr = state.spaces("DG")
 
     # Isentropic background state
     Tsurf = Constant(300.)

--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -73,9 +73,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 x, z = SpatialCoordinate(mesh)
 
 # Define constant theta_e and water_t

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -104,9 +104,9 @@ b0 = state.fields("b")
 p0 = state.fields("p")
 
 # spaces
-Vu = u0.function_space()
-Vb = b0.function_space()
-Vp = p0.function_space()
+Vu = state.spaces("HDiv")
+Vb = state.spaces("HDiv_v")
+Vp = state.spaces("DG")
 
 # parameters
 x, y, z = SpatialCoordinate(mesh)

--- a/examples/moist_bf_bubble.py
+++ b/examples/moist_bf_bubble.py
@@ -78,9 +78,9 @@ water_c0 = state.fields("water_c", theta0.function_space())
 moisture = ["water_v", "water_c"]
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 x, z = SpatialCoordinate(mesh)
 quadrature_degree = (4, 4)
 dxp = dx(degree=(quadrature_degree))

--- a/examples/mountain_hydrostatic.py
+++ b/examples/mountain_hydrostatic.py
@@ -80,9 +80,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Thermodynamic constants required for setting initial conditions
 # and reference profiles

--- a/examples/mountain_nonhydrostatic.py
+++ b/examples/mountain_nonhydrostatic.py
@@ -76,9 +76,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Thermodynamic constants required for setting initial conditions
 # and reference profiles

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -48,9 +48,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Isentropic background state
 Tsurf = Constant(300.)

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -55,9 +55,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Thermodynamic constants required for setting initial conditions
 # and reference profiles

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -45,9 +45,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Thermodynamic constants required for setting initial conditions
 # and reference profiles

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -59,9 +59,9 @@ rho0 = state.fields("rho")
 theta0 = state.fields("theta")
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 
 # Thermodynamic constants required for setting initial conditions
 # and reference profiles

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -55,9 +55,9 @@ for delta, dt in res_dt.items():
     water0 = state.fields("water", theta0.function_space())
 
     # spaces
-    Vu = u0.function_space()
-    Vt = theta0.function_space()
-    Vr = rho0.function_space()
+    Vu = state.spaces("HDiv")
+    Vt = state.spaces("HDiv_v")
+    Vr = state.spaces("DG")
 
     # Isentropic background state
     Tsurf = Constant(300.)

--- a/examples/unsaturated_bubble.py
+++ b/examples/unsaturated_bubble.py
@@ -72,9 +72,9 @@ rain0 = state.fields("rain", theta0.function_space())
 moisture = ["water_v", "water_c", "rain"]
 
 # spaces
-Vu = u0.function_space()
-Vt = theta0.function_space()
-Vr = rho0.function_space()
+Vu = state.spaces("HDiv")
+Vt = state.spaces("HDiv_v")
+Vr = state.spaces("DG")
 Vt_brok = FunctionSpace(mesh, BrokenElement(Vt.ufl_element()))
 x, z = SpatialCoordinate(mesh)
 quadrature_degree = (4, 4)

--- a/gusto/eady_diagnostics.py
+++ b/gusto/eady_diagnostics.py
@@ -75,7 +75,7 @@ class GeostrophicImbalance(DiagnosticField):
         b = state.fields("b")
         p = state.fields("p")
         f = state.parameters.f
-        Vu = u.function_space()
+        Vu = state.spaces("HDiv")
 
         v = TrialFunction(Vu)
         w = TestFunction(Vu)

--- a/gusto/kernels.py
+++ b/gusto/kernels.py
@@ -382,7 +382,7 @@ class PhysicsRecoveryTop():
                  args={"DG1": (v_DG1, WRITE),
                        "CG1": (v_CG1, READ)},
                  is_loopy_kernel=True,
-                 iterate=ON_TOP)
+                 iteration_region=ON_TOP)
 
 
 class PhysicsRecoveryBottom():
@@ -418,4 +418,4 @@ class PhysicsRecoveryBottom():
                  args={"DG1": (v_DG1, WRITE),
                        "CG1": (v_CG1, READ)},
                  is_loopy_kernel=True,
-                 iterate=ON_BOTTOM)
+                 iteration_region=ON_BOTTOM)

--- a/gusto/preconditioners.py
+++ b/gusto/preconditioners.py
@@ -192,7 +192,6 @@ class VerticalHybridizationPC(PCBase):
 
         # Assemble the Schur complement operator and right-hand side
         self.schur_rhs = Function(Vv_tr)
-        print('Create schur_rhs assembly callable')
         self._assemble_Srhs = OneFormAssembler(
             K * Atilde.inv * AssembledVector(self.broken_residual),
             tensor=self.schur_rhs,
@@ -205,7 +204,6 @@ class VerticalHybridizationPC(PCBase):
                                  form_compiler_parameters=self.ctx.fc_params,
                                  mat_type=mat_type,
                                  options_prefix=prefix)
-        print('Create schur assembly callable')
         self._assemble_S = TwoFormAssembler(schur_comp,
                                             tensor=self.S,
                                             bcs=trace_bcs,
@@ -271,14 +269,12 @@ class VerticalHybridizationPC(PCBase):
         R = K_1.T - C * A.inv * K_0.T
         u_rec = M.solve(f - C * A.inv * g - R * lambdar,
                         decomposition="PartialPivLU")
-        print('Create u_rec assembly callable')
         self._sub_unknown = OneFormAssembler(u_rec,
                                              tensor=u,
                                              form_compiler_parameters=self.ctx.fc_params).assemble
 
         sigma_rec = A.solve(g - B * AssembledVector(u) - K_0.T * lambdar,
                             decomposition="PartialPivLU")
-        print('Create sigma_rec assembly callable')
         self._elim_unknown = OneFormAssembler(sigma_rec,
                                               tensor=sigma,
                                               form_compiler_parameters=self.ctx.fc_params).assemble

--- a/gusto/preconditioners.py
+++ b/gusto/preconditioners.py
@@ -51,8 +51,8 @@ class VerticalHybridizationPC(PCBase):
                                FiniteElement, TensorProductElement,
                                TrialFunction, TrialFunctions, TestFunction,
                                DirichletBC, interval, MixedElement, BrokenElement)
-        from firedrake.assemble import (allocate_matrix,
-                                        create_assembly_callable)
+        from firedrake.assemble import (allocate_matrix, OneFormAssembler,
+                                        TwoFormAssembler)
         from firedrake.formmanipulation import split_form
         from ufl.algorithms.replace import replace
         from ufl.cell import TensorProductCell
@@ -192,10 +192,11 @@ class VerticalHybridizationPC(PCBase):
 
         # Assemble the Schur complement operator and right-hand side
         self.schur_rhs = Function(Vv_tr)
-        self._assemble_Srhs = create_assembly_callable(
+        print('Create schur_rhs assembly callable')
+        self._assemble_Srhs = OneFormAssembler(
             K * Atilde.inv * AssembledVector(self.broken_residual),
             tensor=self.schur_rhs,
-            form_compiler_parameters=self.ctx.fc_params)
+            form_compiler_parameters=self.ctx.fc_params).assemble
 
         mat_type = PETSc.Options().getString(prefix + "mat_type", "aij")
 
@@ -204,11 +205,11 @@ class VerticalHybridizationPC(PCBase):
                                  form_compiler_parameters=self.ctx.fc_params,
                                  mat_type=mat_type,
                                  options_prefix=prefix)
-        self._assemble_S = create_assembly_callable(schur_comp,
-                                                    tensor=self.S,
-                                                    bcs=trace_bcs,
-                                                    form_compiler_parameters=self.ctx.fc_params,
-                                                    mat_type=mat_type)
+        print('Create schur assembly callable')
+        self._assemble_S = TwoFormAssembler(schur_comp,
+                                            tensor=self.S,
+                                            bcs=trace_bcs,
+                                            form_compiler_parameters=self.ctx.fc_params).assemble
 
         self._assemble_S()
         Smat = self.S.petscmat
@@ -242,7 +243,7 @@ class VerticalHybridizationPC(PCBase):
                              contribution in the hybridized mixed system.
         """
 
-        from firedrake.assemble import create_assembly_callable
+        from firedrake.assemble import OneFormAssembler
 
         # We always eliminate the velocity block first
         id0, id1 = (self.vidx, self.pidx)
@@ -270,15 +271,17 @@ class VerticalHybridizationPC(PCBase):
         R = K_1.T - C * A.inv * K_0.T
         u_rec = M.solve(f - C * A.inv * g - R * lambdar,
                         decomposition="PartialPivLU")
-        self._sub_unknown = create_assembly_callable(u_rec,
-                                                     tensor=u,
-                                                     form_compiler_parameters=self.ctx.fc_params)
+        print('Create u_rec assembly callable')
+        self._sub_unknown = OneFormAssembler(u_rec,
+                                             tensor=u,
+                                             form_compiler_parameters=self.ctx.fc_params).assemble
 
         sigma_rec = A.solve(g - B * AssembledVector(u) - K_0.T * lambdar,
                             decomposition="PartialPivLU")
-        self._elim_unknown = create_assembly_callable(sigma_rec,
-                                                      tensor=sigma,
-                                                      form_compiler_parameters=self.ctx.fc_params)
+        print('Create sigma_rec assembly callable')
+        self._elim_unknown = OneFormAssembler(sigma_rec,
+                                              tensor=sigma,
+                                              form_compiler_parameters=self.ctx.fc_params).assemble
 
     @timed_function("VertHybridRecon")
     def _reconstruct(self):

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -387,7 +387,7 @@ class State(object):
             for name in self.output.dumplist_latlon:
                 f = self.fields(name)
                 field = Function(
-                    functionspaceimpl.WithGeometry(
+                    functionspaceimpl.WithGeometry.create(
                         f.function_space(), mesh_ll),
                     val=f.topological, name=name+'_ll')
                 self.to_dump_latlon.append(field)

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -263,7 +263,7 @@ class State(object):
         self.fields = FieldCreator(fieldlist, self.xn, self.output.dumplist)
 
         # set up bcs
-        V = self.fields('u').function_space()
+        V = self.spaces("HDiv")
         self.bcs = []
         if V.extruded:
             self.bcs.append(DirichletBC(V, 0.0, "bottom"))


### PR DESCRIPTION
This is a series of changes to keep Gusto up-to-date with Firedrake. At first I just hoped it was a simple one line change but it's ended up requiring quite a bit!

These changes are:
* updating `functionspaceimpl.WithGeometry(...)` to `functionspaceimpl.WithGeometry.create(...)` following the changes in Firedrake at https://github.com/firedrakeproject/firedrake/commit/f8f30a9051f360f96b2fdb13f78aea5113b72f11
* changing `iterate` to `iteration_region` for the parloop kernels in `kernels.py` that only run in the top / bottom layers of an extruded mesh
* changing the spaces used by `DirichletBC` so that it is a pure function space, and not a subspace of a `MixedFunctionSpace`
* changing the way function spaces are extracted from `state` for our examples. This was only necessary for those that use diffusion (because this requires BCs to be set up), but to keep the examples consistent I have changed all of those that get function spaces from `state`
* in `linear_solvers.py`, the boundary conditions are required for a mixed problem, so I have added some code to convert `state.bcs` to the appropriate boundary conditions there
* avoiding the warnings for `create_assembly_callable` being deprecated, by removing these in `preconditioners.py`