### PR TITLE
Active Tracers

### DIFF
--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -62,7 +62,10 @@ if diffusion:
 else:
     diffusion_options = None
 
+u_advection_option = "vector_advection_form" if recovered else "vector_invariant_form"
+
 eqns = CompressibleEulerEquations(state, "CG", degree,
+                                  u_advection_option=u_advection_option,
                                   diffusion_options=diffusion_options,
                                   no_normal_flow_bc_ids=[1, 2])
 
@@ -114,7 +117,7 @@ state.set_reference_profiles([('rho', rho_b),
 
 # Set up advection schemes
 if recovered:
-    VDG1 = state.spaces("DG1")
+    VDG1 = state.spaces("DG1", "DG", 1)
     VCG1 = FunctionSpace(mesh, "CG", 1)
     Vt_brok = FunctionSpace(mesh, BrokenElement(Vt.ufl_element()))
     Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())

--- a/examples/moist_bf_bubble.py
+++ b/examples/moist_bf_bubble.py
@@ -58,6 +58,7 @@ output = OutputParameters(dirname=dirname,
 params = CompressibleParameters()
 diagnostic_fields = [Theta_e(), InternalEnergy(),
                      Perturbation('InternalEnergy'), PotentialEnergy()]
+tracers = [WaterVapour(), CloudWater()]
 
 state = State(mesh,
               dt=dt,
@@ -65,15 +66,15 @@ state = State(mesh,
               parameters=params,
               diagnostic_fields=diagnostic_fields)
 
-eqns = MoistCompressibleEulerEquations(state, "CG", degree)
+eqns = CompressibleEulerEquations(state, "CG", degree, tracers=tracers)
 
 # Initial conditions
 u0 = state.fields("u")
 rho0 = state.fields("rho")
 theta0 = state.fields("theta")
-water_v0 = state.fields("water_v")
-water_c0 = state.fields("water_c")
-moisture = ["water_v", "water_c"]
+water_v0 = state.fields("vapour_mixing_ratio")
+water_c0 = state.fields("cloud_liquid_mixing_ratio")
+moisture = ["vapour_mixing_ratio", "cloud_liquid_mixing_ratio"]
 
 # spaces
 Vu = state.spaces("HDiv")
@@ -153,11 +154,12 @@ water_c0.assign(water_t - water_v0)
 
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b),
-                              ('water_v', water_vb)])
+                              ('vapour_mixing_ratio', water_vb)])
 
 # set up limiter
 if limit:
     if recovered:
+        VDG1 = state.spaces("DG1", "DG", 1)
         limiter = VertexBasedLimiter(VDG1)
     else:
         limiter = ThetaLimiter(Vt)
@@ -167,7 +169,7 @@ else:
 
 # Set up advection schemes
 if recovered:
-    VDG1 = state.spaces("DG", "DG", 1)
+    VDG1 = state.spaces("DG1", "DG", 1)
     VCG1 = FunctionSpace(mesh, "CG", 1)
     Vt_brok = FunctionSpace(mesh, BrokenElement(Vt.ufl_element()))
     Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())
@@ -184,17 +186,17 @@ if recovered:
     theta_opts = RecoveredOptions(embedding_space=VDG1,
                                   recovered_space=VCG1,
                                   broken_space=Vt_brok)
-    u_advection = SSPRK3(state, "u")
+    u_advection = SSPRK3(state, "u", options=u_opts)
 else:
     rho_opts = None
     theta_opts = EmbeddedDGOptions()
     u_advection = ImplicitMidpoint(state, "u")
 
-advected_fields = [u_advection,
-                   SSPRK3(state, "rho", options=rho_opts),
+advected_fields = [SSPRK3(state, "rho", options=rho_opts),
                    SSPRK3(state, "theta", options=theta_opts, limiter=limiter),
-                   SSPRK3(state, "water_v", options=theta_opts, limiter=limiter),
-                   SSPRK3(state, "water_c", options=theta_opts, limiter=limiter)]
+                   SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
+                   SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
+                   u_advection]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)

--- a/examples/moist_bf_bubble.py
+++ b/examples/moist_bf_bubble.py
@@ -66,7 +66,7 @@ state = State(mesh,
               parameters=params,
               diagnostic_fields=diagnostic_fields)
 
-eqns = CompressibleEulerEquations(state, "CG", degree, tracers=tracers)
+eqns = CompressibleEulerEquations(state, "CG", degree, active_tracers=tracers)
 
 # Initial conditions
 u0 = state.fields("u")

--- a/examples/unsaturated_bubble.py
+++ b/examples/unsaturated_bubble.py
@@ -45,10 +45,11 @@ if diffusion:
     dirname += '_diffusion'
 
 output = OutputParameters(dirname=dirname, dumpfreq=20,
-                          perturbation_fields=['theta', 'water_v', 'rho'],
+                          perturbation_fields=['theta', 'vapour_mixing_ratio', 'rho'],
                           log_level='INFO')
 params = CompressibleParameters()
 diagnostic_fields = [RelativeHumidity(), Theta_e()]
+tracers = [WaterVapour(), CloudWater(), Rain()]
 
 state = State(mesh,
               dt=dt,
@@ -61,17 +62,18 @@ if diffusion:
 else:
     diffusion_options = None
 
-eqns = MoistCompressibleEulerEquations(state, "CG", 1,
-                                       diffusion_options=diffusion_options)
+eqns = CompressibleEulerEquations(state, "CG", degree,
+                                  diffusion_options=diffusion_options,
+                                  tracers=tracers)
 
 # Initial conditions
 u0 = state.fields("u")
 rho0 = state.fields("rho")
 theta0 = state.fields("theta")
-water_v0 = state.fields("water_v")
-water_c0 = state.fields("water_c")
+water_v0 = state.fields("vapour_mixing_ratio")
+water_c0 = state.fields("cloud_liquid_mixing_ratio")
 rain0 = state.fields("rain", theta0.function_space())
-moisture = ["water_v", "water_c", "rain"]
+moisture = ["vapour_mixing_ratio", "cloud_liquid_mixing_ratio", "rain_mixing_ratio"]
 
 # spaces
 Vu = state.spaces("HDiv")
@@ -84,7 +86,7 @@ dxp = dx(degree=(quadrature_degree))
 physics_boundary_method = None
 
 if recovered:
-    VDG1 = state.spaces("DG1")
+    VDG1 = state.spaces("DG1", "DG", 1)
     VCG1 = FunctionSpace(mesh, "CG", 1)
     Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())
     Vu_CG1 = VectorFunctionSpace(mesh, "CG", 1)
@@ -99,8 +101,7 @@ if recovered:
                                 boundary_method=Boundary_Method.dynamics)
     theta_opts = RecoveredOptions(embedding_space=VDG1,
                                   recovered_space=VCG1,
-                                  broken_space=Vt_brok,
-                                  boundary_method=Boundary_Method.dynamics)
+                                  broken_space=Vt_brok)
     physics_boundary_method = Boundary_Method.physics
 
 # Define constant theta_e and water_t
@@ -208,11 +209,11 @@ for i in range(max_outer_solve_count):
 # initialise fields
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b),
-                              ('water_v', water_vb)])
+                              ('vapour_mixing_ratio', water_vb)])
 
 # Set up advection schemes
 if recovered:
-    u_advection = SSPRK3(state, "u")
+    u_advection = SSPRK3(state, "u", options=u_opts)
     rho_opts = EmbeddedDGOptions()
     theta_opts = EmbeddedDGOptions()
     limiter = VertexBasedLimiter(VDG1)
@@ -226,9 +227,9 @@ else:
 advected_fields = [u_advection,
                    SSPRK3(state, "rho", options=rho_opts),
                    SSPRK3(state, "theta", options=theta_opts),
-                   SSPRK3(state, "water_v", limiter=limiter),
-                   SSPRK3(state, "water_c", limiter=limiter),
-                   SSPRK3(state, "rain", limiter=limiter)]
+                   SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
+                   SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
+                   SSPRK3(state, "rain_mixing_ratio", options=theta_opts, limiter=limiter)]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)

--- a/examples/unsaturated_bubble.py
+++ b/examples/unsaturated_bubble.py
@@ -64,7 +64,7 @@ else:
 
 eqns = CompressibleEulerEquations(state, "CG", degree,
                                   diffusion_options=diffusion_options,
-                                  tracers=tracers)
+                                  active_tracers=tracers)
 
 # Initial conditions
 u0 = state.fields("u")

--- a/gusto/__init__.py
+++ b/gusto/__init__.py
@@ -16,4 +16,4 @@ from gusto.state import *                            # noqa
 from gusto.timeloop import *                         # noqa
 from gusto.transport_equation import *               # noqa
 from gusto.fml import *                              # noqa
-from gusto.tracers import *                          # noqa
+from gusto.active_tracers import *                   # noqa

--- a/gusto/__init__.py
+++ b/gusto/__init__.py
@@ -16,3 +16,4 @@ from gusto.state import *                            # noqa
 from gusto.timeloop import *                         # noqa
 from gusto.transport_equation import *               # noqa
 from gusto.fml import *                              # noqa
+from gusto.tracers import *                          # noqa

--- a/gusto/active_tracers.py
+++ b/gusto/active_tracers.py
@@ -1,11 +1,18 @@
+"""
+This file contains the ActiveTracer class, which contains the metadata to
+augment equation sets with additional active tracer variables. Some specific
+commonly used tracers are also provided.
+
+Enumerators are also defined to encode different aspects of the tracers (e.g.
+what type of variable the tracer is, what phase it is, etc).
+"""
+
 from enum import Enum
 
 __all__ = ["TransportEquationForm", "TracerVariableType", "Phases",
-           "Tracer", "PassiveTracer", "ActiveTracer", "WaterVapour",
-           "CloudWater", "Rain"]
+           "ActiveTracer", "WaterVapour", "CloudWater", "Rain"]
 
 
-# TODO: Move this to somewhere else
 class TransportEquationForm(Enum):
     """
     An Enum object which stores the forms of the transport equation. For
@@ -47,50 +54,12 @@ class Phases(Enum):
     plasma = 2000  # Why not!
 
 
-class Tracer(object):
+class ActiveTracer(object):
     """
-    Base class for declaring the metadata for a tracer variable.
-
-    :arg name:           A string naming the tracer field.
-    :arg space:          A string indicating the function space for the variable.
-    :arg transport_flag: A Boolean indicating if the variable is transported.
-    :arg transport_eqn:  A TransportEquationForm Enum indicating the form of
-                         the transport equation to be used.
-    """
-    def __init__(self, name, space, transport_flag,
-                 transport_eqn=TransportEquationForm.no_transport):
-
-        if transport_flag and transport_eqn == TransportEquationForm.no_transport:
-            raise ValueError('If tracer is to be transported, transport_eqn must be specified')
-        elif not transport_flag and transport_eqn != TransportEquationForm.no_transport:
-            raise ValueError('If tracer is not to be transported, transport_eqn must be no_transport')
-
-        self.name = name
-        self.space = space
-        self.transport_flag = transport_flag
-        self.transport_eqn = transport_eqn
-
-
-class PassiveTracer(Tracer):
-    """
-    A class containing the metadata for a passive tracer variable. This
-    variable does not feed back onto the prognostic variables.
-
-    :arg name:           A string naming the tracer field.
-    :arg space:          A string indicating the function space for the variable.
-    :arg transport_flag: A Boolean indicating if the variable is transported.
-    :arg transport_eqn:  A TransportEquationForm Enum indicating the form of
-                         the transport equation to be used.
-    """
-    def __init__(self, name, space, transport_flag=True,
-                 transport_eqn=TransportEquationForm.advective):
-        super().__init__(name, space, transport_flag, transport_eqn)
-
-
-class ActiveTracer(Tracer):
-    """
-    A class containing the metadata for an active tracer variable, which
-    interacts with the other variables.
+    A class containing the metadata to describe how an active tracer variable
+    is used within an equation set, being added as a component within the
+    MixedFunctionSpace as these variables interact strongly with the other
+    prognostic variables.
 
     :arg name:           A string naming the tracer field.
     :arg space:          A string indicating the function space for the variable.
@@ -105,8 +74,16 @@ class ActiveTracer(Tracer):
     def __init__(self, name, space, variable_type, transport_flag=True,
                  transport_eqn=TransportEquationForm.advective,
                  phase=Phases.gas, is_moisture=False):
-        super().__init__(name, space, transport_flag, transport_eqn)
 
+        if transport_flag and transport_eqn == TransportEquationForm.no_transport:
+            raise ValueError('If tracer is to be transported, transport_eqn must be specified')
+        elif not transport_flag and transport_eqn != TransportEquationForm.no_transport:
+            raise ValueError('If tracer is not to be transported, transport_eqn must be no_transport')
+
+        self.name = name
+        self.space = space
+        self.transport_flag = transport_flag
+        self.transport_eqn = transport_eqn
         self.variable_type = variable_type
         self.phase = phase
         self.is_moisture = is_moisture
@@ -115,7 +92,9 @@ class ActiveTracer(Tracer):
 
 
 class WaterVapour(ActiveTracer):
-
+    """
+    An object encoding the details of water vapour as a tracer.
+    """
     def __init__(self, name='vapour', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_flag=True,
@@ -125,7 +104,9 @@ class WaterVapour(ActiveTracer):
 
 
 class CloudWater(ActiveTracer):
-
+    """
+    An object encoding the details of cloud water as a tracer.
+    """
     def __init__(self, name='cloud_liquid', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_flag=True,
@@ -135,7 +116,9 @@ class CloudWater(ActiveTracer):
 
 
 class Rain(ActiveTracer):
-
+    """
+    An object encoding the details of rain as a tracer.
+    """
     def __init__(self, name='rain', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_flag=True,

--- a/gusto/advection.py
+++ b/gusto/advection.py
@@ -2,7 +2,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, Projector, Interpolator,
                        BrokenElement, VectorElement, FunctionSpace,
-                       TestFunction, action, Constant, dot, grad, as_ufl)
+                       TestFunction, Constant, dot, grad, as_ufl)
 from firedrake.formmanipulation import split_form
 from firedrake.utils import cached_property
 import ufl

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -485,15 +485,15 @@ class ThermodynamicDiagnostic(DiagnosticField):
             self.rho_averaged = Function(space)
             self.recoverer = Recoverer(self.rho, self.rho_averaged, VDG=broken_space, boundary_method=boundary_method)
             try:
-                self.r_v = state.fields("water_v")
+                self.r_v = state.fields("vapour_mixing_ratio")
             except NotImplementedError:
                 self.r_v = Constant(0.0)
             try:
-                self.r_c = state.fields("water_c")
+                self.r_c = state.fields("cloud_liquid_mixing_ratio")
             except NotImplementedError:
                 self.r_c = Constant(0.0)
             try:
-                self.rain = state.fields("rain")
+                self.rain = state.fields("rain_mixing_ratio")
             except NotImplementedError:
                 self.rain = Constant(0.0)
 
@@ -647,7 +647,7 @@ class Precipitation(DiagnosticField):
             space = state.spaces("DG0", "DG", 0)
             super().setup(state, space=space)
 
-            rain = state.fields('rain')
+            rain = state.fields('rain_mixing_ratio')
             rho = state.fields('rho')
             v = state.fields('rainfall_velocity')
             self.phi = TestFunction(space)

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -315,7 +315,8 @@ class CompressibleEulerEquations(PrognosticEquation):
         theta_mass = linearisation(theta_mass, linear_theta_mass)
 
         mass_form = time_derivative(u_mass + rho_mass + theta_mass)
-        mass_form += tracer_mass_forms(X, tests, self.field_names, active_tracers)
+        if len(active_tracers) > 0:
+            mass_form += tracer_mass_forms(X, tests, self.field_names, active_tracers)
 
         # define velocity advection form
         if u_advection_option == "vector_invariant_form":
@@ -351,8 +352,8 @@ class CompressibleEulerEquations(PrognosticEquation):
         theta_adv = linearisation(theta_adv, linear_theta_adv)
 
         adv_form = subject(u_adv + rho_adv + theta_adv, X)
-        adv_form += tracer_transport_forms(state, X, tests, self.field_names, active_tracers)
-
+        if len(active_tracers) > 0:
+            adv_form += tracer_transport_forms(state, X, tests, self.field_names, active_tracers)
 
         # define pressure gradient form and its linearisation
         tracer_mr_total = zero_expr
@@ -487,7 +488,7 @@ class IncompressibleBoussinesqEquations(PrognosticEquation):
 
         spaces = state.spaces.build_compatible_spaces(family, degree)
 
-        if tracers is not None:
+        if active_tracers is not None:
             raise NotImplementedError('Tracers not implemented for Boussinesq equations')
 
         W = MixedFunctionSpace(spaces)

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -38,7 +38,7 @@ def replace_subject(new, idx=None):
                 else:
                     try:
                         replace_dict[split(subj)[idx]] = split(new)[idx]
-                    except:
+                    except IndexError:
                         replace_dict[split(subj)[idx]] = new
 
         else:

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -1,5 +1,5 @@
 import ufl
-from firedrake import Function, split
+from firedrake import Function, split, VectorElement
 from gusto.fml.form_manipulation_labelling import Term, Label, LabelledForm
 
 
@@ -35,8 +35,13 @@ def replace_subject(new, idx=None):
                 if idx is None:
                     for k, v in zip(split(subj), split(new)):
                         replace_dict[k] = v
+                # TODO: Could we do something better here?
+                elif isinstance(new.ufl_element(), VectorElement):
+                    replace_dict[split(subj)[idx]] = new
                 else:
                     try:
+                        # This needs to handle with MixedFunctionSpace and
+                        # VectorFunctionSpace differently
                         replace_dict[split(subj)[idx]] = split(new)[idx]
                     except IndexError:
                         replace_dict[split(subj)[idx]] = new

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -54,11 +54,12 @@ class Condensation(Physics):
         self.iterations = iterations
         # obtain our fields
         self.theta = state.fields('theta')
-        self.water_v = state.fields('water_v')
-        self.water_c = state.fields('water_c')
+        self.water_v = state.fields('vapour_mixing_ratio')
+        self.water_c = state.fields('cloud_liquid_mixing_ratio')
         rho = state.fields('rho')
         try:
-            rain = state.fields('rain')
+            # TODO: use the phase flag for the tracers here
+            rain = state.fields('rain_mixing_ratio')
             water_l = self.water_c + rain
         except NotImplementedError:
             water_l = self.water_c
@@ -186,8 +187,8 @@ class Fallout(Physics):
             advect_options = EmbeddedDGOptions()
 
         # need to define advection equation before limiter (as it is needed for the ThetaLimiter)
-        advection_equation = AdvectionEquation(state, Vt, "rain", outflow=True)
-        self.rain = state.fields("rain")
+        advection_equation = AdvectionEquation(state, Vt, "rain_mixing_ratio", outflow=True)
+        self.rain = state.fields("rain_mixing_ratio")
 
         if moments == AdvectedMoments.M0:
             # all rain falls at terminal velocity
@@ -275,8 +276,8 @@ class Coalescence(Physics):
         super().__init__(state)
 
         # obtain our fields
-        self.water_c = state.fields('water_c')
-        self.rain = state.fields('rain')
+        self.water_c = state.fields('cloud_liquid_mixing_ratio')
+        self.rain = state.fields('rain_mixing_ratio')
 
         # declare function space
         Vt = self.water_c.function_space()
@@ -338,11 +339,11 @@ class Evaporation(Physics):
 
         # obtain our fields
         self.theta = state.fields('theta')
-        self.water_v = state.fields('water_v')
-        self.rain = state.fields('rain')
+        self.water_v = state.fields('vapour_mixing_ratio')
+        self.rain = state.fields('rain_mixing_ratio')
         rho = state.fields('rho')
         try:
-            water_c = state.fields('water_c')
+            water_c = state.fields('cloud_liquid_mixing_ratio')
             water_l = self.rain + water_c
         except NotImplementedError:
             water_l = self.rain

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -581,8 +581,8 @@ class State(object):
                 # a Function
                 ref = self.fields(name+'bar', space=profile.function_space(), dump=False)
             else:
-                raise ValueError(f'When initialising reference profile {name}'+
-                                 f' the passed profile must be a Function')
+                raise ValueError(f'When initialising reference profile {name}'
+                                 + ' the passed profile must be a Function')
             ref.interpolate(profile)
 
 

--- a/gusto/tracers.py
+++ b/gusto/tracers.py
@@ -1,21 +1,144 @@
-from abc import ABCMeta
+from enum import Enum
+
+__all__ = ["TransportEquationForm", "TracerVariableType", "Phases",
+           "Tracer", "PassiveTracer", "ActiveTracer", "WaterVapour",
+           "CloudWater", "Rain"]
 
 
-class Tracer(object, metaclass=ABCMeta):
+# TODO: Move this to somewhere else
+class TransportEquationForm(Enum):
+    """
+    An Enum object which stores the forms of the transport equation. For
+    transporting velocity 'u' and transported quantity 'q', these equations are:
 
-    def __init__(self, name, space):
-        
+    advective: dq / dt + dot(u, grad(q)) = 0
+    conservative: dq / dt + div(q*u) = 0
+    """
 
-    @abstractproperty
-    def name(self):
-        pass
+    no_transport = 702
+    advective = 19
+    conservative = 291
 
-    @abstractproperty
-    def space(self):
-        pass
+
+class TracerVariableType(Enum):
+    """
+    An Enum object which stores the variable type of a tracer X. If the density
+    of tracer X is \rho_X, the density of dry air is \rho_d and the total
+    density is \rho_t then these variables are given by:
+
+    mixing ratio = \rho_X / \rho_d
+    specific_humidity = \rho_X / \rho_t
+    density = \rho_X
+    """
+
+    mixing_ratio = 25
+    specific_humidity = 644
+    density = 137
+
+
+class Phases(Enum):
+    """
+    An Enum object which describes the phase of a substance.
+    """
+
+    gas = 38
+    liquid = 112
+    solid = 83
+    plasma = 2000  # Why not!
+
+
+class Tracer(object):
+    """
+    Base class for declaring the metadata for a tracer variable.
+
+    :arg name:           A string naming the tracer field.
+    :arg space:          A string indicating the function space for the variable.
+    :arg transport_flag: A Boolean indicating if the variable is transported.
+    :arg transport_eqn:  A TransportEquationForm Enum indicating the form of
+                         the transport equation to be used.
+    """
+    def __init__(self, name, space, transport_flag,
+                 transport_eqn=TransportEquationForm.no_transport):
+
+        if transport_flag and transport_eqn == TransportEquationForm.no_transport:
+            raise ValueError('If tracer is to be transported, transport_eqn must be specified')
+        elif not transport_flag and transport_eqn != TransportEquationForm.no_transport:
+            raise ValueError('If tracer is not to be transported, transport_eqn must be no_transport')
+
+        self.name = name
+        self.space = space
+        self.transport_flag = transport_flag
+        self.transport_eqn = transport_eqn
 
 
 class PassiveTracer(Tracer):
+    """
+    A class containing the metadata for a passive tracer variable. This
+    variable does not feed back onto the prognostic variables.
+
+    :arg name:           A string naming the tracer field.
+    :arg space:          A string indicating the function space for the variable.
+    :arg transport_flag: A Boolean indicating if the variable is transported.
+    :arg transport_eqn:  A TransportEquationForm Enum indicating the form of
+                         the transport equation to be used.
+    """
+    def __init__(self, name, space, transport_flag=True,
+                 transport_eqn=TransportEquationForm.advective):
+        super().__init__(name, space, transport_flag, transport_eqn)
 
 
 class ActiveTracer(Tracer):
+    """
+    A class containing the metadata for an active tracer variable, which
+    interacts with the other variables.
+
+    :arg name:           A string naming the tracer field.
+    :arg space:          A string indicating the function space for the variable.
+    :arg variable_type:  A TracerVariableType Enum indicating the type of tracer
+                         variable (e.g. mixing ratio or density).
+    :arg transport_flag: A Boolean indicating if the variable is transported.
+    :arg transport_eqn:  A TransportEquationForm Enum indicating the form of
+                         the transport equation to be used.
+    :arg phase:          A Phases Enum indicating the phase of the variable.
+    :arg is_moisture:    A Boolean indicating whether the variable is moisture.
+    """
+    def __init__(self, name, space, variable_type, transport_flag=True,
+                 transport_eqn=TransportEquationForm.advective,
+                 phase=Phases.gas, is_moisture=False):
+        super().__init__(name, space, transport_flag, transport_eqn)
+
+        self.variable_type = variable_type
+        self.phase = phase
+        self.is_moisture = is_moisture
+        if self.variable_type != TracerVariableType.mixing_ratio:
+            raise NotImplementedError('Only mixing ratio tracers are currently implemented')
+
+
+class WaterVapour(ActiveTracer):
+
+    def __init__(self, name='vapour', space='theta',
+                 variable_type=TracerVariableType.mixing_ratio,
+                 transport_flag=True,
+                 transport_eqn=TransportEquationForm.advective):
+        super().__init__(f'{name}_{variable_type.name}', space, variable_type,
+                         transport_flag, phase=Phases.gas, is_moisture=True)
+
+
+class CloudWater(ActiveTracer):
+
+    def __init__(self, name='cloud_liquid', space='theta',
+                 variable_type=TracerVariableType.mixing_ratio,
+                 transport_flag=True,
+                 transport_eqn=TransportEquationForm.advective):
+        super().__init__(f'{name}_{variable_type.name}', space, variable_type,
+                         transport_flag, phase=Phases.liquid, is_moisture=True)
+
+
+class Rain(ActiveTracer):
+
+    def __init__(self, name='rain', space='theta',
+                 variable_type=TracerVariableType.mixing_ratio,
+                 transport_flag=True,
+                 transport_eqn=TransportEquationForm.advective):
+        super().__init__(f'{name}_{variable_type.name}', space, variable_type,
+                         transport_flag, phase=Phases.liquid, is_moisture=True)

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -36,7 +36,7 @@ def setup_condens(dirname):
                   dt=dt,
                   output=output,
                   parameters=parameters,
-                  diagnostic_fields=[Sum('water_v', 'water_c')])
+                  diagnostic_fields=[Sum('vapour_mixing_ratio', 'cloud_liquid_mixing_ratio')])
 
     # spaces
     Vpsi = FunctionSpace(mesh, "CG", 2)
@@ -46,14 +46,14 @@ def setup_condens(dirname):
     # set up equations
     rhoeqn = ContinuityEquation(state, Vr, "rho", ufamily="CG", udegree=1)
     thetaeqn = AdvectionEquation(state, Vt, "theta")
-    wveqn = AdvectionEquation(state, Vt, "water_v")
-    wceqn = AdvectionEquation(state, Vt, "water_c")
+    wveqn = AdvectionEquation(state, Vt, "vapour_mixing_ratio")
+    wceqn = AdvectionEquation(state, Vt, "cloud_liquid_mixing_ratio")
 
     # declare initial fields
     u0 = state.fields("u")
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    water_v0 = state.fields("water_v")
+    water_v0 = state.fields("vapour_mixing_ratio")
 
     # make a gradperp
     gradperp = lambda u: as_vector([-u.dx(1), u.dx(0)])
@@ -122,7 +122,7 @@ def test_condens_setup(tmpdir):
     filename = path.join(dirname, "condens/diagnostics.nc")
     data = Dataset(filename, "r")
 
-    water = data.groups["water_v_plus_water_c"]
+    water = data.groups["vapour_mixing_ratio_plus_cloud_liquid_mixing_ratio"]
     total = water.variables["total"]
     water_t_0 = total[0]
     water_t_T = total[-1]

--- a/tests/test_precipitation.py
+++ b/tests/test_precipitation.py
@@ -28,7 +28,7 @@ def setup_fallout(dirname):
     dt = 0.1
     output = OutputParameters(dirname=dirname+"/fallout",
                               dumpfreq=10,
-                              dumplist=['rain'])
+                              dumplist=['rain_mixing_ratio'])
     parameters = CompressibleParameters()
     diagnostic_fields = [Precipitation()]
     state = State(mesh,
@@ -42,7 +42,7 @@ def setup_fallout(dirname):
     state.fields("rho").assign(1.)
 
     physics_list = [Fallout(state)]
-    rain0 = state.fields("rain")
+    rain0 = state.fields("rain_mixing_ratio")
 
     # set up rain
     xc = L / 2
@@ -77,7 +77,7 @@ def test_fallout_setup(tmpdir):
     filename = path.join(dirname, "fallout/diagnostics.nc")
     data = Dataset(filename, "r")
 
-    rain = data.groups["rain"]
+    rain = data.groups["rain_mixing_ratio"]
     final_rain = rain.variables["total"][-1]
     final_rms_rain = rain.variables["rms"][-1]
 

--- a/tests/test_saturated_balance.py
+++ b/tests/test_saturated_balance.py
@@ -29,7 +29,7 @@ def setup_saturated(dirname, recovered):
     # default should be to use lowest order set of spaces
     degree = 0 if recovered else 1
 
-    output = OutputParameters(dirname=dirname+'/saturated_balance', dumpfreq=1, dumplist=['u'], perturbation_fields=['water_v'])
+    output = OutputParameters(dirname=dirname+'/saturated_balance', dumpfreq=1, dumplist=['u'])
     parameters = CompressibleParameters()
     diagnostic_fields = [Theta_e()]
 
@@ -39,20 +39,22 @@ def setup_saturated(dirname, recovered):
                   parameters=parameters,
                   diagnostic_fields=diagnostic_fields)
 
+    tracers = [WaterVapour(), CloudWater()]
+
     if recovered:
         u_advection_option = "vector_advection_form"
     else:
         u_advection_option = "vector_invariant_form"
-    eqns = MoistCompressibleEulerEquations(
-        state, "CG", degree, u_advection_option=u_advection_option)
+    eqns = CompressibleEulerEquations(
+        state, "CG", degree, u_advection_option=u_advection_option, tracers=tracers)
 
     # Initial conditions
     u0 = state.fields("u")
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    water_v0 = state.fields("water_v")
-    water_c0 = state.fields("water_c")
-    moisture = ['water_v', 'water_c']
+    water_v0 = state.fields("vapour_mixing_ratio")
+    water_c0 = state.fields("cloud_liquid_mixing_ratio")
+    moisture = ['vapour_mixing_ratio', 'cloud_liquid_mixing_ratio']
 
     # spaces
     Vu = u0.function_space()
@@ -70,8 +72,7 @@ def setup_saturated(dirname, recovered):
     water_c0.assign(water_t - water_v0)
 
     state.set_reference_profiles([('rho', rho0),
-                                  ('theta', theta0),
-                                  ('water_v', water_v0)])
+                                  ('theta', theta0)])
 
     # Set up advection schemes
     if recovered:
@@ -107,8 +108,8 @@ def setup_saturated(dirname, recovered):
 
     advected_fields = [SSPRK3(state, 'rho', options=rho_opts),
                        SSPRK3(state, 'theta', options=theta_opts),
-                       SSPRK3(state, 'water_v', options=wv_opts),
-                       SSPRK3(state, 'water_c', options=wc_opts)]
+                       SSPRK3(state, 'vapour_mixing_ratio', options=wv_opts),
+                       SSPRK3(state, 'cloud_liquid_mixing_ratio', options=wc_opts)]
 
     if recovered:
         advected_fields.append(SSPRK3(state, 'u', options=u_opts))

--- a/tests/test_saturated_balance.py
+++ b/tests/test_saturated_balance.py
@@ -46,7 +46,7 @@ def setup_saturated(dirname, recovered):
     else:
         u_advection_option = "vector_invariant_form"
     eqns = CompressibleEulerEquations(
-        state, "CG", degree, u_advection_option=u_advection_option, tracers=tracers)
+        state, "CG", degree, u_advection_option=u_advection_option, active_tracers=tracers)
 
     # Initial conditions
     u0 = state.fields("u")

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,9 +1,9 @@
 """
-Tests various Gusto Tracer objects.
+Tests various Gusto ActiveTracer objects.
 """
 
-from gusto import (Tracer, PassiveTracer, ActiveTracer,
-                   TransportEquationForm, TracerVariableType, Phases)
+from gusto import (ActiveTracer, TransportEquationForm,
+                   TracerVariableType, Phases)
 import pytest
 
 def test_tracer_classes():
@@ -18,20 +18,7 @@ def test_tracer_classes():
     for name, space, transport_flag, transport_eqn in \
         zip(names, spaces, transport_flags, transport_eqns):
 
-        # Test Tracer base class
-        tracer = Tracer(name, space, transport_flag, transport_eqn)
-        assert tracer.name == name
-        assert tracer.space == space
-        assert tracer.transport_flag == transport_flag
-        assert tracer.transport_eqn == transport_eqn
-
-        # Test PassiveTracer base class
-        tracer = PassiveTracer(name, space, transport_flag, transport_eqn)
-        assert tracer.name == name
-        assert tracer.space == space
-        assert tracer.transport_flag == transport_flag
-        assert tracer.transport_eqn == transport_eqn
-
+        # Test active tracer class
         for variable_type in variable_types:
             tracer = ActiveTracer(name, space, variable_type,
                                   transport_flag, transport_eqn)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,43 @@
+"""
+Tests various Gusto Tracer objects.
+"""
+
+from gusto import (Tracer, PassiveTracer, ActiveTracer,
+                   TransportEquationForm, TracerVariableType, Phases)
+import pytest
+
+def test_tracer_classes():
+
+    names = ['mr_v', 'big_blob']
+    spaces = ['V', 'U']
+    transport_flags = [True, False]
+    transport_eqns = [TransportEquationForm.advective,
+                      TransportEquationForm.no_transport]
+    variable_types = [TracerVariableType.mixing_ratio]
+
+    for name, space, transport_flag, transport_eqn in \
+        zip(names, spaces, transport_flags, transport_eqns):
+
+        # Test Tracer base class
+        tracer = Tracer(name, space, transport_flag, transport_eqn)
+        assert tracer.name == name
+        assert tracer.space == space
+        assert tracer.transport_flag == transport_flag
+        assert tracer.transport_eqn == transport_eqn
+
+        # Test PassiveTracer base class
+        tracer = PassiveTracer(name, space, transport_flag, transport_eqn)
+        assert tracer.name == name
+        assert tracer.space == space
+        assert tracer.transport_flag == transport_flag
+        assert tracer.transport_eqn == transport_eqn
+
+        for variable_type in variable_types:
+            tracer = ActiveTracer(name, space, variable_type,
+                                  transport_flag, transport_eqn)
+            assert tracer.name == name
+            assert tracer.space == space
+            assert tracer.transport_flag == transport_flag
+            assert tracer.transport_eqn == transport_eqn
+            assert tracer.variable_type == variable_type
+            assert tracer.phase == Phases.gas

--- a/tests/test_unsaturated_balance.py
+++ b/tests/test_unsaturated_balance.py
@@ -44,7 +44,7 @@ def setup_unsaturated(dirname, recovered):
     else:
         u_advection_option = "vector_invariant_form"
     eqns = CompressibleEulerEquations(
-        state, "CG", degree, u_advection_option=u_advection_option, tracers=tracers)
+        state, "CG", degree, u_advection_option=u_advection_option, active_tracers=tracers)
 
     # Initial conditions
     u0 = state.fields("u")

--- a/tests/test_vector_recovered_space.py
+++ b/tests/test_vector_recovered_space.py
@@ -1,0 +1,94 @@
+from gusto import *
+from firedrake import (as_vector, Constant, PeriodicIntervalMesh,
+                       SpatialCoordinate, ExtrudedMesh, FunctionSpace,
+                       Function, conditional, sqrt, VectorFunctionSpace,
+                       FiniteElement, TensorProductElement, HDiv, interval)
+
+# This setup creates a sharp bubble of warm air in a vertical slice
+# This bubble is then advected by a prescribed advection scheme
+
+
+def run(state, advection_scheme, tmax):
+    timestepper = PrescribedAdvection(state, advection_scheme)
+    timestepper.run(0, tmax)
+
+
+def test_vector_recovered_space_setup(tmpdir):
+
+    # declare grid shape, with length L and height H
+    L = 400.
+    H = 400.
+    nlayers = int(H / 20.)
+    ncolumns = int(L / 20.)
+
+    # make mesh
+    m = PeriodicIntervalMesh(ncolumns, L)
+    mesh = ExtrudedMesh(m, layers=nlayers, layer_height=(H / nlayers))
+
+    dt = 1.0
+    output = OutputParameters(dirname=str(tmpdir), dumpfreq=5)
+
+    state = State(mesh,
+                  dt=dt,
+                  output=output)
+
+    # horizontal base spaces
+    cell = mesh._base_mesh.ufl_cell().cellname()
+    u_hori = FiniteElement("CG", cell, 1, variant="equispaced")
+    w_hori = FiniteElement("DG", cell, 0, variant="equispaced")
+
+    # vertical base spaces
+    u_vert = FiniteElement("DG", interval, 0, variant="equispaced")
+    w_vert = FiniteElement("CG", interval, 1, variant="equispaced")
+
+    # build elements
+    u_element = HDiv(TensorProductElement(u_hori, u_vert))
+    w_element = HDiv(TensorProductElement(w_hori, w_vert))
+    theta_element = TensorProductElement(w_hori, w_vert)
+    v_element = u_element + w_element
+
+    # spaces
+    Vpsi = FunctionSpace(mesh, "CG", 2)
+    VDG1 = state.spaces("DG", "DG", 1)
+    Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element(), name='Vec_DG1')
+    Vu_CG1 = VectorFunctionSpace(mesh, "CG", 1, name='Vec_CG1')
+    Vu = FunctionSpace(mesh, v_element)
+
+    tracereqn = AdvectionEquation(state, Vu, "tracer", ufamily="CG",
+                                  udegree=1)
+
+    # initialise fields
+    u0 = state.fields("u")
+
+    x, z = SpatialCoordinate(mesh)
+
+    # set up velocity field
+    u_max = Constant(10.0)
+    psi_expr = - u_max * z
+    psi0 = Function(Vpsi).interpolate(psi_expr)
+
+    # make a gradperp
+    gradperp = lambda u: as_vector([-u.dx(1), u.dx(0)])
+
+    u0.project(gradperp(psi0))
+
+    # set up bubble
+    xc = 200.
+    zc = 200.
+    rc = 100.
+    tracer = state.fields("tracer")
+    scalar_expr = conditional(sqrt((x - xc) ** 2.0) < rc,
+                              conditional(sqrt((z - zc) ** 2.0) < rc,
+                                          Constant(0.2),
+                                          Constant(0.0)), Constant(0.0))
+    tracer.project(as_vector([scalar_expr, scalar_expr]))
+
+    # set up advection scheme
+    recovered_opts = RecoveredOptions(embedding_space=Vu_DG1,
+                                      recovered_space=Vu_CG1,
+                                      broken_space=Vu,
+                                      boundary_method=Boundary_Method.dynamics)
+
+    advection_scheme = [(tracereqn, SSPRK3(state, options=recovered_opts))]
+
+    run(state, advection_scheme, tmax=10)


### PR DESCRIPTION
This PR introduces the `ActiveTracer` object to the FML branch.

The idea is to introduce a way to flexibly add active tracers (chiefly moisture) to equation sets, so that we don't require separate `Moist` versions of each equation set. The `ActiveTracer` class stores metadata describing an "active tracer" -- which interacts with the other prognostic variables and so needs including in the `MixedFunctionSpace` for the whole equation set.

Most of the work is done in `active_tracers.py` which introduces the object, and various enumerators to encode properties of the tracer being described. Some common tracer objects for moisture species are also provided. These are then added to the equation sets through routines in `equations.py`.

Along the way, I also:
- moved the `equation.field_names` to be set up in the `__init__` of the equation sets
- encounted an issue with the vector recovered transport. I've introduce a standalone test
- fixed some lint
- renamed some of the moisture variables (this isn't complete and I suggest following it up in a separate PR)
- fixed a handful of the examples that didn't work with the `recovered` settings 

----

**Issues still to solve before merging**:
- I have set the tracer transport forms to use `IntegrateByParts.TWICE` as is used in for transporting `theta`. However I'm not sure if we want to enforce that `theta` is always transported with this option. This should be addressed here or postponed to another PR.
- In the `repl` routine in `labels.py`, functions in a `MixedFunctionSpace` and a `VectorFunctionSpace` need handling separately (this caused failures when using the recovered transport scheme for the wind field). I've put in a temporary fix but there will be a better way to do this. 

----

**This should be extended in the future by**:
- adding the `active_tracers` to the other equation sets (it is currently not implemented for `Incompressible` or `ShallowWater` equations)
- this may be better facilitated introducing a new parent class, e.g. `PrognosticEquationSet`, and moving the routines to add `active_tracer` things to belong to that?
- adding support for tracer variable types that aren't mixing ratios. This might fit with a general consideration of how we create flexibility in which prognostic variables are used (and maybe even a Gibbs function approach?!)