### PR TITLE
Allow transport terms to be altered depending on transport options

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -129,14 +129,14 @@ u0.project(u_exp)
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
-advected_fields = [SSPRK3(state, "u"),
+# Set up transport schemes
+transported_fields = [SSPRK3(state, "u"),
                    SSPRK3(state, "rho"),
                    SSPRK3(state, "theta")]
 
 linear_solver = CompressibleSolver(state, eqns)
 
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -125,8 +125,8 @@ rho0.assign(rho_b)
 state.initialise([('u', u0), ('rho', rho0), ('theta', theta0)])
 state.set_reference_profiles([('rho', rho_b), ('theta', theta_b)])
 
-# Set up advection schemes
-advected_fields = [ImplicitMidpoint(state, "u"),
+# Set up transport schemes
+transported_fields = [ImplicitMidpoint(state, "u"),
                    SSPRK3(state, "rho", subcycles=2),
                    SSPRK3(state, "theta", options=SUPGOptions(), subcycles=2)]
 
@@ -134,7 +134,7 @@ advected_fields = [ImplicitMidpoint(state, "u"),
 linear_solver = CompressibleSolver(state, eqns)
 
 # Build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 # Run!

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -82,13 +82,13 @@ for delta, dt in res_dt.items():
     state.set_reference_profiles([('rho', rho_b),
                                   ('theta', theta_b)])
 
-    # Set up advection schemes
+    # Set up transport schemes
     supg = True
     if supg:
         theta_opts = SUPGOptions()
     else:
         thetaeqn = EmbeddedDGOptions()
-    advected_fields = [ImplicitMidpoint(state, "u"),
+    transported_fields = [ImplicitMidpoint(state, "u"),
                        SSPRK3(state, "rho"),
                        SSPRK3(state, "theta", options=theta_opts)]
 
@@ -99,7 +99,7 @@ for delta, dt in res_dt.items():
                          BackwardEuler(state, "theta")]
 
     # build time stepper
-    stepper = CrankNicolson(state, eqns, advected_fields,
+    stepper = CrankNicolson(state, eqns, transported_fields,
                             linear_solver=linear_solver,
                             diffusion_schemes=diffusion_schemes)
 

--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -62,10 +62,10 @@ if diffusion:
 else:
     diffusion_options = None
 
-u_advection_option = "vector_advection_form" if recovered else "vector_invariant_form"
+u_transport_option = "vector_advection_form" if recovered else "vector_invariant_form"
 
 eqns = CompressibleEulerEquations(state, "CG", degree,
-                                  u_advection_option=u_advection_option,
+                                  u_transport_option=u_transport_option,
                                   diffusion_options=diffusion_options,
                                   no_normal_flow_bc_ids=[1, 2])
 
@@ -115,7 +115,7 @@ rho_solver.solve()
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 if recovered:
     VDG1 = state.spaces("DG1", "DG", 1)
     VCG1 = FunctionSpace(mesh, "CG", 1)
@@ -148,12 +148,12 @@ if limit:
 else:
     limiter = None
 
-advected_fields = [SSPRK3(state, "rho", options=rho_opts),
+transported_fields = [SSPRK3(state, "rho", options=rho_opts),
                    SSPRK3(state, "theta", options=theta_opts, limiter=limiter)]
 if recovered:
-    advected_fields.append(SSPRK3(state, "u", options=u_opts))
+    transported_fields.append(SSPRK3(state, "u", options=u_opts))
 else:
-    advected_fields.append(ImplicitMidpoint(state, "u"))
+    transported_fields.append(ImplicitMidpoint(state, "u"))
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns)
@@ -163,7 +163,7 @@ if diffusion:
     diffusion_schemes.append(BackwardEuler(state, "u"))
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver,
                         diffusion_schemes=diffusion_schemes)
 

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -73,20 +73,20 @@ u0.project(uinit)
 # set the background buoyancy
 state.set_reference_profiles([('b', b_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 supg = True
 if supg:
     b_opts = SUPGOptions()
 else:
     b_opts = EmbeddedDGOptions()
-advected_fields = [ImplicitMidpoint(state, "u"),
+transported_fields = [ImplicitMidpoint(state, "u"),
                    SSPRK3(state, "b", options=b_opts)]
 
 # Set up linear solver for the timestepping scheme
 linear_solver = IncompressibleSolver(state, eqns)
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 # Run!

--- a/examples/incompressible_eady.py
+++ b/examples/incompressible_eady.py
@@ -121,17 +121,17 @@ u0.project(u_exp)
 state.set_reference_profiles([('p', p_b),
                               ('b', b_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 supg = True
 if supg:
     b_opts = SUPGOptions()
 else:
     b_opts = EmbeddedDGOptions()
-advected_fields = [SSPRK3(state, "u"), SSPRK3(state, "b", options=b_opts)]
+transported_fields = [SSPRK3(state, "u"), SSPRK3(state, "b", options=b_opts)]
 
 linear_solver = IncompressibleSolver(state, eqns)
 
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/moist_bf_bubble.py
+++ b/examples/moist_bf_bubble.py
@@ -167,7 +167,7 @@ else:
     limiter = None
 
 
-# Set up advection schemes
+# Set up transport schemes
 if recovered:
     VDG1 = state.spaces("DG1", "DG", 1)
     VCG1 = FunctionSpace(mesh, "CG", 1)
@@ -186,17 +186,17 @@ if recovered:
     theta_opts = RecoveredOptions(embedding_space=VDG1,
                                   recovered_space=VCG1,
                                   broken_space=Vt_brok)
-    u_advection = SSPRK3(state, "u", options=u_opts)
+    u_transport = SSPRK3(state, "u", options=u_opts)
 else:
     rho_opts = None
     theta_opts = EmbeddedDGOptions()
-    u_advection = ImplicitMidpoint(state, "u")
+    u_transport = ImplicitMidpoint(state, "u")
 
-advected_fields = [SSPRK3(state, "rho", options=rho_opts),
-                   SSPRK3(state, "theta", options=theta_opts, limiter=limiter),
-                   SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
-                   SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
-                   u_advection]
+transported_fields = [SSPRK3(state, "rho", options=rho_opts),
+                      SSPRK3(state, "theta", options=theta_opts, limiter=limiter),
+                      SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
+                      SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
+                      u_transport]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
@@ -216,7 +216,7 @@ if diffusion:
 physics_list = [Condensation(state)]
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver,
                         physics_list=physics_list,
                         diffusion_schemes=diffusion_schemes)

--- a/examples/mountain_hydrostatic.py
+++ b/examples/mountain_hydrostatic.py
@@ -140,13 +140,13 @@ remove_initial_w(u0)
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 supg = True
 if supg:
     theta_opts = SUPGOptions()
 else:
     theta_opts = EmbeddedDGOptions()
-advected_fields = [ImplicitMidpoint(state, "u"),
+transported_fields = [ImplicitMidpoint(state, "u"),
                    SSPRK3(state, "rho"),
                    SSPRK3(state, "theta", options=theta_opts)]
 
@@ -174,7 +174,7 @@ linear_solver = CompressibleSolver(state, eqns, alpha, solver_parameters=params,
                                    overwrite_solver_parameters=True)
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver,
                         alpha=alpha)
 

--- a/examples/mountain_nonhydrostatic.py
+++ b/examples/mountain_nonhydrostatic.py
@@ -134,13 +134,13 @@ remove_initial_w(u0)
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 supg = True
 if supg:
     theta_opts = SUPGOptions()
 else:
     theta_opts = EmbeddedDGOptions()
-advected_fields = [ImplicitMidpoint(state, "u"),
+transported_fields = [ImplicitMidpoint(state, "u"),
                    SSPRK3(state, "rho"),
                    SSPRK3(state, "theta", options=theta_opts)]
 
@@ -148,7 +148,7 @@ advected_fields = [ImplicitMidpoint(state, "u"),
 linear_solver = CompressibleSolver(state, eqns)
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/rising_bubble.py
+++ b/examples/rising_bubble.py
@@ -69,21 +69,21 @@ rho0.interpolate(rho_b)
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 supg = True
 if supg:
     theta_opts = SUPGOptions()
 else:
     theta_opts = EmbeddedDGOptions()
-advected_fields = []
-advected_fields.append(ImplicitMidpoint(state, "u"))
-advected_fields.append(SSPRK3(state, "rho"))
-advected_fields.append(SSPRK3(state, "theta", options=theta_opts))
+transported_fields = []
+transported_fields.append(ImplicitMidpoint(state, "u"))
+transported_fields.append(SSPRK3(state, "rho"))
+transported_fields.append(SSPRK3(state, "theta", options=theta_opts))
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns)
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields, linear_solver=linear_solver)
+stepper = CrankNicolson(state, eqns, transported_fields, linear_solver=linear_solver)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_hydrostatic.py
+++ b/examples/sk_hydrostatic.py
@@ -86,17 +86,17 @@ u0.project(as_vector([20.0, 0.0, 0.0]))
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
-advected_fields = []
-advected_fields.append(ImplicitMidpoint(state, "u"))
-advected_fields.append(SSPRK3(state, "rho"))
-advected_fields.append(SSPRK3(state, "theta", options=SUPGOptions()))
+# Set up transport schemes
+transported_fields = []
+transported_fields.append(ImplicitMidpoint(state, "u"))
+transported_fields.append(SSPRK3(state, "rho"))
+transported_fields.append(SSPRK3(state, "theta", options=SUPGOptions()))
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns)
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_linear_advection.py
+++ b/examples/sk_linear_advection.py
@@ -82,13 +82,13 @@ state.initialise([('u', u0),
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
-rhoeqn = LinearAdvection(state, Vr, qbar=rho_b, ibp=IntegrateByParts.ONCE, equation_form="continuity")
-thetaeqn = LinearAdvection(state, Vt, qbar=theta_b)
-advected_fields = []
-advected_fields.append(("u", NoAdvection(state, u0, None)))
-advected_fields.append(("rho", ForwardEuler(state, rho0, rhoeqn)))
-advected_fields.append(("theta", ForwardEuler(state, theta0, thetaeqn)))
+# Set up transport schemes
+rhoeqn = LinearTransport(state, Vr, qbar=rho_b, ibp=IntegrateByParts.ONCE, equation_form="continuity")
+thetaeqn = LinearTransport(state, Vt, qbar=theta_b)
+transported_fields = []
+transported_fields.append(("u", NoTransport(state, u0, None)))
+transported_fields.append(("rho", ForwardEuler(state, rho0, rhoeqn)))
+transported_fields.append(("theta", ForwardEuler(state, theta0, thetaeqn)))
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state)
@@ -97,7 +97,7 @@ linear_solver = CompressibleSolver(state)
 compressible_forcing = CompressibleForcing(state, linear=True)
 
 # build time stepper
-stepper = CrankNicolson(state, advected_fields, linear_solver,
+stepper = CrankNicolson(state, transported_fields, linear_solver,
                         compressible_forcing)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -94,13 +94,13 @@ u0.project(as_vector([20.0, 0.0]))
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
-# Set up advection schemes
+# Set up transport schemes
 supg = True
 if supg:
     theta_opts = SUPGOptions()
 else:
     theta_opts = EmbeddedDGOptions()
-advected_fields = [ImplicitMidpoint(state, "u"),
+transported_fields = [ImplicitMidpoint(state, "u"),
                    SSPRK3(state, "rho"),
                    SSPRK3(state, "theta", options=theta_opts)]
 
@@ -108,7 +108,7 @@ advected_fields = [ImplicitMidpoint(state, "u"),
 linear_solver = CompressibleSolver(state, eqns)
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -84,7 +84,7 @@ for delta, dt in res_dt.items():
     state.set_reference_profiles([('rho', rho_b),
                                   ('theta', theta_b)])
 
-    # Set up advection schemes
+    # Set up transport schemes
     supg = True
     if supg:
         theta_opts = SUPGOptions()
@@ -92,7 +92,7 @@ for delta, dt in res_dt.items():
     else:
         theta_opts = EmbeddedDGOptions()
         water_opts = EmbeddedDGOptions()
-    advected_fields = [ImplicitMidpoint(state, "u"),
+    transported_fields = [ImplicitMidpoint(state, "u"),
                        SSPRK3(state, "rho"),
                        SSPRK3(state, "theta", options=theta_opts)]
 
@@ -105,7 +105,7 @@ for delta, dt in res_dt.items():
                          BackwardEuler(state, "theta")]
 
     # build time stepper
-    stepper = CrankNicolson(state, eqns, advected_fields,
+    stepper = CrankNicolson(state, eqns, transported_fields,
                             auxiliary_equations_and_schemes=[(watereqn, SSPRK3(state, options=water_opts))],
                             linear_solver=linear_solver,
                             diffusion_schemes=diffusion_schemes)

--- a/examples/unsaturated_bubble.py
+++ b/examples/unsaturated_bubble.py
@@ -211,25 +211,25 @@ state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b),
                               ('vapour_mixing_ratio', water_vb)])
 
-# Set up advection schemes
+# Set up transport schemes
 if recovered:
-    u_advection = SSPRK3(state, "u", options=u_opts)
+    u_transport = SSPRK3(state, "u", options=u_opts)
     rho_opts = EmbeddedDGOptions()
     theta_opts = EmbeddedDGOptions()
     limiter = VertexBasedLimiter(VDG1)
 else:
-    u_advection = ImplicitMidpoint(state, "u")
+    u_transport = ImplicitMidpoint(state, "u")
     rho_opts = None
     theta_opts = EmbeddedDGOptions()
 
     limiter = ThetaLimiter(Vt)
 
-advected_fields = [u_advection,
-                   SSPRK3(state, "rho", options=rho_opts),
-                   SSPRK3(state, "theta", options=theta_opts),
-                   SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
-                   SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
-                   SSPRK3(state, "rain_mixing_ratio", options=theta_opts, limiter=limiter)]
+transported_fields = [u_transport,
+                      SSPRK3(state, "rho", options=rho_opts),
+                      SSPRK3(state, "theta", options=theta_opts),
+                      SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
+                      SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
+                      SSPRK3(state, "rain_mixing_ratio", options=theta_opts, limiter=limiter)]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
@@ -244,7 +244,7 @@ physics_list = [Fallout(state), Coalescence(state), Evaporation(state),
                 Condensation(state)]
 
 # build time stepper
-stepper = CrankNicolson(state, eqns, advected_fields,
+stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver,
                         physics_list=physics_list,
                         diffusion_schemes=diffusion_schemes)

--- a/gusto/__init__.py
+++ b/gusto/__init__.py
@@ -1,9 +1,10 @@
-from gusto.advection import *                        # noqa
+from gusto.active_tracers import *                   # noqa
 from gusto.configuration import *                    # noqa
 from gusto.diagnostics import *                      # noqa
 from gusto.diffusion import *                        # noqa
 from gusto.eady_diagnostics import *                 # noqa
 from gusto.equations import *                        # noqa
+from gusto.fml import *                              # noqa
 from gusto.forcing import *                          # noqa
 from gusto.initialisation_tools import *             # noqa
 from gusto.labels import *                           # noqa
@@ -13,7 +14,6 @@ from gusto.physics import *                          # noqa
 from gusto.preconditioners import *                  # noqa
 from gusto.recovery import *                         # noqa
 from gusto.state import *                            # noqa
+from gusto.time_discretisation import *              # noqa
 from gusto.timeloop import *                         # noqa
-from gusto.transport_equation import *               # noqa
-from gusto.fml import *                              # noqa
-from gusto.active_tracers import *                   # noqa
+from gusto.transport_forms import *                  # noqa

--- a/gusto/active_tracers.py
+++ b/gusto/active_tracers.py
@@ -8,23 +8,10 @@ what type of variable the tracer is, what phase it is, etc).
 """
 
 from enum import Enum
+from gusto.configuration import TransportEquationType
 
-__all__ = ["TransportEquationForm", "TracerVariableType", "Phases",
-           "ActiveTracer", "WaterVapour", "CloudWater", "Rain"]
-
-
-class TransportEquationForm(Enum):
-    """
-    An Enum object which stores the forms of the transport equation. For
-    transporting velocity 'u' and transported quantity 'q', these equations are:
-
-    advective: dq / dt + dot(u, grad(q)) = 0
-    conservative: dq / dt + div(q*u) = 0
-    """
-
-    no_transport = 702
-    advective = 19
-    conservative = 291
+__all__ = ["TracerVariableType", "Phases", "ActiveTracer",
+           "WaterVapour", "CloudWater", "Rain"]
 
 
 class TracerVariableType(Enum):
@@ -66,18 +53,18 @@ class ActiveTracer(object):
     :arg variable_type:  A TracerVariableType Enum indicating the type of tracer
                          variable (e.g. mixing ratio or density).
     :arg transport_flag: A Boolean indicating if the variable is transported.
-    :arg transport_eqn:  A TransportEquationForm Enum indicating the form of
+    :arg transport_eqn:  A TransportEquationType Enum indicating the form of
                          the transport equation to be used.
     :arg phase:          A Phases Enum indicating the phase of the variable.
     :arg is_moisture:    A Boolean indicating whether the variable is moisture.
     """
     def __init__(self, name, space, variable_type, transport_flag=True,
-                 transport_eqn=TransportEquationForm.advective,
+                 transport_eqn=TransportEquationType.advective,
                  phase=Phases.gas, is_moisture=False):
 
-        if transport_flag and transport_eqn == TransportEquationForm.no_transport:
+        if transport_flag and transport_eqn == TransportEquationType.no_transport:
             raise ValueError('If tracer is to be transported, transport_eqn must be specified')
-        elif not transport_flag and transport_eqn != TransportEquationForm.no_transport:
+        elif not transport_flag and transport_eqn != TransportEquationType.no_transport:
             raise ValueError('If tracer is not to be transported, transport_eqn must be no_transport')
 
         self.name = name
@@ -98,7 +85,7 @@ class WaterVapour(ActiveTracer):
     def __init__(self, name='vapour', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_flag=True,
-                 transport_eqn=TransportEquationForm.advective):
+                 transport_eqn=TransportEquationType.advective):
         super().__init__(f'{name}_{variable_type.name}', space, variable_type,
                          transport_flag, phase=Phases.gas, is_moisture=True)
 
@@ -110,7 +97,7 @@ class CloudWater(ActiveTracer):
     def __init__(self, name='cloud_liquid', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_flag=True,
-                 transport_eqn=TransportEquationForm.advective):
+                 transport_eqn=TransportEquationType.advective):
         super().__init__(f'{name}_{variable_type.name}', space, variable_type,
                          transport_flag, phase=Phases.liquid, is_moisture=True)
 
@@ -122,6 +109,6 @@ class Rain(ActiveTracer):
     def __init__(self, name='rain', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_flag=True,
-                 transport_eqn=TransportEquationForm.advective):
+                 transport_eqn=TransportEquationType.advective):
         super().__init__(f'{name}_{variable_type.name}', space, variable_type,
                          transport_flag, phase=Phases.liquid, is_moisture=True)

--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -2,12 +2,13 @@
 Some simple tools for making model configuration nicer.
 """
 from abc import ABCMeta, abstractproperty
+from enum import Enum
 import logging
 from logging import DEBUG, INFO, WARNING
 from firedrake import sqrt
 
 
-__all__ = ["WARNING", "INFO", "DEBUG", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters", "logger", "EmbeddedDGOptions", "RecoveredOptions", "SUPGOptions", "SpongeLayerParameters", "DiffusionParameters"]
+__all__ = ["WARNING", "INFO", "DEBUG", "IntegrateByParts", "TransportEquationType", "OutputParameters", "CompressibleParameters", "ShallowWaterParameters", "EadyParameters", "CompressibleEadyParameters", "logger", "EmbeddedDGOptions", "RecoveredOptions", "SUPGOptions", "SpongeLayerParameters", "DiffusionParameters"]
 
 logger = logging.getLogger("gusto")
 
@@ -21,6 +22,27 @@ def set_log_handler(comm):
         logger.addHandler(handler)
     else:
         logger.addHandler(logging.NullHandler())
+
+
+class IntegrateByParts(Enum):
+    NEVER = 0
+    ONCE = 1
+    TWICE = 2
+
+
+class TransportEquationType(Enum):
+    """
+    An Enum object which stores the types of the transport equation. For
+    transporting velocity 'u' and transported quantity 'q', these equations are:
+
+    advective: dq / dt + dot(u, grad(q)) = 0
+    conservative: dq / dt + div(q*u) = 0
+    """
+
+    no_transport = 702
+    advective = 19
+    conservative = 291
+    vector_invariant = 9081
 
 
 class Configuration(object):
@@ -156,6 +178,7 @@ class SUPGOptions(AdvectionOptions):
     name = "supg"
     tau = None
     default = 1/sqrt(15)
+    ibp = IntegrateByParts.TWICE
 
 
 class SpongeLayerParameters(Configuration):

--- a/gusto/eady_diagnostics.py
+++ b/gusto/eady_diagnostics.py
@@ -103,11 +103,7 @@ class TrueResidualV(DiagnosticField):
     def setup(self, state):
         super(TrueResidualV, self).setup(state)
         unew = state.fields("u")
-        bnew = state.fields("b")
-        pnew = state.fields("p")
         uold = state.xb("u")
-        bold = state.xb("b")
-        pold = state.xb("p")
         ubar = 0.5*(unew+uold)
         H = state.parameters.H
         f = state.parameters.f

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -18,7 +18,7 @@ from gusto.transport_forms import (advection_form, continuity_form,
                                    linear_advection_form)
 from gusto.diffusion import interior_penalty_diffusion_form
 from gusto.active_tracers import ActiveTracer, Phases, TracerVariableType
-from gusto.configuration import IntegrateByParts, TransportEquationType
+from gusto.configuration import TransportEquationType
 import ufl
 
 

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -5,17 +5,17 @@ from firedrake import (TestFunction, Function, sin, inner, dx, div, cross,
                        DirichletBC, conditional, SpatialCoordinate,
                        as_vector, split, Constant)
 from gusto.fml.form_manipulation_labelling import Term, all_terms
-from gusto.labels import (subject, time_derivative, advection, prognostic,
-                          advecting_velocity, replace_subject, linearisation,
+from gusto.labels import (subject, time_derivative, transport, prognostic,
+                          transporting_velocity, replace_subject, linearisation,
                           name)
 from gusto.thermodynamics import pi as Pi
-from gusto.transport_equation import (advection_form, continuity_form,
-                                      vector_invariant_form,
-                                      vector_manifold_advection_form,
-                                      kinetic_energy_form,
-                                      advection_equation_circulation_form,
-                                      linear_continuity_form,
-                                      linear_advection_form)
+from gusto.transport_forms import (advection_form, continuity_form,
+                                   vector_invariant_form,
+                                   vector_manifold_advection_form,
+                                   kinetic_energy_form,
+                                   advection_equation_circulation_form,
+                                   linear_continuity_form,
+                                   linear_advection_form)
 from gusto.diffusion import interior_penalty_diffusion_form
 from gusto.active_tracers import ActiveTracer, Phases, TracerVariableType
 from gusto.configuration import IntegrateByParts, TransportEquationType
@@ -106,12 +106,12 @@ class ContinuityEquation(PrognosticEquation):
 
 class DiffusionEquation(PrognosticEquation):
     """
-    Class defining the advection equation.
+    Class defining the diffusion equation.
 
     :arg state: :class:`.State` object
     :arg function_space: :class:`.FunctionSpace` object
     :arg field_name: name of the prognostic field
-    :kwargs: any kwargs to be passed on to the advection_form
+    :kwargs: any kwargs to be passed on to the diffusion form
     """
     def __init__(self, state, function_space, field_name,
                  diffusion_parameters):
@@ -160,7 +160,7 @@ class AdvectionDiffusionEquation(PrognosticEquation):
 class ShallowWaterEquations(PrognosticEquation):
 
     def __init__(self, state, family, degree, fexpr=None, bexpr=None,
-                 u_advection_option="vector_invariant_form",
+                 u_transport_option="vector_invariant_form",
                  no_normal_flow_bc_ids=None, active_tracers=None):
 
         self.field_names = ["u", "D"]
@@ -200,29 +200,29 @@ class ShallowWaterEquations(PrognosticEquation):
         D_mass = linearisation(D_mass, linear_D_mass)
         mass_form = time_derivative(u_mass + D_mass)
 
-        # define velocity advection term
-        if u_advection_option == "vector_invariant_form":
+        # define velocity transport term
+        if u_transport_option == "vector_invariant_form":
             u_adv = prognostic(vector_invariant_form(state, w, u), "u")
-        elif u_advection_option == "vector_advection_form":
+        elif u_transport_option == "vector_advection_form":
             u_adv = prognostic(advection_form(state, w, u), "u")
-        elif u_advection_option == "vector_manifold_advection_form":
+        elif u_transport_option == "vector_manifold_advection_form":
             u_adv = prognostic(vector_manifold_advection_form(state, w, u), "u")
-        elif u_advection_option == "circulation_form":
+        elif u_transport_option == "circulation_form":
             ke_form = kinetic_energy_form(state, w, u)
-            ke_form = advection.remove(ke_form)
+            ke_form = transport.remove(ke_form)
             ke_form = ke_form.label_map(
-                lambda t: t.has_label(advecting_velocity),
+                lambda t: t.has_label(transporting_velocity),
                 lambda t: Term(ufl.replace(
-                    t.form, {t.get(advecting_velocity): u}), t.labels))
-            ke_form = advecting_velocity.remove(ke_form)
+                    t.form, {t.get(transporting_velocity): u}), t.labels))
+            ke_form = transporting_velocity.remove(ke_form)
             u_adv = advection_equation_circulation_form(state, w, u) + ke_form
         else:
-            raise ValueError("Invalid u_advection_option: %s" % u_advection_option)
+            raise ValueError("Invalid u_transport_option: %s" % u_transport_option)
         D_adv = prognostic(continuity_form(state, phi, D), "D")
         linear_D_adv = linear_continuity_form(state, phi, H).label_map(
-            lambda t: t.has_label(advecting_velocity),
+            lambda t: t.has_label(transporting_velocity),
             lambda t: Term(ufl.replace(
-                t.form, {t.get(advecting_velocity): trials[0]}), t.labels))
+                t.form, {t.get(transporting_velocity): trials[0]}), t.labels))
         D_adv = linearisation(D_adv, linear_D_adv)
 
         adv_form = subject(u_adv + D_adv, X)
@@ -255,7 +255,7 @@ class CompressibleEulerEquations(PrognosticEquation):
 
     def __init__(self, state, family, degree, Omega=None, sponge=None,
                  extra_terms=None,
-                 u_advection_option="vector_invariant_form",
+                 u_transport_option="vector_invariant_form",
                  diffusion_options=None,
                  no_normal_flow_bc_ids=None,
                  active_tracers=None):
@@ -318,36 +318,36 @@ class CompressibleEulerEquations(PrognosticEquation):
         if len(active_tracers) > 0:
             mass_form += tracer_mass_forms(X, tests, self.field_names, active_tracers)
 
-        # define velocity advection form
-        if u_advection_option == "vector_invariant_form":
+        # define velocity transport form
+        if u_transport_option == "vector_invariant_form":
             u_adv = prognostic(vector_invariant_form(state, w, u), "u")
-        elif u_advection_option == "vector_advection_form":
+        elif u_transport_option == "vector_advection_form":
             u_adv = prognostic(advection_form(state, w, u), "u")
-        elif u_advection_option == "vector_manifold_advection_form":
+        elif u_transport_option == "vector_manifold_advection_form":
             u_adv = prognostic(vector_manifold_advection_form(state, w, u), "u")
-        elif u_advection_option == "circulation_form":
+        elif u_transport_option == "circulation_form":
             ke_form = kinetic_energy_form(state, w, u)
-            ke_form = advection.remove(ke_form)
+            ke_form = transport.remove(ke_form)
             ke_form = ke_form.label_map(
-                lambda t: t.has_label(advecting_velocity),
+                lambda t: t.has_label(transporting_velocity),
                 lambda t: Term(ufl.replace(
-                    t.form, {t.get(advecting_velocity): u}), t.labels))
-            ke_form = advecting_velocity.remove(ke_form)
+                    t.form, {t.get(transporting_velocity): u}), t.labels))
+            ke_form = transporting_velocity.remove(ke_form)
             u_adv = advection_equation_circulation_form(state, w, u) + ke_form
         else:
-            raise ValueError("Invalid u_advection_option: %s" % u_advection_option)
+            raise ValueError("Invalid u_transport_option: %s" % u_transport_option)
         rho_adv = prognostic(continuity_form(state, phi, rho), "rho")
         linear_rho_adv = linear_continuity_form(state, phi, rhobar).label_map(
-            lambda t: t.has_label(advecting_velocity),
+            lambda t: t.has_label(transporting_velocity),
             lambda t: Term(ufl.replace(
-                t.form, {t.get(advecting_velocity): trials[0]}), t.labels))
+                t.form, {t.get(transporting_velocity): trials[0]}), t.labels))
         rho_adv = linearisation(rho_adv, linear_rho_adv)
 
         theta_adv = prognostic(advection_form(state, gamma, theta), "theta")
         linear_theta_adv = linear_advection_form(state, gamma, thetabar).label_map(
-            lambda t: t.has_label(advecting_velocity),
+            lambda t: t.has_label(transporting_velocity),
             lambda t: Term(ufl.replace(
-                t.form, {t.get(advecting_velocity): trials[0]}), t.labels))
+                t.form, {t.get(transporting_velocity): trials[0]}), t.labels))
         theta_adv = linearisation(theta_adv, linear_theta_adv)
 
         adv_form = subject(u_adv + rho_adv + theta_adv, X)
@@ -445,14 +445,14 @@ class CompressibleEulerEquations(PrognosticEquation):
 class CompressibleEadyEquations(CompressibleEulerEquations):
 
     def __init__(self, state, family, degree, Omega=None, sponge=None,
-                 u_advection_option="vector_invariant_form",
+                 u_transport_option="vector_invariant_form",
                  diffusion_options=None,
                  no_normal_flow_bc_ids=None,
                  active_tracers=None):
 
         super().__init__(state, family, degree,
                          Omega=Omega, sponge=sponge,
-                         u_advection_option=u_advection_option,
+                         u_transport_option=u_transport_option,
                          diffusion_options=diffusion_options,
                          no_normal_flow_bc_ids=no_normal_flow_bc_ids,
                          active_tracers=active_tracers)
@@ -479,7 +479,7 @@ class CompressibleEadyEquations(CompressibleEulerEquations):
 class IncompressibleBoussinesqEquations(PrognosticEquation):
 
     def __init__(self, state, family, degree, Omega=None,
-                 u_advection_option="vector_invariant_form",
+                 u_transport_option="vector_invariant_form",
                  no_normal_flow_bc_ids=None,
                  active_tracers=None):
 
@@ -531,30 +531,30 @@ class IncompressibleBoussinesqEquations(PrognosticEquation):
 
         mass_form = time_derivative(u_mass + p_mass + b_mass)
 
-        # define velocity advection term
-        if u_advection_option == "vector_invariant_form":
+        # define velocity transport term
+        if u_transport_option == "vector_invariant_form":
             u_adv = prognostic(vector_invariant_form(state, w, u), "u")
-        elif u_advection_option == "vector_advection_form":
+        elif u_transport_option == "vector_advection_form":
             u_adv = prognostic(advection_form(state, w, u), "u")
-        elif u_advection_option == "vector_manifold_advection_form":
+        elif u_transport_option == "vector_manifold_advection_form":
             u_adv = prognostic(vector_manifold_advection_form(state, w, u), "u")
-        elif u_advection_option == "circulation_form":
+        elif u_transport_option == "circulation_form":
             ke_form = kinetic_energy_form(state, w, u)
-            ke_form = advection.remove(ke_form)
+            ke_form = transport.remove(ke_form)
             ke_form = ke_form.label_map(
-                lambda t: t.has_label(advecting_velocity),
+                lambda t: t.has_label(transporting_velocity),
                 lambda t: Term(ufl.replace(
-                    t.form, {t.get(advecting_velocity): u}), t.labels))
-            ke_form = advecting_velocity.remove(ke_form)
+                    t.form, {t.get(transporting_velocity): u}), t.labels))
+            ke_form = transporting_velocity.remove(ke_form)
             u_adv = advection_equation_circulation_form(state, w, u) + ke_form
         else:
-            raise ValueError("Invalid u_advection_option: %s" % u_advection_option)
+            raise ValueError("Invalid u_transport_option: %s" % u_transport_option)
 
         b_adv = prognostic(advection_form(state, gamma, b), "b")
         linear_b_adv = linear_advection_form(state, gamma, bbar).label_map(
-            lambda t: t.has_label(advecting_velocity),
+            lambda t: t.has_label(transporting_velocity),
             lambda t: Term(ufl.replace(
-                t.form, {t.get(advecting_velocity): trials[0]}), t.labels))
+                t.form, {t.get(transporting_velocity): trials[0]}), t.labels))
         b_adv = linearisation(b_adv, linear_b_adv)
 
         adv_form = subject(u_adv + b_adv, X)
@@ -576,13 +576,13 @@ class IncompressibleBoussinesqEquations(PrognosticEquation):
 
 class IncompressibleEadyEquations(IncompressibleBoussinesqEquations):
     def __init__(self, state, family, degree, Omega=None,
-                 u_advection_option="vector_invariant_form",
+                 u_transport_option="vector_invariant_form",
                  no_normal_flow_bc_ids=None,
                  active_tracers=None):
 
         super().__init__(state, family, degree,
                          Omega=Omega,
-                         u_advection_option=u_advection_option,
+                         u_transport_option=u_transport_option,
                          no_normal_flow_bc_ids=no_normal_flow_bc_ids,
                          active_tracers=active_tracers)
 

--- a/gusto/fml/form_manipulation_labelling.py
+++ b/gusto/fml/form_manipulation_labelling.py
@@ -108,13 +108,13 @@ class LabelledForm(object):
         `map_if_true`; terms for which `term_filter` is false are
         transformed by map_is_false."""
 
-        # TODO: I think this should return an empty list if there are no
-        # terms obeying the term filter? Do we need a null term?
         return LabelledForm(
             functools.reduce(operator.add,
                              filter(lambda t: t is not None,
                                     (map_if_true(t) if term_filter(t) else
-                                     map_if_false(t) for t in self.terms))))
+                                     map_if_false(t) for t in self.terms)),
+                             # initialiser for if the list is empty
+                             None))
 
     @property
     def form(self):

--- a/gusto/fml/form_manipulation_labelling.py
+++ b/gusto/fml/form_manipulation_labelling.py
@@ -108,6 +108,8 @@ class LabelledForm(object):
         `map_if_true`; terms for which `term_filter` is false are
         transformed by map_is_false."""
 
+        # TODO: I think this should return an empty list if there are no
+        # terms obeying the term filter? Do we need a null term?
         return LabelledForm(
             functools.reduce(operator.add,
                              filter(lambda t: t is not None,

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -1,7 +1,7 @@
 from firedrake import (Function, TrialFunctions, DirichletBC,
                        LinearVariationalProblem, LinearVariationalSolver)
 from gusto.configuration import logger, DEBUG
-from gusto.labels import (advection, diffusion, name, time_derivative,
+from gusto.labels import (transport, diffusion, name, time_derivative,
                           replace_subject)
 from gusto.fml.form_manipulation_labelling import drop
 
@@ -33,7 +33,7 @@ class Forcing(object):
         self.xF = Function(W)
 
         residual = equation.residual.label_map(
-            lambda t: t.has_label(advection), drop)
+            lambda t: t.has_label(transport), drop)
         residual = equation.residual.label_map(
             lambda t: t.has_label(diffusion), drop)
 

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -60,9 +60,9 @@ def replace_subject(new, idx=None):
 
 
 time_derivative = Label("time_derivative")
-advection = Label("advection", validator=lambda value: type(value) == TransportEquationType)
+transport = Label("transport", validator=lambda value: type(value) == TransportEquationType)
 diffusion = Label("diffusion")
-advecting_velocity = Label("advecting_velocity", validator=lambda value: type(value) == Function)
+transporting_velocity = Label("transporting_velocity", validator=lambda value: type(value) == Function)
 subject = Label("subject", validator=lambda value: type(value) == Function)
 prognostic = Label("prognostic", validator=lambda value: type(value) == str)
 linearisation = Label("linearisation", validator=lambda value: type(value) == LabelledForm)

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -1,5 +1,6 @@
 import ufl
 from firedrake import Function, split, VectorElement
+from gusto.configuration import IntegrateByParts, TransportEquationType
 from gusto.fml.form_manipulation_labelling import Term, Label, LabelledForm
 
 
@@ -59,10 +60,11 @@ def replace_subject(new, idx=None):
 
 
 time_derivative = Label("time_derivative")
-advection = Label("advection")
+advection = Label("advection", validator=lambda value: type(value) == TransportEquationType)
 diffusion = Label("diffusion")
 advecting_velocity = Label("advecting_velocity", validator=lambda value: type(value) == Function)
 subject = Label("subject", validator=lambda value: type(value) == Function)
 prognostic = Label("prognostic", validator=lambda value: type(value) == str)
 linearisation = Label("linearisation", validator=lambda value: type(value) == LabelledForm)
 name = Label("name", validator=lambda value: type(value) == str)
+ibp_label = Label("ibp", validator=lambda value: type(value) == IntegrateByParts)

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from gusto.recovery import Recoverer, Boundary_Method
-from gusto.advection import SSPRK3
+from gusto.time_discretisation import SSPRK3
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from gusto.equations import AdvectionEquation
 from gusto.limiters import ThetaLimiter, NoLimiter

--- a/gusto/recovery.py
+++ b/gusto/recovery.py
@@ -1,5 +1,6 @@
 """
-The recovery operators used for lowest-order advection schemes.
+The recovery operators used for improving accuracy of lowest-order spatial
+discretisations.
 """
 from enum import Enum
 

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -133,12 +133,7 @@ class TimeDiscretisation(object, metaclass=ABCMeta):
         # Routines relating to transport
         # -------------------------------------------------------------------- #
 
-        # TODO: this if statement is a hack for now to prevent errors being
-        # triggered if there are no terms with the "transport" label
-        # or indeed multiple terms (e.g. for mixed test functions)
-        # This is because the label_map routine throws an error when there
-        # are no terms satisfying the term_filter
-        if any([t.has_label(transport) for t in self.residual]) and hasattr(self.options, 'ibp'):
+        if hasattr(self.options, 'ibp'):
             self.replace_transport_term()
         self.replace_transporting_velocity(uadv)
 

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -322,7 +322,7 @@ class TimeDiscretisation(object, metaclass=ABCMeta):
                 elif old_transport_term.labels['transport'] == TransportEquationType.conservative:
                     new_transport_term = continuity_form(self.state, test, field, ibp=self.options.ibp)
                 else:
-                    raise NotImplementedError(f'Replacement of transport term not implemented yet for {old_transport_terms.labels["transport"]}')
+                    raise NotImplementedError(f'Replacement of transport term not implemented yet for {old_transport_term.labels["transport"]}')
 
                 # Finally, drop the old transport term and add the new one
                 self.residual = self.residual.label_map(

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -7,11 +7,11 @@ from firedrake.formmanipulation import split_form
 from firedrake.utils import cached_property
 import ufl
 from gusto.configuration import logger, DEBUG, TransportEquationType
-from gusto.labels import (time_derivative, advecting_velocity, prognostic, subject,
-                          advection, ibp_label, replace_subject, replace_test_function)
+from gusto.labels import (time_derivative, transporting_velocity, prognostic, subject,
+                          transport, ibp_label, replace_subject, replace_test_function)
 from gusto.recovery import Recoverer
 from gusto.fml.form_manipulation_labelling import Term, all_terms, drop
-from gusto.transport_equation import advection_form, continuity_form
+from gusto.transport_forms import advection_form, continuity_form
 
 
 __all__ = ["ForwardEuler", "BackwardEuler", "SSPRK3", "ThetaMethod", "ImplicitMidpoint"]
@@ -35,8 +35,7 @@ def is_cg(V):
 
 def embedded_dg(original_apply):
     """
-    Decorator to add interpolation and projection steps for embedded
-    DG advection.
+    Decorator to add interpolation and projection steps for embedded DG method.
     """
     def get_apply(self, x_in, x_out):
 
@@ -57,17 +56,17 @@ def embedded_dg(original_apply):
     return get_apply
 
 
-class Advection(object, metaclass=ABCMeta):
+class TimeDiscretisation(object, metaclass=ABCMeta):
     """
-    Base class for advection schemes.
+    Base class for time discretisation schemes.
 
     :arg state: :class:`.State` object.
-    :arg field: field to be advected
+    :arg field: field to be evolved
     :arg equation: :class:`.Equation` object, specifying the equation
     that field satisfies
     :arg solver_parameters: solver_parameters
     :arg limiter: :class:`.Limiter` object.
-    :arg options: :class:`.AdvectionOptions` object
+    :arg options: :class:`.DiscretisationOptions` object
     """
 
     def __init__(self, state, field_name=None, solver_parameters=None,
@@ -130,14 +129,22 @@ class Advection(object, metaclass=ABCMeta):
 
         options = self.options
 
+        # -------------------------------------------------------------------- #
+        # Routines relating to transport
+        # -------------------------------------------------------------------- #
+
         # TODO: this if statement is a hack for now to prevent errors being
-        # triggered if there are no terms with the "advection" label
+        # triggered if there are no terms with the "transport" label
         # or indeed multiple terms (e.g. for mixed test functions)
         # This is because the label_map routine throws an error when there
         # are no terms satisfying the term_filter
-        if any([t.has_label(advection) for t in self.residual]) and hasattr(self.options, 'ibp'):
+        if any([t.has_label(transport) for t in self.residual]) and hasattr(self.options, 'ibp'):
             self.replace_transport_term()
-        self.replace_advecting_velocity(uadv)
+        self.replace_transporting_velocity(uadv)
+
+        # -------------------------------------------------------------------- #
+        # Wrappers for embedded / recovery methods
+        # -------------------------------------------------------------------- #
 
         if self.discretisation_option in ["embedded_dg", "recovered"]:
             # construct the embedding space if not specified
@@ -156,6 +163,10 @@ class Advection(object, metaclass=ABCMeta):
             parameters = {'ksp_type': 'cg',
                           'pc_type': 'bjacobi',
                           'sub_pc_type': 'ilu'}
+
+        # -------------------------------------------------------------------- #
+        # Modify test function for SUPG methods
+        # -------------------------------------------------------------------- #
 
         if self.discretisation_option == "supg":
             # construct tau, if it is not specified
@@ -193,7 +204,7 @@ class Advection(object, metaclass=ABCMeta):
         if self.discretisation_option is not None:
             # replace the original test function with one defined on
             # the embedding space, as this is the space where the
-            # advection occurs
+            # the problem will be solved
             self.residual = self.residual.label_map(
                 all_terms,
                 map_if_true=replace_test_function(new_test))
@@ -227,9 +238,9 @@ class Advection(object, metaclass=ABCMeta):
 
     def pre_apply(self, x_in, discretisation_option):
         """
-        Extra steps to advection if using an embedded method,
+        Extra steps to discretisation if using an embedded method,
         which might be either the plain embedded method or the
-        recovered space advection scheme.
+        recovered space scheme.
 
         :arg x_in: the input set of prognostic fields.
         :arg discretisation option: string specifying which scheme to use.
@@ -249,7 +260,7 @@ class Advection(object, metaclass=ABCMeta):
     def post_apply(self, x_out, discretisation_option):
         """
         The projection steps, returning a field to its original space
-        for an embedded DG advection scheme. For the case of the
+        for an embedded DG scheme. For the case of the
         recovered scheme, there are two options dependent on whether
         the scheme is limited or not.
 
@@ -290,10 +301,10 @@ class Advection(object, metaclass=ABCMeta):
         This is necessary because when the prognostic equations are declared,
         the whole transport
         """
-        # TODO: go through this really carefully to see if this is the right way of doing things
+
         # Extract transport term of equation
         old_transport_term_list = self.residual.label_map(
-            lambda t: t.has_label(advection), map_if_false=drop)
+            lambda t: t.has_label(transport), map_if_false=drop)
 
         # If there are more transport terms, extract only the one for this variable
         if len(old_transport_term_list.terms) > 1:
@@ -311,28 +322,28 @@ class Advection(object, metaclass=ABCMeta):
                 test = TestFunction(self.fs)
 
                 # Set up new transport term (depending on the type of transport equation)
-                if old_transport_term.labels['advection'] == TransportEquationType.advective:
+                if old_transport_term.labels['transport'] == TransportEquationType.advective:
                     new_transport_term = advection_form(self.state, test, field, ibp=self.options.ibp)
-                elif old_transport_term.labels['advection'] == TransportEquationType.conservative:
+                elif old_transport_term.labels['transport'] == TransportEquationType.conservative:
                     new_transport_term = continuity_form(self.state, test, field, ibp=self.options.ibp)
                 else:
-                    raise NotImplementedError(f'Replacement of transport term not implemented yet for {old_transport_terms.labels["advection"]}')
+                    raise NotImplementedError(f'Replacement of transport term not implemented yet for {old_transport_terms.labels["transport"]}')
 
                 # Finally, drop the old transport term and add the new one
                 self.residual = self.residual.label_map(
-                    lambda t: t.has_label(advection), map_if_true=drop)
+                    lambda t: t.has_label(transport), map_if_true=drop)
                 self.residual += subject(new_transport_term, field)
 
-    def replace_advecting_velocity(self, uadv):
-        # replace the advecting velocity in any terms that contain it
-        if any([t.has_label(advecting_velocity) for t in self.residual]):
+    def replace_transporting_velocity(self, uadv):
+        # replace the transporting velocity in any terms that contain it
+        if any([t.has_label(transporting_velocity) for t in self.residual]):
             assert uadv is not None
             self.residual = self.residual.label_map(
-                lambda t: t.has_label(advecting_velocity),
+                lambda t: t.has_label(transporting_velocity),
                 map_if_true=lambda t: Term(ufl.replace(
-                    t.form, {t.get(advecting_velocity): uadv}), t.labels)
+                    t.form, {t.get(transporting_velocity): uadv}), t.labels)
             )
-            self.residual = advecting_velocity.update_value(self.residual, uadv)
+            self.residual = transporting_velocity.update_value(self.residual, uadv)
 
     @cached_property
     def solver(self):
@@ -353,12 +364,12 @@ class Advection(object, metaclass=ABCMeta):
         pass
 
 
-class ExplicitAdvection(Advection):
+class ExplicitTimeDiscretisation(TimeDiscretisation):
     """
-    Base class for explicit advection schemes.
+    Base class for explicit time discretisations.
 
     :arg state: :class:`.State` object.
-    :arg field: field to be advected
+    :arg field: field to be evolved
     :arg equation: :class:`.Equation` object, specifying the equation
     that field satisfies
     :arg subcycles: (optional) integer specifying number of subcycles to perform
@@ -415,11 +426,11 @@ class ExplicitAdvection(Advection):
         x_out.assign(self.x[self.ncycles-1])
 
 
-class ForwardEuler(ExplicitAdvection):
+class ForwardEuler(ExplicitTimeDiscretisation):
     """
     Class to implement the forward Euler timestepping scheme:
     y_(n+1) = y_n + dt*L(y_n)
-    where L is the advection operator
+    where L is the operator
     """
 
     @cached_property
@@ -436,15 +447,15 @@ class ForwardEuler(ExplicitAdvection):
         x_out.assign(self.dq)
 
 
-class SSPRK3(ExplicitAdvection):
+class SSPRK3(ExplicitTimeDiscretisation):
     """
     Class to implement the Strongly Structure Preserving Runge Kutta 3-stage
     timestepping method:
     y^1 = y_n + L(y_n)
     y^2 = (3/4)y_n + (1/4)(y^1 + L(y^1))
     y_(n+1) = (1/3)y_n + (2/3)(y^2 + L(y^2))
-    where subscripts indicate the timelevel, superscripts indicate the stage
-    number and L is the advection operator.
+    where subscripts indicate the time-level, superscripts indicate the stage
+    number and L is the operator.
     """
 
     @cached_property
@@ -483,7 +494,7 @@ class SSPRK3(ExplicitAdvection):
         x_out.assign(self.q1)
 
 
-class BackwardEuler(Advection):
+class BackwardEuler(TimeDiscretisation):
 
     @property
     def lhs(self):
@@ -511,10 +522,10 @@ class BackwardEuler(Advection):
         x_out.assign(self.dq)
 
 
-class ThetaMethod(Advection):
+class ThetaMethod(TimeDiscretisation):
     """
     Class to implement the theta timestepping method:
-    y_(n+1) = y_n + dt*(theta*L(y_n) + (1-theta)*L(y_(n+1))) where L is the advection operator.
+    y_(n+1) = y_n + dt*(theta*L(y_n) + (1-theta)*L(y_(n+1))) where L is the operator.
     """
     def __init__(self, state, field_name=None, theta=None,
                  solver_parameters=None, options=None):
@@ -565,7 +576,7 @@ class ImplicitMidpoint(ThetaMethod):
     Class to implement the implicit midpoint timestepping method, i.e. the
     theta method with theta=0.5:
     y_(n+1) = y_n + 0.5*dt*(L(y_n) + L(y_(n+1)))
-    where L is the advection operator.
+    where L is the operator.
     """
     def __init__(self, state, field_name=None, solver_parameters=None,
                  options=None):

--- a/gusto/transport_equation.py
+++ b/gusto/transport_equation.py
@@ -1,19 +1,13 @@
-from enum import Enum
 from firedrake import (Function, FacetNormal,
                        dx, dot, grad, div, jump, avg, dS, dS_v, dS_h, inner,
                        ds_v, ds_t, ds_b,
                        outer, sign, cross, CellNormal,
                        curl)
-from gusto.labels import advection, advecting_velocity
+from gusto.configuration import IntegrateByParts, TransportEquationType
+from gusto.labels import advection, advecting_velocity, ibp_label
 
 
-__all__ = ["IntegrateByParts", "advection_form", "continuity_form", "vector_invariant_form", "vector_manifold_advection_form", "kinetic_energy_form", "advection_equation_circulation_form", "linear_continuity_form"]
-
-
-class IntegrateByParts(Enum):
-    NEVER = 0
-    ONCE = 1
-    TWICE = 2
+__all__ = ["advection_form", "continuity_form", "vector_invariant_form", "vector_manifold_advection_form", "kinetic_energy_form", "advection_equation_circulation_form", "linear_continuity_form"]
 
 
 def linear_advection_form(state, test, qbar):
@@ -24,7 +18,7 @@ def linear_advection_form(state, test, qbar):
 
     form = advecting_velocity(L, ubar)
 
-    return advection(form)
+    return advection(form, TransportEquationType.advective)
 
 
 def linear_continuity_form(state, test, qbar):
@@ -36,7 +30,7 @@ def linear_continuity_form(state, test, qbar):
 
     form = advecting_velocity(L, ubar)
 
-    return advection(form)
+    return advection(form, TransportEquationType.conservative)
 
 
 def advection_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
@@ -69,7 +63,7 @@ def advection_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
 
     form = advecting_velocity(L, ubar)
 
-    return advection(form)
+    return ibp_label(advection(form, TransportEquationType.advective), ibp)
 
 
 def continuity_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
@@ -102,7 +96,7 @@ def continuity_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
 
     form = advecting_velocity(L, ubar)
 
-    return advection(form)
+    return ibp_label(advection(form, TransportEquationType.conservative), ibp)
 
 
 def vector_manifold_advection_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
@@ -191,7 +185,7 @@ def vector_invariant_form(state, test, q, ibp=IntegrateByParts.ONCE):
 
     form = advecting_velocity(L, ubar)
 
-    return advection(form)
+    return advection(form, TransportEquationType.vector_invariant)
 
 
 def kinetic_energy_form(state, test, q):
@@ -201,7 +195,7 @@ def kinetic_energy_form(state, test, q):
 
     form = advecting_velocity(L, ubar)
 
-    return advection(form)
+    return advection(form, TransportEquationType.vector_invariant)
 
 
 def advection_equation_circulation_form(state, test, q,

--- a/gusto/transport_forms.py
+++ b/gusto/transport_forms.py
@@ -4,7 +4,7 @@ from firedrake import (Function, FacetNormal,
                        outer, sign, cross, CellNormal,
                        curl)
 from gusto.configuration import IntegrateByParts, TransportEquationType
-from gusto.labels import advection, advecting_velocity, ibp_label
+from gusto.labels import transport, transporting_velocity, ibp_label
 
 
 __all__ = ["advection_form", "continuity_form", "vector_invariant_form", "vector_manifold_advection_form", "kinetic_energy_form", "advection_equation_circulation_form", "linear_continuity_form"]
@@ -16,9 +16,9 @@ def linear_advection_form(state, test, qbar):
 
     L = test*dot(ubar, state.k)*dot(state.k, grad(qbar))*dx
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return advection(form, TransportEquationType.advective)
+    return transport(form, TransportEquationType.advective)
 
 
 def linear_continuity_form(state, test, qbar):
@@ -28,9 +28,9 @@ def linear_continuity_form(state, test, qbar):
 
     L = qbar*test*div(ubar)*dx
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return advection(form, TransportEquationType.conservative)
+    return transport(form, TransportEquationType.conservative)
 
 
 def advection_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
@@ -61,9 +61,9 @@ def advection_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
         un = 0.5*(dot(ubar, n) + abs(dot(ubar, n)))
         L += test*un*q*(ds_v + ds_t + ds_b)
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return ibp_label(advection(form, TransportEquationType.advective), ibp)
+    return ibp_label(transport(form, TransportEquationType.advective), ibp)
 
 
 def continuity_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
@@ -94,9 +94,9 @@ def continuity_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
         un = 0.5*(dot(ubar, n) + abs(dot(ubar, n)))
         L += test*un*q*(ds_v + ds_t + ds_b)
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return ibp_label(advection(form, TransportEquationType.conservative), ibp)
+    return ibp_label(transport(form, TransportEquationType.conservative), ibp)
 
 
 def vector_manifold_advection_form(state, test, q, ibp=IntegrateByParts.ONCE, outflow=False):
@@ -126,9 +126,9 @@ def vector_manifold_continuity_form(state, test, q, ibp=IntegrateByParts.ONCE, o
     L += un('+')*inner(test('-'), n('+')+n('-'))*inner(q('+'), n('+'))*dS_
     L += un('-')*inner(test('+'), n('+')+n('-'))*inner(q('-'), n('-'))*dS_
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return advection(form)
+    return transport(form)
 
 
 def vector_invariant_form(state, test, q, ibp=IntegrateByParts.ONCE):
@@ -183,9 +183,9 @@ def vector_invariant_form(state, test, q, ibp=IntegrateByParts.ONCE):
 
     L -= 0.5*div(test)*inner(q, ubar)*dx
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return advection(form, TransportEquationType.vector_invariant)
+    return transport(form, TransportEquationType.vector_invariant)
 
 
 def kinetic_energy_form(state, test, q):
@@ -193,9 +193,9 @@ def kinetic_energy_form(state, test, q):
     ubar = Function(state.spaces("HDiv"))
     L = 0.5*div(test)*inner(q, ubar)*dx
 
-    form = advecting_velocity(L, ubar)
+    form = transporting_velocity(L, ubar)
 
-    return advection(form, TransportEquationType.vector_invariant)
+    return transport(form, TransportEquationType.vector_invariant)
 
 
 def advection_equation_circulation_form(state, test, q,

--- a/tests/test_advection_diffusion.py
+++ b/tests/test_advection_diffusion.py
@@ -13,12 +13,12 @@ def run(setup):
     equation = AdvectionDiffusionEquation(state, V, "f", ufamily=setup.family,
                                           udegree=setup.degree,
                                           diffusion_parameters=diffusion_params)
-    problem = [(equation, ((SSPRK3(state), advection),
+    problem = [(equation, ((SSPRK3(state), transport),
                            (BackwardEuler(state), diffusion)))]
     state.fields("f").interpolate(f_init)
     state.fields("u").project(as_vector([10, 0.]))
 
-    timestepper = PrescribedAdvection(state, problem)
+    timestepper = PrescribedTransport(state, problem)
 
     timestepper.run(0, tmax=tmax)
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -23,7 +23,6 @@ def setup_sk(dirname):
     points = np.array([p for p in itertools.product(points_x, points_z)])
 
     output = OutputParameters(dirname=dirname+"/sk_nonlinear", dumpfreq=5, dumplist=['u'], log_level=INFO, perturbation_fields=['theta', 'rho'],
-
                               point_data=[('rho', points), ('u', points)])
     parameters = CompressibleParameters()
     diagnostic_fields = [CourantNumber()]

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -70,17 +70,17 @@ def setup_sk(dirname):
     state.set_reference_profiles([('rho', rho_b),
                                   ('theta', theta_b)])
 
-    # Set up advection schemes
-    advected_fields = []
-    advected_fields.append(ImplicitMidpoint(state, "u"))
-    advected_fields.append(SSPRK3(state, "rho"))
-    advected_fields.append(SSPRK3(state, "theta", options=SUPGOptions()))
+    # Set up transport schemes
+    transported_fields = []
+    transported_fields.append(ImplicitMidpoint(state, "u"))
+    transported_fields.append(SSPRK3(state, "rho"))
+    transported_fields.append(SSPRK3(state, "theta", options=SUPGOptions()))
 
     # Set up linear solver
     linear_solver = CompressibleSolver(state, eqns)
 
     # build time stepper
-    stepper = CrankNicolson(state, eqns, advected_fields, linear_solver=linear_solver)
+    stepper = CrankNicolson(state, eqns, transported_fields, linear_solver=linear_solver)
 
     return stepper, 2*dt
 

--- a/tests/test_compressible_balance.py
+++ b/tests/test_compressible_balance.py
@@ -47,16 +47,16 @@ def setup_balance(dirname):
     state.set_reference_profiles([('rho', rho0),
                                   ('theta', theta0)])
 
-    # Set up advection schemes
-    advected_fields = [ImplicitMidpoint(state, "u"),
-                       SSPRK3(state, "rho"),
-                       SSPRK3(state, "theta", options=EmbeddedDGOptions())]
+    # Set up transport schemes
+    transported_fields = [ImplicitMidpoint(state, "u"),
+                          SSPRK3(state, "rho"),
+                          SSPRK3(state, "theta", options=EmbeddedDGOptions())]
 
     # Set up linear solver
     linear_solver = CompressibleSolver(state, eqns)
 
     # build time stepper
-    stepper = CrankNicolson(state, eqns, advected_fields, linear_solver=linear_solver)
+    stepper = CrankNicolson(state, eqns, transported_fields, linear_solver=linear_solver)
 
     return stepper, tmax
 

--- a/tests/test_condensation.py
+++ b/tests/test_condensation.py
@@ -102,9 +102,9 @@ def setup_condens(dirname):
     physics_list = [Condensation(state)]
 
     # build time stepper
-    stepper = PrescribedAdvection(state, problem,
+    stepper = PrescribedTransport(state, problem,
                                   physics_list=physics_list,
-                                  prescribed_advecting_velocity=u_evaluation)
+                                  prescribed_transporting_velocity=u_evaluation)
 
     return stepper, tmax
 

--- a/tests/test_dg_transport.py
+++ b/tests/test_dg_transport.py
@@ -3,8 +3,8 @@ from gusto import *
 import pytest
 
 
-def run(state, advection_scheme, tmax, f_end):
-    timestepper = PrescribedAdvection(state, advection_scheme)
+def run(state, transport_scheme, tmax, f_end):
+    timestepper = PrescribedTransport(state, transport_scheme)
     timestepper.run(0, tmax)
     return norm(state.fields("f") - f_end)
 
@@ -12,7 +12,7 @@ def run(state, advection_scheme, tmax, f_end):
 @pytest.mark.parametrize("geometry", ["slice", "sphere"])
 @pytest.mark.parametrize("equation_form", ["advective", "continuity"])
 @pytest.mark.parametrize("scheme", ["ssprk", "implicit_midpoint"])
-def test_dg_advection_scalar(tmpdir, geometry, equation_form, scheme,
+def test_dg_transport_scalar(tmpdir, geometry, equation_form, scheme,
                              tracer_setup):
     setup = tracer_setup(tmpdir, geometry)
     state = setup.state
@@ -27,16 +27,16 @@ def test_dg_advection_scalar(tmpdir, geometry, equation_form, scheme,
     state.fields("u").project(setup.uexpr)
 
     if scheme == "ssprk":
-        advection_scheme = [(eqn, SSPRK3(state))]
+        transport_scheme = [(eqn, SSPRK3(state))]
     elif scheme == "implicit_midpoint":
-        advection_scheme = [(eqn, ImplicitMidpoint(state))]
-    assert run(state, advection_scheme, setup.tmax, setup.f_end) < setup.tol
+        transport_scheme = [(eqn, ImplicitMidpoint(state))]
+    assert run(state, transport_scheme, setup.tmax, setup.f_end) < setup.tol
 
 
 @pytest.mark.parametrize("geometry", ["slice", "sphere"])
 @pytest.mark.parametrize("equation_form", ["advective", "continuity"])
 @pytest.mark.parametrize("scheme", ["ssprk", "implicit_midpoint"])
-def test_dg_advection_vector(tmpdir, geometry, equation_form, scheme,
+def test_dg_transport_vector(tmpdir, geometry, equation_form, scheme,
                              tracer_setup):
     setup = tracer_setup(tmpdir, geometry)
     state = setup.state
@@ -52,8 +52,8 @@ def test_dg_advection_vector(tmpdir, geometry, equation_form, scheme,
     state.fields("f").interpolate(f_init)
     state.fields("u").project(setup.uexpr)
     if scheme == "ssprk":
-        advection_schemes = [(eqn, SSPRK3(state))]
+        transport_schemes = [(eqn, SSPRK3(state))]
     elif scheme == "implicit_midpoint":
-        advection_schemes = [(eqn, ImplicitMidpoint(state))]
+        transport_schemes = [(eqn, ImplicitMidpoint(state))]
     f_end = as_vector((setup.f_end, *[0.]*(gdim-1)))
-    assert run(state, advection_schemes, setup.tmax, f_end) < setup.tol
+    assert run(state, transport_schemes, setup.tmax, f_end) < setup.tol

--- a/tests/test_embedded_dg_advection.py
+++ b/tests/test_embedded_dg_advection.py
@@ -3,8 +3,8 @@ from gusto import *
 import pytest
 
 
-def run(state, advection_schemes, tmax, f_end):
-    timestepper = PrescribedAdvection(state, advection_schemes)
+def run(state, transport_schemes, tmax, f_end):
+    timestepper = PrescribedTransport(state, transport_schemes)
     timestepper.run(0, tmax)
     return norm(state.fields("f") - f_end)
 
@@ -32,6 +32,6 @@ def test_embedded_dg_advection_scalar(tmpdir, ibp, equation_form, space,
     state.fields("f").interpolate(setup.f_init)
     state.fields("u").project(setup.uexpr)
 
-    advection_schemes = [(eqn, SSPRK3(state, options=opts))]
+    transport_schemes = [(eqn, SSPRK3(state, options=opts))]
 
-    assert run(state, advection_schemes, setup.tmax, setup.f_end) < setup.tol
+    assert run(state, transport_schemes, setup.tmax, setup.f_end) < setup.tol

--- a/tests/test_precipitation.py
+++ b/tests/test_precipitation.py
@@ -57,9 +57,9 @@ def setup_fallout(dirname):
         return as_vector((Constant(0.), Constant(0.)))
 
     # build time stepper
-    stepper = PrescribedAdvection(state, problem,
+    stepper = PrescribedTransport(state, problem,
                                   physics_list=physics_list,
-                                  prescribed_advecting_velocity=zero_u)
+                                  prescribed_transporting_velocity=zero_u)
 
     return stepper, 10.0
 

--- a/tests/test_recovered_space.py
+++ b/tests/test_recovered_space.py
@@ -4,11 +4,11 @@ from firedrake import (as_vector, Constant, PeriodicIntervalMesh,
                        Function, conditional, sqrt)
 
 # This setup creates a sharp bubble of warm air in a vertical slice
-# This bubble is then advected by a prescribed advection scheme
+# This bubble is then transported by a prescribed transport scheme
 
 
-def run(state, advection_scheme, tmax):
-    timestepper = PrescribedAdvection(state, advection_scheme)
+def run(state, transport_scheme, tmax):
+    timestepper = PrescribedTransport(state, transport_scheme)
     timestepper.run(0, tmax)
 
 
@@ -64,12 +64,12 @@ def test_recovered_space_setup(tmpdir):
                                                Constant(0.2),
                                                Constant(0.0)), Constant(0.0)))
 
-    # set up advection scheme
+    # set up transport scheme
     recovered_opts = RecoveredOptions(embedding_space=VDG1,
                                       recovered_space=VCG1,
                                       broken_space=VDG0,
                                       boundary_method=Boundary_Method.dynamics)
 
-    advection_scheme = [(tracereqn, SSPRK3(state, options=recovered_opts))]
+    transport_scheme = [(tracereqn, SSPRK3(state, options=recovered_opts))]
 
-    run(state, advection_scheme, tmax=10)
+    run(state, transport_scheme, tmax=10)

--- a/tests/test_supg_advection.py
+++ b/tests/test_supg_advection.py
@@ -25,14 +25,14 @@ def test_supg_advection_scalar(tmpdir, equation_form, scheme, space,
         V = state.spaces("theta", degree=1)
         ibp = IntegrateByParts.TWICE
 
-    opts = SUPGOptions()
+    opts = SUPGOptions(ibp=ibp)
 
     if equation_form == "advective":
         eqn = AdvectionEquation(state, V, "f", ufamily=setup.family,
-                                udegree=setup.degree, ibp=ibp)
+                                udegree=setup.degree)
     else:
         eqn = ContinuityEquation(state, V, "f", ufamily=setup.family,
-                                 udegree=setup.degree, ibp=ibp)
+                                 udegree=setup.degree)
     state.fields("f").interpolate(setup.f_init)
     state.fields("u").project(setup.uexpr)
     if scheme == "ssprk":
@@ -61,14 +61,14 @@ def test_supg_advection_vector(tmpdir, equation_form, scheme, space,
         V = state.spaces("HDiv", setup.family, setup.degree)
         ibp = IntegrateByParts.TWICE
 
-    opts = SUPGOptions()
+    opts = SUPGOptions(ibp=ibp)
 
     if equation_form == "advective":
         eqn = AdvectionEquation(state, V, "f", ufamily=setup.family,
-                                udegree=setup.degree, ibp=ibp)
+                                udegree=setup.degree)
     else:
         eqn = ContinuityEquation(state, V, "f", ufamily=setup.family,
-                                 udegree=setup.degree, ibp=ibp)
+                                 udegree=setup.degree)
     f = state.fields("f")
     if space == "CG":
         f.interpolate(f_init)

--- a/tests/test_supg_transport.py
+++ b/tests/test_supg_transport.py
@@ -3,8 +3,8 @@ from gusto import *
 import pytest
 
 
-def run(state, advection_scheme, tmax, f_end):
-    timestepper = PrescribedAdvection(state, advection_scheme)
+def run(state, transport_scheme, tmax, f_end):
+    timestepper = PrescribedTransport(state, transport_scheme)
     timestepper.run(0, tmax)
     return norm(state.fields("f") - f_end)
 
@@ -12,7 +12,7 @@ def run(state, advection_scheme, tmax, f_end):
 @pytest.mark.parametrize("equation_form", ["advective", "continuity"])
 @pytest.mark.parametrize("scheme", ["ssprk", "implicit_midpoint"])
 @pytest.mark.parametrize("space", ["CG", "theta"])
-def test_supg_advection_scalar(tmpdir, equation_form, scheme, space,
+def test_supg_transport_scalar(tmpdir, equation_form, scheme, space,
                                tracer_setup):
 
     setup = tracer_setup(tmpdir, geometry="slice")
@@ -36,17 +36,17 @@ def test_supg_advection_scalar(tmpdir, equation_form, scheme, space,
     state.fields("f").interpolate(setup.f_init)
     state.fields("u").project(setup.uexpr)
     if scheme == "ssprk":
-        advection_scheme = [(eqn, SSPRK3(state, options=opts))]
+        transport_scheme = [(eqn, SSPRK3(state, options=opts))]
     elif scheme == "implicit_midpoint":
-        advection_scheme = [(eqn, ImplicitMidpoint(state, options=opts))]
+        transport_scheme = [(eqn, ImplicitMidpoint(state, options=opts))]
 
-    assert run(state, advection_scheme, setup.tmax, setup.f_end) < setup.tol
+    assert run(state, transport_scheme, setup.tmax, setup.f_end) < setup.tol
 
 
 @pytest.mark.parametrize("equation_form", ["advective", "continuity"])
 @pytest.mark.parametrize("scheme", ["ssprk", "implicit_midpoint"])
 @pytest.mark.parametrize("space", ["CG", "HDiv"])
-def test_supg_advection_vector(tmpdir, equation_form, scheme, space,
+def test_supg_transport_vector(tmpdir, equation_form, scheme, space,
                                tracer_setup):
 
     setup = tracer_setup(tmpdir, geometry="slice")
@@ -76,9 +76,9 @@ def test_supg_advection_vector(tmpdir, equation_form, scheme, space,
         f.project(f_init)
     state.fields("u").project(setup.uexpr)
     if scheme == "ssprk":
-        advection_scheme = [(eqn, SSPRK3(state, options=opts))]
+        transport_scheme = [(eqn, SSPRK3(state, options=opts))]
     elif scheme == "implicit_midpoint":
-        advection_scheme = [(eqn, ImplicitMidpoint(state, options=opts))]
+        transport_scheme = [(eqn, ImplicitMidpoint(state, options=opts))]
 
     f_end = as_vector((setup.f_end, *[0.]*(gdim-1)))
-    assert run(state, advection_scheme, setup.tmax, f_end) < setup.tol
+    assert run(state, transport_scheme, setup.tmax, f_end) < setup.tol

--- a/tests/test_sw_linear_triangle.py
+++ b/tests/test_sw_linear_triangle.py
@@ -43,10 +43,10 @@ def setup_sw(dirname):
     u0.project(uexpr)
     D0.interpolate(Dexpr)
 
-    advection_schemes = [ForwardEuler(state, "D")]
+    transport_schemes = [ForwardEuler(state, "D")]
 
     # build time stepper
-    stepper = CrankNicolson(state, eqns, advection_schemes)
+    stepper = CrankNicolson(state, eqns, transport_schemes)
 
     return stepper, 2*day
 

--- a/tests/test_sw_triangle.py
+++ b/tests/test_sw_triangle.py
@@ -12,7 +12,7 @@ day = 24.*60.*60.
 u_max = 2*pi*R/(12*day)  # Maximum amplitude of the zonal wind (m/s)
 
 
-def setup_sw(dirname, dt, u_advection_option):
+def setup_sw(dirname, dt, u_transport_option):
 
     refinements = 3  # number of horizontal cells = 20*(4^refinements)
 
@@ -52,7 +52,7 @@ def setup_sw(dirname, dt, u_advection_option):
     fexpr = 2*Omega*x[2]/R
     eqns = ShallowWaterEquations(state, family="BDM", degree=1,
                                  fexpr=fexpr,
-                                 u_advection_option=u_advection_option)
+                                 u_transport_option=u_transport_option)
 
     # interpolate initial conditions
     u0 = state.fields("u")
@@ -124,32 +124,32 @@ def check_results(dirname):
     assert u_max * (1 - tolerance) < u_zonal["max"][0] < u_max * (1 + tolerance)
 
 
-@pytest.mark.parametrize("u_advection_option",
+@pytest.mark.parametrize("u_transport_option",
                          ["vector_invariant_form", "circulation_form",
                           "vector_advection_form"])
-def test_sw_setup(tmpdir, u_advection_option):
+def test_sw_setup(tmpdir, u_transport_option):
 
     dirname = str(tmpdir)
     dt = 1500
-    state, eqns = setup_sw(dirname, dt, u_advection_option)
+    state, eqns = setup_sw(dirname, dt, u_transport_option)
 
-    advected_fields = []
-    advected_fields.append((ImplicitMidpoint(state, "u")))
-    advected_fields.append((SSPRK3(state, "D")))
-    stepper = CrankNicolson(state, eqns, advected_fields)
+    transported_fields = []
+    transported_fields.append((ImplicitMidpoint(state, "u")))
+    transported_fields.append((SSPRK3(state, "D")))
+    stepper = CrankNicolson(state, eqns, transported_fields)
     stepper.run(t=0, tmax=0.25*day)
 
     check_results(dirname)
 
 
-@pytest.mark.parametrize("u_advection_option",
+@pytest.mark.parametrize("u_transport_option",
                          ["vector_invariant_form", "circulation_form",
                           "vector_advection_form"])
-def test_sw_ssprk3(tmpdir, u_advection_option):
+def test_sw_ssprk3(tmpdir, u_transport_option):
 
     dirname = str(tmpdir)
     dt = 100
-    state, eqns = setup_sw(dirname, dt, u_advection_option)
+    state, eqns = setup_sw(dirname, dt, u_transport_option)
 
     stepper = Timestepper(state, ((eqns, SSPRK3(state)),))
     stepper.run(t=0, tmax=0.01*day)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -2,7 +2,7 @@
 Tests various Gusto ActiveTracer objects.
 """
 
-from gusto import (ActiveTracer, TransportEquationForm,
+from gusto import (ActiveTracer, TransportEquationType,
                    TracerVariableType, Phases)
 import pytest
 
@@ -11,8 +11,8 @@ def test_tracer_classes():
     names = ['mr_v', 'big_blob']
     spaces = ['V', 'U']
     transport_flags = [True, False]
-    transport_eqns = [TransportEquationForm.advective,
-                      TransportEquationForm.no_transport]
+    transport_eqns = [TransportEquationType.advective,
+                      TransportEquationType.no_transport]
     variable_types = [TracerVariableType.mixing_ratio]
 
     for name, space, transport_flag, transport_eqn in \

--- a/tests/test_vector_recovered_space.py
+++ b/tests/test_vector_recovered_space.py
@@ -5,11 +5,11 @@ from firedrake import (as_vector, Constant, PeriodicIntervalMesh,
                        FiniteElement, TensorProductElement, HDiv, interval)
 
 # This setup creates a sharp bubble of warm air in a vertical slice
-# This bubble is then advected by a prescribed advection scheme
+# This bubble is then transported by a prescribed transport scheme
 
 
-def run(state, advection_scheme, tmax):
-    timestepper = PrescribedAdvection(state, advection_scheme)
+def run(state, transport_scheme, tmax):
+    timestepper = PrescribedTransport(state, transport_scheme)
     timestepper.run(0, tmax)
 
 
@@ -83,12 +83,12 @@ def test_vector_recovered_space_setup(tmpdir):
                                           Constant(0.0)), Constant(0.0))
     tracer.project(as_vector([scalar_expr, scalar_expr]))
 
-    # set up advection scheme
+    # set up transport scheme
     recovered_opts = RecoveredOptions(embedding_space=Vu_DG1,
                                       recovered_space=Vu_CG1,
                                       broken_space=Vu,
                                       boundary_method=Boundary_Method.dynamics)
 
-    advection_scheme = [(tracereqn, SSPRK3(state, options=recovered_opts))]
+    transport_scheme = [(tracereqn, SSPRK3(state, options=recovered_opts))]
 
-    run(state, advection_scheme, tmax=10)
+    run(state, transport_scheme, tmax=10)

--- a/tests/test_weightless_tracer.py
+++ b/tests/test_weightless_tracer.py
@@ -70,8 +70,8 @@ def setup_tracer(dirname):
     state.set_reference_profiles([('rho', rho_b),
                                   ('theta', theta_b)])
 
-    # set up advection schemes
-    advection_schemes = [ImplicitMidpoint(state, "u"),
+    # set up transport schemes
+    transport_schemes = [ImplicitMidpoint(state, "u"),
                          SSPRK3(state, "rho"),
                          SSPRK3(state, "theta", options=SUPGOptions())]
 
@@ -79,7 +79,7 @@ def setup_tracer(dirname):
     linear_solver = CompressibleSolver(state, eqns)
 
     # build time stepper
-    stepper = CrankNicolson(state, eqns, advection_schemes,
+    stepper = CrankNicolson(state, eqns, transport_schemes,
                             auxiliary_equations_and_schemes=[(tracer_eqn, SSPRK3(state, options=SUPGOptions()))],
                             linear_solver=linear_solver)
 


### PR DESCRIPTION
### FML Transport Updates

This PR:
1. allows us to alter the transport term used by equations after they are created. This is necessary because the transport term is set up with the equations, but when the specific transport scheme is declared later, it may need a different integration by parts (e.g. for SUPG). To provide this capability, this PR:
  - introduces a `replace_transport_term` method to the `Transport` object (formally `Advection`, see 3. below)
  - this method allows the transport term of the `Transport` object to be removed and replaced with a new term
  - the new term is set up from information in the `options` configuration object
2. makes the default potential temperature / buoyancy transport use an `IntegrateByParts.ONCE` term (as is the case for many tests on Gusto master branch)
3. moves the `IntegrateByParts` and `TransportEquationType` enumerators to configuration.py
4. changes the terminology of transport-related things, so that:
  - "transport" is the most general term, referring to any transport form
  - the "advective form" of the transport equation has transport term with (u.grad)q
  - the "conservative form" of the transport equation has transport term with div(q*u)
  - "advection" is when the "advective form" of the transport equation is solved
5. changes two file names (`advection.py` --> `transport_time_steps.py` and `transport_equation.py` -> `transport_forms.py`)
6. fixes a small bug in the moist heat capacity computation in `equations.py`
7. Adds a `None` initialiser to `functools.reduce` in the `label_map`, allowing the `label_map` routine to return an empty form