### PR TITLE
Reorganise replace_subject function

### DIFF
--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -75,9 +75,17 @@ def replace_subject(new, idx=None):
 
         # subj is a normal Function
         else:
-            if not isinstance(new, Function):
+            if type(new) is tuple:
+                if idx is None:
+                    raise ValueError('idx must be specified to replace_subject'+
+                                     ' when new is a tuple')
+                replace_dict[subj] = new[idx]
+            elif not isinstance(new, Function):
                 raise ValueError(f'new must be a Function, not type {type(new)}')
-            elif type(new.ufl_element()) is MixedElement:
+            elif type(new.ufl_element()) == MixedElement:
+                if idx is None:
+                    raise ValueError('idx must be specified to replace_subject'+
+                                     ' when new is a tuple')
                 replace_dict[subj] = split(new)[idx]
             else:
                 replace_dict[subj] = new

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -1,5 +1,5 @@
 import ufl
-from firedrake import Function, split, VectorElement
+from firedrake import Function, split, MixedElement, VectorElement
 from gusto.fml.form_manipulation_labelling import Term, Label, LabelledForm
 
 
@@ -21,38 +21,72 @@ def replace_test_function(new_test):
 
 
 def replace_subject(new, idx=None):
+    """
+    Returns a function that takes a :class:`Term` and returns a new
+    :class:`Term` with the subject of a term replaced by another variable.
 
+    :arg new: the new variable to replace the subject
+    :arg idx: (Optional) index of the subject in a mixed function space
+    """
     def repl(t):
+        """
+        Function returned by replace_subject to return a new :class:`Term` with
+        the subject replaced by the variable `new`. It is built around the ufl
+        replace routine.
+
+        Returns a new :class:`Term`.
+
+        :arg t: the original :class:`Term`.
+        """
+
         subj = t.get(subject)
 
+        # Build a dictionary to pass to the ufl.replace routine
+        # The dictionary matches variables in the old term with those in the new
         replace_dict = {}
-        if len(subj.function_space()) > 1:
+
+        # Consider cases that subj is normal Function or MixedFunction
+        # vs cases of new being Function vs MixedFunction vs tuple
+        # Ideally catch all cases or fail gracefully
+        if (isinstance(subj.ufl_element(), MixedElement)
+            and not isinstance(subj.ufl_element(), VectorElement)):
             if type(new) == tuple:
                 assert len(new) == len(subj.function_space())
                 for k, v in zip(split(subj), new):
                     replace_dict[k] = v
-            else:
-                if idx is None:
+
+            # Otherwise fail if new is not a function
+            elif not isinstance(new, Function):
+                raise ValueError(f'new must be a tuple or Function, not type {type(new)}')
+
+            # Now handle MixedElements separately as these need indexing
+            elif (isinstance(new.ufl_element(), MixedElement)
+              and not isinstance(new.ufl_element(), VectorElement)):
+                assert len(new.function_space()) == len(subj.function_space())
+                # If idx specified, replace only that component
+                if idx is not None:
+                    replace_dict[split(subj)[idx]] = split(new)[idx]
+                # Otherwise replace all components
+                else:
                     for k, v in zip(split(subj), split(new)):
                         replace_dict[k] = v
-                # TODO: Could we do something better here?
-                elif isinstance(new.ufl_element(), VectorElement):
-                    replace_dict[split(subj)[idx]] = new
-                else:
-                    try:
-                        # This needs to handle with MixedFunctionSpace and
-                        # VectorFunctionSpace differently
-                        replace_dict[split(subj)[idx]] = split(new)[idx]
-                    except IndexError:
-                        replace_dict[split(subj)[idx]] = new
 
+            # Otherwise 'new' is a normal Function
+            else:
+                replace_dict[split(subj)[idx]] = new
+
+        # subj is a normal Function
         else:
-            if len(new.function_space()) > 1:
-                replace_dict[subj] = new[idx]
+            if not isinstance(new, Function):
+                raise ValueError(f'new must be a Function, not type {type(new)}')
+            elif (isinstance(new.ufl_element(), MixedElement)
+                  and not isinstance(new.ufl_element(), VectorElement)):
+                replace_dict[subj] = split(new)[idx]
             else:
                 replace_dict[subj] = new
 
         new_form = ufl.replace(t.form, replace_dict)
+
         return Term(new_form, t.labels)
 
     return repl

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -48,8 +48,7 @@ def replace_subject(new, idx=None):
         # Consider cases that subj is normal Function or MixedFunction
         # vs cases of new being Function vs MixedFunction vs tuple
         # Ideally catch all cases or fail gracefully
-        if (isinstance(subj.ufl_element(), MixedElement)
-            and not isinstance(subj.ufl_element(), VectorElement)):
+        if type(subj.ufl_element()) is MixedElement:
             if type(new) == tuple:
                 assert len(new) == len(subj.function_space())
                 for k, v in zip(split(subj), new):
@@ -60,8 +59,7 @@ def replace_subject(new, idx=None):
                 raise ValueError(f'new must be a tuple or Function, not type {type(new)}')
 
             # Now handle MixedElements separately as these need indexing
-            elif (isinstance(new.ufl_element(), MixedElement)
-              and not isinstance(new.ufl_element(), VectorElement)):
+            elif type(new.ufl_element()) is MixedElement:
                 assert len(new.function_space()) == len(subj.function_space())
                 # If idx specified, replace only that component
                 if idx is not None:
@@ -79,8 +77,7 @@ def replace_subject(new, idx=None):
         else:
             if not isinstance(new, Function):
                 raise ValueError(f'new must be a Function, not type {type(new)}')
-            elif (isinstance(new.ufl_element(), MixedElement)
-                  and not isinstance(new.ufl_element(), VectorElement)):
+            elif type(new.ufl_element()) is MixedElement:
                 replace_dict[subj] = split(new)[idx]
             else:
                 replace_dict[subj] = new

--- a/tests/test_replace_subject.py
+++ b/tests/test_replace_subject.py
@@ -1,0 +1,101 @@
+"""
+Tests the replace_subject routine from labels.py
+"""
+
+from firedrake import (UnitSquareMesh, FunctionSpace, Function, TestFunction,
+                       VectorFunctionSpace, MixedFunctionSpace, dx, inner,
+                       TrialFunctions)
+from gusto.fml import Label, all_terms
+from gusto import subject, replace_subject
+import pytest
+
+
+@pytest.mark.parametrize('subject_type', ['normal', 'mixed', 'vector'])
+@pytest.mark.parametrize('replacement_type', ['normal', 'mixed', 'vector', 'tuple'])
+def test_replace_subject(subject_type, replacement_type):
+
+    # ------------------------------------------------------------------------ #
+    # Only certain combinations of options are valid
+    # ------------------------------------------------------------------------ #
+
+    if subject_type == 'vector' and replacement_type != 'vector':
+        return True
+    elif replacement_type == 'vector' and subject_type != 'vector':
+        return True
+
+    # ------------------------------------------------------------------------ #
+    # Set up
+    # ------------------------------------------------------------------------ #
+
+    # Some basic labels
+    foo_label = Label("foo")
+    bar_label = Label("bar")
+
+    # Create mesh, function space and forms
+    n = 3
+    mesh = UnitSquareMesh(n, n)
+    V0 = FunctionSpace(mesh, "DG", 0)
+    V1 = FunctionSpace(mesh, "CG", 1)
+    V2 = VectorFunctionSpace(mesh, "DG", 0)
+    Vmixed = MixedFunctionSpace((V0, V1))
+
+    idx = None
+
+    # ------------------------------------------------------------------------ #
+    # Choose subject
+    # ------------------------------------------------------------------------ #
+
+    if subject_type == 'normal':
+        V = V0
+    elif subject_type == 'mixed':
+        V = Vmixed
+        if replacement_type == 'normal':
+            idx = 0
+    elif subject_type == 'vector':
+        V = V2
+    else:
+        raise ValueError
+
+    the_subject = Function(V)
+    not_subject = Function(V)
+    test = TestFunction(V)
+
+    form_1 = inner(the_subject, test)*dx
+    form_2 = inner(not_subject, test)*dx
+
+    term_1 = foo_label(subject(form_1, the_subject))
+    term_2 = bar_label(form_2)
+    labelled_form = term_1 + term_2
+
+    # ------------------------------------------------------------------------ #
+    # Choose replacement
+    # ------------------------------------------------------------------------ #
+
+    if replacement_type == 'normal':
+        V = V1
+    elif replacement_type == 'mixed':
+        V = Vmixed
+        if subject_type != 'mixed':
+            idx = 0
+    elif replacement_type == 'vector':
+        V = V2
+    elif replacement_type == 'tuple':
+        V = Vmixed
+    else:
+        raise ValueError
+
+    the_replacement = Function(V)
+
+    if replacement_type == 'tuple':
+        the_replacement = TrialFunctions(Vmixed)
+        if subject_type == 'normal':
+            idx = 0
+
+    # ------------------------------------------------------------------------ #
+    # Test replace_subject
+    # ------------------------------------------------------------------------ #
+
+    new_labelled_form = labelled_form.label_map(
+        lambda t: t.has_label(subject),
+        map_if_true=replace_subject(the_replacement, idx=idx)
+    )


### PR DESCRIPTION
This is a small PR to improve the `replace_subject` function.

There are a number of special cases (e.g. mixed functions, tuples, etc) that need special handling. This reorganises this routine in an attempt to capture errors properly.