### PR TITLE
FML unit tests

### DIFF
--- a/examples/compressible_eady.py
+++ b/examples/compressible_eady.py
@@ -131,8 +131,8 @@ state.set_reference_profiles([('rho', rho_b),
 
 # Set up transport schemes
 transported_fields = [SSPRK3(state, "u"),
-                   SSPRK3(state, "rho"),
-                   SSPRK3(state, "theta")]
+                      SSPRK3(state, "rho"),
+                      SSPRK3(state, "theta")]
 
 linear_solver = CompressibleSolver(state, eqns)
 

--- a/examples/dcmip_3_1_meanflow_quads.py
+++ b/examples/dcmip_3_1_meanflow_quads.py
@@ -127,8 +127,8 @@ state.set_reference_profiles([('rho', rho_b), ('theta', theta_b)])
 
 # Set up transport schemes
 transported_fields = [ImplicitMidpoint(state, "u"),
-                   SSPRK3(state, "rho", subcycles=2),
-                   SSPRK3(state, "theta", options=SUPGOptions(), subcycles=2)]
+                      SSPRK3(state, "rho", subcycles=2),
+                      SSPRK3(state, "theta", options=SUPGOptions(), subcycles=2)]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns)

--- a/examples/dense_bubble.py
+++ b/examples/dense_bubble.py
@@ -89,8 +89,8 @@ for delta, dt in res_dt.items():
     else:
         thetaeqn = EmbeddedDGOptions()
     transported_fields = [ImplicitMidpoint(state, "u"),
-                       SSPRK3(state, "rho"),
-                       SSPRK3(state, "theta", options=theta_opts)]
+                          SSPRK3(state, "rho"),
+                          SSPRK3(state, "theta", options=theta_opts)]
 
     # Set up linear solver
     linear_solver = CompressibleSolver(state, eqns)

--- a/examples/dry_bf_bubble.py
+++ b/examples/dry_bf_bubble.py
@@ -149,7 +149,7 @@ else:
     limiter = None
 
 transported_fields = [SSPRK3(state, "rho", options=rho_opts),
-                   SSPRK3(state, "theta", options=theta_opts, limiter=limiter)]
+                      SSPRK3(state, "theta", options=theta_opts, limiter=limiter)]
 if recovered:
     transported_fields.append(SSPRK3(state, "u", options=u_opts))
 else:

--- a/examples/gw_incompressible.py
+++ b/examples/gw_incompressible.py
@@ -80,7 +80,7 @@ if supg:
 else:
     b_opts = EmbeddedDGOptions()
 transported_fields = [ImplicitMidpoint(state, "u"),
-                   SSPRK3(state, "b", options=b_opts)]
+                      SSPRK3(state, "b", options=b_opts)]
 
 # Set up linear solver for the timestepping scheme
 linear_solver = IncompressibleSolver(state, eqns)

--- a/examples/mountain_hydrostatic.py
+++ b/examples/mountain_hydrostatic.py
@@ -147,8 +147,8 @@ if supg:
 else:
     theta_opts = EmbeddedDGOptions()
 transported_fields = [ImplicitMidpoint(state, "u"),
-                   SSPRK3(state, "rho"),
-                   SSPRK3(state, "theta", options=theta_opts)]
+                      SSPRK3(state, "rho"),
+                      SSPRK3(state, "theta", options=theta_opts)]
 
 # Set up linear solver
 params = {'mat_type': 'matfree',

--- a/examples/mountain_nonhydrostatic.py
+++ b/examples/mountain_nonhydrostatic.py
@@ -141,8 +141,8 @@ if supg:
 else:
     theta_opts = EmbeddedDGOptions()
 transported_fields = [ImplicitMidpoint(state, "u"),
-                   SSPRK3(state, "rho"),
-                   SSPRK3(state, "theta", options=theta_opts)]
+                      SSPRK3(state, "rho"),
+                      SSPRK3(state, "theta", options=theta_opts)]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns)

--- a/examples/sk_nonlinear.py
+++ b/examples/sk_nonlinear.py
@@ -101,8 +101,8 @@ if supg:
 else:
     theta_opts = EmbeddedDGOptions()
 transported_fields = [ImplicitMidpoint(state, "u"),
-                   SSPRK3(state, "rho"),
-                   SSPRK3(state, "theta", options=theta_opts)]
+                      SSPRK3(state, "rho"),
+                      SSPRK3(state, "theta", options=theta_opts)]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns)

--- a/examples/tracer.py
+++ b/examples/tracer.py
@@ -93,8 +93,8 @@ for delta, dt in res_dt.items():
         theta_opts = EmbeddedDGOptions()
         water_opts = EmbeddedDGOptions()
     transported_fields = [ImplicitMidpoint(state, "u"),
-                       SSPRK3(state, "rho"),
-                       SSPRK3(state, "theta", options=theta_opts)]
+                          SSPRK3(state, "rho"),
+                          SSPRK3(state, "theta", options=theta_opts)]
 
     # Set up linear solver
     linear_solver = CompressibleSolver(state, eqns)

--- a/gusto/fml/form_manipulation_labelling.py
+++ b/gusto/fml/form_manipulation_labelling.py
@@ -11,7 +11,7 @@ all_terms = lambda t: True
 
 class Term(object):
     """
-    Term class, containing a form and its labels.
+    Term class, contains a form and its labels.
 
     :arg form: the form for this term
     :arg label_dict: dictionary of key-value pairs corresponding to current form labels.
@@ -25,8 +25,8 @@ class Term(object):
     def get(self, label, default=None):
         return self.labels.get(label.label)
 
-    def has_label(self, *labels):
-        if len(labels) == 1:
+    def has_label(self, *labels, return_tuple=False):
+        if len(labels) == 1 and not return_tuple:
             return labels[0].label in self.labels
         else:
             return tuple(self.has_label(l) for l in labels)
@@ -41,7 +41,9 @@ class Term(object):
         else:
             return NotImplemented
 
-    __radd__ = __add__
+    def __sub__(self, other):
+        other = other * -1
+        return self + other
 
     def __mul__(self, other):
         if type(other) in (float, int):
@@ -50,16 +52,35 @@ class Term(object):
             return NotImplemented
         return Term(other*self.form, self.labels)
 
+    def __truediv__(self, other):
+        if type(other) in (float, int, Constant, ufl.algebra.Product):
+            other = Constant(1.0 / other)
+            return self * other
+        else:
+            return NotImplemented
+
     __rmul__ = __mul__
 
 
+NullTerm = Term(None)
+
+
 class LabelledForm(object):
+    """
+    The `LabelledForm` object holds a list of terms, which pair :class:`Form`
+    objects with :class:`Label`s. The `label_map` routine allows the terms to be
+    manipulated or selected based on particular filters.
+
+    :arg *terms: a list of `Term` objects or a single `LabelledForm`.
+    """
     __slots__ = ["terms"]
 
     def __init__(self, *terms):
         if len(terms) == 1 and isinstance(terms[0], LabelledForm):
             self.terms = terms[0].terms
         else:
+            if any([type(term) is not Term for term in list(terms)]):
+                raise TypeError('Can only pass terms or a LabelledForm to LabelledForm')
             self.terms = list(terms)
 
     def __add__(self, other):
@@ -87,11 +108,18 @@ class LabelledForm(object):
             return NotImplemented
 
     def __mul__(self, other):
-        if type(other) is float:
+        if type(other) in (float, int):
             other = Constant(other)
         elif type(other) not in [Constant, ufl.algebra.Product]:
             return NotImplemented
         return self.label_map(all_terms, lambda t: Term(other*t.form, t.labels))
+
+    def __truediv__(self, other):
+        if type(other) in (float, int, Constant, ufl.algebra.Product):
+            other = Constant(1.0 / other)
+            return self * other
+        else:
+            return NotImplemented
 
     __rmul__ = __mul__
 
@@ -108,13 +136,22 @@ class LabelledForm(object):
         `map_if_true`; terms for which `term_filter` is false are
         transformed by map_is_false."""
 
-        return LabelledForm(
+        new_labelled_form = LabelledForm(
             functools.reduce(operator.add,
                              filter(lambda t: t is not None,
                                     (map_if_true(t) if term_filter(t) else
                                      map_if_false(t) for t in self.terms)),
-                             # initialiser for if the list is empty
-                             None))
+                             # TODO: Not clear what the initialiser should be!
+                             # No initialiser means label_map can't work if everything is false
+                             # None is a problem as cannot be added to Term
+                             # NullTerm works but will need dropping ...
+                             NullTerm))
+
+        # Drop the NullTerm
+        new_labelled_form.terms = list(filter(lambda t: t is not NullTerm,
+                                              new_labelled_form.terms))
+
+        return new_labelled_form
 
     @property
     def form(self):
@@ -123,7 +160,7 @@ class LabelledForm(object):
 
 class Label(object):
     """
-    Class providing labelling functionality for Gusto terms and equations
+    Class providing labelling functionality for Gusto forms and equations
 
     :arg label: str giving the name of the label.
     :arg value: str providing the value of the label. Defaults to True.
@@ -138,6 +175,10 @@ class Label(object):
         self.validator = validator
 
     def __call__(self, target, value=None):
+        """
+        Application of the `Label` to the `target` adds the label to the terms
+        in the `target`. If `value` is provided, the label takes this value.
+        """
         # if value is provided, check that we have a validator function
         # and validate the value, otherwise use default value
         if value is not None:
@@ -160,6 +201,7 @@ class Label(object):
     def remove(self, target):
         """Remove any :form:`Label` with this `label` from
         `target`. If called on an :class:`LabelledForm`, act termwise."""
+
         if isinstance(target, LabelledForm):
             return LabelledForm(*(self.remove(t) for t in target.terms))
         elif isinstance(target, Term):
@@ -173,6 +215,9 @@ class Label(object):
             raise ValueError("Unable to unlabel %s" % target)
 
     def update_value(self, target, new):
+        """Update any :form:`Label` with this `label` in `target`, giving it
+        the new value of `new`."""
+
         if isinstance(target, LabelledForm):
             return LabelledForm(*(self.update_value(t, new) for t in target.terms))
         elif isinstance(target, Term):

--- a/tests/fml_tests/test_label.py
+++ b/tests/fml_tests/test_label.py
@@ -1,0 +1,71 @@
+"""
+Tests FML's Label objects.
+"""
+
+from firedrake import IntervalMesh, FunctionSpace, Function, TestFunction
+from gusto.configuration import TransportEquationType
+from gusto.fml import Label, LabelledForm, Term
+from ufl import Form
+import pytest
+
+@pytest.fixture
+def label(label_type):
+    # Returns labels with different value validation
+
+    if label_type == "boolean":
+        # A label that is simply a string, whose value is Boolean
+        return Label("foo")
+
+    elif label_type == "integer":
+        # A label whose value is an integer
+        return Label("foo", validator=lambda value: (type(value) == int and value < 9))
+
+    elif label_type == "other":
+        # A label whose value is some other type
+        return Label("foo", validator=type(value) == TransportEquationType)
+
+    elif label_type == "function":
+        # A label whose value is an Function
+        return Label("foo", type(value) == Function)
+
+
+@pytest.fixture
+def object_to_label(object_type):
+    # A series of different objects to be labelled
+
+    if object_type == int:
+        return 10
+
+    else:
+        # Create mesh and function space
+        L = 3.0
+        n = 3
+        mesh = IntervalMesh(n, L)
+        V = FunctionSpace(mesh, "DG", 0)
+        f = Function(V)
+        g = TestFunction(V)
+        form = f*g*dx
+        term = Term(form)
+
+        if object_type == Form:
+            return form
+
+        elif object_type == Term:
+            return term
+
+        elif object_type == LabelledForm:
+            return LabelledForm(term)
+
+        else:
+            raise ValueError(f'object_type {object_type} not implemented')
+
+
+@pytest.mark.parametrize("label_type", ["boolean", "integer", "other", "function"],
+                         "object_to_label", [LabelledForm, Term, Form, int])
+def test_label(label_type, label, object_type, object_to_label):
+
+    assert label.label == "foo"
+
+    labelled_object = label(object_to_label)
+
+    import pdb; pdb.set_trace()

--- a/tests/fml_tests/test_label.py
+++ b/tests/fml_tests/test_label.py
@@ -2,31 +2,58 @@
 Tests FML's Label objects.
 """
 
-from firedrake import IntervalMesh, FunctionSpace, Function, TestFunction
+from firedrake import IntervalMesh, FunctionSpace, Function, TestFunction, dx
 from gusto.configuration import TransportEquationType
 from gusto.fml import Label, LabelledForm, Term
 from ufl import Form
 import pytest
 
+
 @pytest.fixture
-def label(label_type):
+def label_and_values(label_type):
     # Returns labels with different value validation
+
+    bad_value = "bar"
 
     if label_type == "boolean":
         # A label that is simply a string, whose value is Boolean
-        return Label("foo")
+        this_label = Label("foo")
+        good_value = True
+        new_value = False
 
     elif label_type == "integer":
         # A label whose value is an integer
-        return Label("foo", validator=lambda value: (type(value) == int and value < 9))
+        this_label = Label("foo", validator=lambda value: (type(value) == int and value < 9))
+        good_value = 5
+        bad_value = 10
+        new_value = 7
 
     elif label_type == "other":
         # A label whose value is some other type
-        return Label("foo", validator=type(value) == TransportEquationType)
+        this_label = Label("foo", validator=lambda value: type(value) == TransportEquationType)
+        good_value = TransportEquationType.advective
+        new_value = TransportEquationType.conservative
 
     elif label_type == "function":
         # A label whose value is an Function
-        return Label("foo", type(value) == Function)
+        this_label = Label("foo", validator=lambda value: type(value) == Function)
+        good_value, _ = setup_form()
+        new_value = Function(good_value.function_space())
+
+    return this_label, good_value, bad_value, new_value
+
+
+def setup_form():
+    # Create mesh and function space
+    L = 3.0
+    n = 3
+    mesh = IntervalMesh(n, L)
+    V = FunctionSpace(mesh, "DG", 0)
+    f = Function(V)
+    g = TestFunction(V)
+    form = f*g*dx
+
+    return f, form
 
 
 @pytest.fixture
@@ -37,14 +64,7 @@ def object_to_label(object_type):
         return 10
 
     else:
-        # Create mesh and function space
-        L = 3.0
-        n = 3
-        mesh = IntervalMesh(n, L)
-        V = FunctionSpace(mesh, "DG", 0)
-        f = Function(V)
-        g = TestFunction(V)
-        form = f*g*dx
+        _, form = setup_form()
         term = Term(form)
 
         if object_type == Form:
@@ -60,12 +80,111 @@ def object_to_label(object_type):
             raise ValueError(f'object_type {object_type} not implemented')
 
 
-@pytest.mark.parametrize("label_type", ["boolean", "integer", "other", "function"],
-                         "object_to_label", [LabelledForm, Term, Form, int])
-def test_label(label_type, label, object_type, object_to_label):
+@pytest.mark.parametrize("label_type", ["boolean", "integer",
+                                        "other", "function"])
+@pytest.mark.parametrize("object_type", [LabelledForm, Term, Form, int])
+def test_label(label_type, object_type, label_and_values, object_to_label):
 
-    assert label.label == "foo"
+    label, good_value, bad_value, new_value = label_and_values
 
-    labelled_object = label(object_to_label)
+    # ------------------------------------------------------------------------ #
+    # Check label has correct name
+    # ------------------------------------------------------------------------ #
 
-    import pdb; pdb.set_trace()
+    assert label.label == "foo", "Label has incorrect name"
+
+    # ------------------------------------------------------------------------ #
+    # Check we can't label unsupported objects
+    # ------------------------------------------------------------------------ #
+
+    if object_type == int:
+        # Can't label integers, so check this fails and force end
+        try:
+            labelled_object = label(object_to_label)
+        except ValueError:
+            # Appropriate error has been returned so end the test
+            return
+
+        # If we get here there has been an error
+        assert False, "Labelling an integer should throw an error"
+
+    # ------------------------------------------------------------------------ #
+    # Test application of labels
+    # ------------------------------------------------------------------------ #
+
+    if label_type == "boolean":
+        labelled_object = label(object_to_label)
+
+    else:
+        # Check that passing an inappropriate label gives the correct error
+        try:
+            labelled_object = label(object_to_label, bad_value)
+            # If we get here the validator has not worked
+            assert False, 'The labelling validator has not worked for ' \
+                + f'label_type {label_type} and object_type {object_type}'
+
+        except AssertionError:
+            # Now label object properly
+            labelled_object = label(object_to_label, good_value)
+
+    # ------------------------------------------------------------------------ #
+    # Check labelled form or term has been returned
+    # ------------------------------------------------------------------------ #
+
+    if object_type == Term:
+        assert type(labelled_object) == Term, 'Labelled Term should be a ' \
+            + f'be a Term and not type {type(labelled_object)}'
+    else:
+        assert type(labelled_object) == LabelledForm, 'Labelled Form should ' \
+            + f'be a Labelled Form and not type {type(labelled_object)}'
+
+    # ------------------------------------------------------------------------ #
+    # Test that the values are correct
+    # ------------------------------------------------------------------------ #
+
+    if object_type == Term:
+        assert labelled_object.get(label) == good_value, 'Value of label ' \
+            + f'should be {good_value} and not {labelled_object.get(label)}'
+    else:
+        assert labelled_object.terms[0].get(label) == good_value, 'Value of ' \
+            + f'label should be {good_value} and not ' \
+            + f'{labelled_object.terms[0].get(label)}'
+
+    # ------------------------------------------------------------------------ #
+    # Test updating of values
+    # ------------------------------------------------------------------------ #
+
+    # Check that passing an inappropriate label gives the correct error
+    try:
+        labelled_object = label.update_value(labelled_object, bad_value)
+        # If we get here the validator has not worked
+        assert False, 'The validator has not worked for updating label of ' \
+            + f'label_type {label_type} and object_type {object_type}'
+    except AssertionError:
+        # Update new value
+        labelled_object = label.update_value(labelled_object, new_value)
+
+    # Check that new value is correct
+    if object_type == Term:
+        assert labelled_object.get(label) == new_value, 'Updated value of ' \
+            + f'label should be {new_value} and not {labelled_object.get(label)}'
+    else:
+        assert labelled_object.terms[0].get(label) == new_value, 'Updated ' \
+            + f'value of label should be {new_value} and not ' \
+            + f'{labelled_object.terms[0].get(label)}'
+
+    # ------------------------------------------------------------------------ #
+    # Test removal of values
+    # ------------------------------------------------------------------------ #
+
+    labelled_object = label.remove(labelled_object)
+
+    # Try to see if object still has that label
+    if object_type == Term:
+        label_value = labelled_object.get(label)
+    else:
+        label_value = labelled_object.terms[0].get(label)
+
+    # If we get here then the label has been extracted but it shouldn't have
+    assert label_value is None, f'The label {label_type} appears has not to ' \
+        + f'have been removed for object_type {object_type}'

--- a/tests/fml_tests/test_label_map.py
+++ b/tests/fml_tests/test_label_map.py
@@ -1,0 +1,74 @@
+"""
+Tests FML's LabelledForm label_map routine.
+"""
+
+from firedrake import IntervalMesh, FunctionSpace, Function, TestFunction, dx
+from gusto.fml import Label, Term, identity, drop, all_terms
+
+
+def test_label_map():
+
+    # ------------------------------------------------------------------------ #
+    # Set up labelled forms
+    # ------------------------------------------------------------------------ #
+
+    # Some basic labels
+    foo_label = Label("foo")
+    bar_label = Label("bar", validator=lambda value: type(value) == int)
+
+    # Create mesh, function space and forms
+    L = 3.0
+    n = 3
+    mesh = IntervalMesh(n, L)
+    V = FunctionSpace(mesh, "DG", 0)
+    f = Function(V)
+    g = Function(V)
+    test = TestFunction(V)
+    form_1 = f*test*dx
+    form_2 = g*test*dx
+    term_1 = foo_label(Term(form_1))
+    term_2 = bar_label(Term(form_2), 5)
+
+    labelled_form = term_1 + term_2
+
+    # ------------------------------------------------------------------------ #
+    # Test all_terms
+    # ------------------------------------------------------------------------ #
+
+    # Passing all_terms should return the same labelled form
+    new_labelled_form = labelled_form.label_map(all_terms)
+    assert len(new_labelled_form) == len(labelled_form), \
+        'new_labelled_form should be the same as labelled_form'
+    for new_term, term in zip(new_labelled_form.terms, labelled_form.terms):
+        assert new_term == term, 'terms in new_labelled_form should be the ' + \
+            'same as those in labelled_form'
+
+    # ------------------------------------------------------------------------ #
+    # Test identity and drop
+    # ------------------------------------------------------------------------ #
+
+    # Get just the first term, which has the foo label
+    new_labelled_form = labelled_form.label_map(
+        lambda t: t.has_label(foo_label), map_if_true=identity, map_if_false=drop
+    )
+    assert len(new_labelled_form) == 1, 'new_labelled_form should be length 1'
+    for new_term in new_labelled_form.terms:
+        assert new_term.has_label(foo_label), 'All terms in ' + \
+            'new_labelled_form should have foo_label'
+
+    # Give term_1 the bar label
+    new_labelled_form = labelled_form.label_map(
+        lambda t: t.has_label(bar_label), map_if_true=identity,
+        map_if_false=lambda t: bar_label(t, 0)
+    )
+    assert len(new_labelled_form) == 2, 'new_labelled_form should be length 2'
+    for new_term in new_labelled_form.terms:
+        assert new_term.has_label(bar_label), 'All terms in ' + \
+            'new_labelled_form should have bar_label'
+
+    # Test with a more complex filter, which should give an empty labelled_form
+    new_labelled_form = labelled_form.label_map(
+        lambda t: (t.has_label(bar_label) and t.get(bar_label) > 10),
+        map_if_true=identity, map_if_false=drop
+    )
+    assert len(new_labelled_form) == 0, 'new_labelled_form should be length 0'

--- a/tests/fml_tests/test_labelled_form.py
+++ b/tests/fml_tests/test_labelled_form.py
@@ -1,0 +1,134 @@
+"""
+Tests FML's LabelledForm objects.
+"""
+
+from firedrake import (IntervalMesh, FunctionSpace, Function,
+                       TestFunction, dx, Constant)
+from gusto.fml import Label, Term, LabelledForm
+from ufl import Form
+
+
+def test_labelled_form():
+
+    # ------------------------------------------------------------------------ #
+    # Set up labelled forms
+    # ------------------------------------------------------------------------ #
+
+    # Some basic labels
+    lorem_label = Label("lorem", validator=lambda value: type(value) == str)
+    ipsum_label = Label("ipsum", validator=lambda value: type(value) == int)
+
+    # Create mesh, function space and forms
+    L = 3.0
+    n = 3
+    mesh = IntervalMesh(n, L)
+    V = FunctionSpace(mesh, "DG", 0)
+    f = Function(V)
+    g = Function(V)
+    test = TestFunction(V)
+    form_1 = f*test*dx
+    form_2 = g*test*dx
+    term_1 = lorem_label(Term(form_1), 'i_have_lorem')
+    term_2 = ipsum_label(Term(form_2), 5)
+
+    # ------------------------------------------------------------------------ #
+    # Test labelled forms have the correct number of terms
+    # ------------------------------------------------------------------------ #
+
+    # Create from a single term
+    labelled_form_1 = LabelledForm(term_1)
+    assert len(labelled_form_1) == 1, 'LabelledForm should have 1 term'
+
+    # Create from multiple terms
+    labelled_form_2 = LabelledForm(*[term_1, term_2])
+    assert len(labelled_form_2) == 2, 'LabelledForm should have 2 terms'
+
+    # Trying to create from two LabelledForms should give an error
+    try:
+        labelled_form_3 = LabelledForm(labelled_form_1, labelled_form_2)
+        # If we get here something has gone wrong
+        assert False, 'We should not be able to create LabelledForm ' + \
+            'from two LabelledForms'
+    except TypeError:
+        pass
+
+    # Create from a single LabelledForm
+    labelled_form_3 = LabelledForm(labelled_form_1)
+    assert len(labelled_form_3) == 1, 'LabelledForm should have 1 term'
+
+    # ------------------------------------------------------------------------ #
+    # Test getting form
+    # ------------------------------------------------------------------------ #
+
+    assert type(labelled_form_1.form) is Form, 'The form belonging to the ' + \
+        f'LabelledForm must be a Form, and not {type(labelled_form_1.form)}'
+
+    assert type(labelled_form_2.form) is Form, 'The form belonging to the ' + \
+        f'LabelledForm must be a Form, and not {type(labelled_form_2.form)}'
+
+    assert type(labelled_form_3.form) is Form, 'The form belonging to the ' + \
+        f'LabelledForm must be a Form, and not {type(labelled_form_3.form)}'
+
+    # ------------------------------------------------------------------------ #
+    # Test addition and subtraction of labelled forms
+    # ------------------------------------------------------------------------ #
+
+    # Add a Form to a LabelledForm
+    new_labelled_form = labelled_form_1 + form_2
+    assert len(new_labelled_form) == 2, 'LabelledForm should have 2 terms'
+
+    # Add a Term to a LabelledForm
+    new_labelled_form = labelled_form_1 + term_2
+    assert len(new_labelled_form) == 2, 'LabelledForm should have 2 terms'
+
+    # Add a LabelledForm to a LabelledForm
+    new_labelled_form = labelled_form_1 + labelled_form_2
+    assert len(new_labelled_form) == 3, 'LabelledForm should have 3 terms'
+
+    # Adding None to a LabelledForm should give the same LabelledForm
+    new_labelled_form = labelled_form_1 + None
+    assert new_labelled_form == labelled_form_1, 'Two LabelledForms should be equal'
+
+    # Subtract a Form from a LabelledForm
+    new_labelled_form = labelled_form_1 - form_2
+    assert len(new_labelled_form) == 2, 'LabelledForm should have 2 terms'
+
+    # Subtract a Term from a LabelledForm
+    new_labelled_form = labelled_form_1 - term_2
+    assert len(new_labelled_form) == 2, 'LabelledForm should have 2 terms'
+
+    # Subtract a LabelledForm from a LabelledForm
+    new_labelled_form = labelled_form_1 - labelled_form_2
+    assert len(new_labelled_form) == 3, 'LabelledForm should have 3 terms'
+
+    # Subtracting None from a LabelledForm should give the same LabelledForm
+    new_labelled_form = labelled_form_1 - None
+    assert new_labelled_form == labelled_form_1, 'Two LabelledForms should be equal'
+
+    # ------------------------------------------------------------------------ #
+    # Test multiplication and division of labelled forms
+    # ------------------------------------------------------------------------ #
+
+    # Multiply by integer
+    new_labelled_form = labelled_form_1 * -4
+    assert len(new_labelled_form) == 1, 'LabelledForm should have 1 term'
+
+    # Multiply by float
+    new_labelled_form = labelled_form_1 * 12.4
+    assert len(new_labelled_form) == 1, 'LabelledForm should have 1 term'
+
+    # Multiply by Constant
+    new_labelled_form = labelled_form_1 * Constant(5.0)
+    assert len(new_labelled_form) == 1, 'LabelledForm should have 1 term'
+
+    # Divide by integer
+    new_labelled_form = labelled_form_1 / (-8)
+    assert len(new_labelled_form) == 1, 'LabelledForm should have 1 term'
+
+    # Divide by float
+    new_labelled_form = labelled_form_1 / (-6.2)
+    assert len(new_labelled_form) == 1, 'LabelledForm should have 1 term'
+
+    # Divide by Constant
+    new_labelled_form = labelled_form_1 / Constant(0.01)
+    assert len(new_labelled_form) == 1, 'LabelledForm should have 1 term'

--- a/tests/fml_tests/test_term.py
+++ b/tests/fml_tests/test_term.py
@@ -1,0 +1,113 @@
+"""
+Tests FML's label objects.
+"""
+
+from firedrake import (IntervalMesh, Function, RectangleMesh, SpatialCoordinate,
+                       VectorFunctionSpace, FiniteElement)
+
+from gusto import kernels
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def mesh(geometry):
+
+    L = 3.0
+    n = 3
+
+    if geometry == "1D":
+        m = IntervalMesh(n, L)
+    elif geometry == "2D":
+        m = RectangleMesh(n, n, L, L, quadrilateral=True)
+
+    return m
+
+
+def setup_values(geometry, DG0_field, weights):
+
+    x = SpatialCoordinate(weights.function_space().mesh())
+    coords_CG1 = Function(weights.function_space()).interpolate(x)
+    coords_DG0 = Function(DG0_field.function_space()).interpolate(x)
+
+    if geometry == "1D":
+        # Let us focus on the point at x = 1.0
+        # The test is if at CG_field[CG_index] we get the average of the corresponding DG_field values
+        CG_index = set_val_at_point(coords_CG1, 1.0)
+        set_val_at_point(coords_DG0, 0.5, DG0_field, 6.0)
+        set_val_at_point(coords_DG0, 1.5, DG0_field, -10.0)
+        set_val_at_point(coords_CG1, 1.0, weights, 2.0)
+
+        true_values = 0.5 * (6.0 - 10.0)
+
+    elif geometry == "2D":
+        # Let us focus on the point at (1,1)
+        # The test is if at CG_field[CG_index] we get the average of the corresponding DG_field values
+        # We do it for both components of the vector field
+
+        CG_index = set_val_at_point(coords_CG1, [1.0, 1.0])
+        set_val_at_point(coords_CG1, [1.0, 1.0], weights, [4.0, 4.0])
+        set_val_at_point(coords_DG0, [0.5, 0.5], DG0_field, [6.0, -3.0])
+        set_val_at_point(coords_DG0, [1.5, 0.5], DG0_field, [-7.0, -6.0])
+        set_val_at_point(coords_DG0, [0.5, 1.5], DG0_field, [0.0, 3.0])
+        set_val_at_point(coords_DG0, [1.5, 1.5], DG0_field, [-9.0, -1.0])
+
+        true_values = [0.25 * (6.0 - 7.0 + 0.0 - 9.0),
+                       0.25 * (-3.0 - 6.0 + 3.0 - 1.0)]
+
+    return DG0_field, weights, true_values, CG_index
+
+
+def set_val_at_point(coord_field, coords, field=None, new_value=None):
+    """
+    Finds the DoF of a field at a particular coordinate. If new_value is
+    provided then it also assigns the coefficient for the field there to be
+    new_value. Otherwise the DoF index is returned.
+    """
+    num_points = len(coord_field.dat.data[:])
+    point_found = False
+
+    for i in range(num_points):
+        # Do the coordinates at the ith point match our desired coords?
+        if np.allclose(coord_field.dat.data[i], coords, rtol=1e-14):
+            point_found = True
+            point_index = i
+            if field is not None and new_value is not None:
+                field.dat.data[i] = new_value
+            break
+
+    if not point_found:
+        raise ValueError('Your coordinates do not appear to match the coordinates of a DoF')
+
+    if field is None or new_value is None:
+        return point_index
+
+
+@pytest.mark.parametrize("geometry", ["1D", "2D"])
+def test_average(geometry, mesh):
+
+    cell = mesh.ufl_cell().cellname()
+    DG1_elt = FiniteElement("DG", cell, 1, variant="equispaced")
+    vec_DG1 = VectorFunctionSpace(mesh, DG1_elt)
+    vec_DG0 = VectorFunctionSpace(mesh, "DG", 0)
+    vec_CG1 = VectorFunctionSpace(mesh, "CG", 1)
+
+    # We will fill DG1_field with values, and average them to CG_field
+    # First need to put the values into DG0 and then interpolate
+    DG0_field = Function(vec_DG0)
+    DG1_field = Function(vec_DG1)
+    CG_field = Function(vec_CG1)
+    weights = Function(vec_CG1)
+
+    DG0_field, weights, true_values, CG_index = setup_values(geometry, DG0_field, weights)
+
+    DG1_field.interpolate(DG0_field)
+    kernel = kernels.Average(vec_CG1)
+    kernel.apply(CG_field, weights, DG1_field)
+
+    tolerance = 1e-12
+    if geometry == "1D":
+        assert abs(CG_field.dat.data[CG_index] - true_values) < tolerance
+    elif geometry == "2D":
+        assert abs(CG_field.dat.data[CG_index][0] - true_values[0]) < tolerance
+        assert abs(CG_field.dat.data[CG_index][1] - true_values[1]) < tolerance

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -4,7 +4,7 @@ Tests various Gusto ActiveTracer objects.
 
 from gusto import (ActiveTracer, TransportEquationType,
                    TracerVariableType, Phases)
-import pytest
+
 
 def test_tracer_classes():
 
@@ -16,7 +16,7 @@ def test_tracer_classes():
     variable_types = [TracerVariableType.mixing_ratio]
 
     for name, space, transport_flag, transport_eqn in \
-        zip(names, spaces, transport_flags, transport_eqns):
+            zip(names, spaces, transport_flags, transport_eqns):
 
         # Test active tracer class
         for variable_type in variable_types:

--- a/tests/test_vector_recovered_space.py
+++ b/tests/test_vector_recovered_space.py
@@ -44,7 +44,6 @@ def test_vector_recovered_space_setup(tmpdir):
     # build elements
     u_element = HDiv(TensorProductElement(u_hori, u_vert))
     w_element = HDiv(TensorProductElement(w_hori, w_vert))
-    theta_element = TensorProductElement(w_hori, w_vert)
     v_element = u_element + w_element
 
     # spaces


### PR DESCRIPTION
This PR implements thorough unit-tests for the various aspects of FML.

It also:
- implements subtraction and division methods for `Term`s and `LabelledForm`s
- alters the `Term.has_label` routine so that it can be forced to return a tuple if a list of labels of length 1 is passed as an argument, which sometimes we might want
- Adds a `NullTerm`, allowing label_map to return an empty `LabelledForm` (see below for discussion)
- fixes remaining lint issues

**Review details**
- this is currently a draft, based on various other FML branches
- the important changes to focus on are in [gusto/fml/form_manipulation_labelling.py](https://github.com/firedrakeproject/gusto/compare/FML_transport...FML_test#diff-e5325f0db0b5dcd51bd0015356dd400f62048232731a350a2e3588bb4d678645)

**Questions**:
- do the `__rmul__` routines do what we expect them to do?
- should we allow more multiplication of `Term`s by things (e.g. functions / Forms)?
- it is not clear in my mind what we should do about the initialiser for the `label_map`. Here I have proposed a `NullTerm` (contains `None` as its `Form`) but we should think about what the best thing to do here is