### PR TITLE
fix transport velocity for equation sets

### DIFF
--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -74,10 +74,7 @@ class Timestepper(object):
 
     @property
     def transporting_velocity(self):
-        if hasattr(self.x.n, 'u'):
-            return self.x.n('u')
-        else:
-            return None
+        return "prognostic"
 
     def _apply_bcs(self):
         """


### PR DESCRIPTION
This fixes a bug with the transport velocity. The `Timestepper` class now assumes that the velocity is a prognostic variable and sets `uadv="prognostic"` so that the transport velocity can be correctly replaced with the first component of the `subject` in the time discretisation.