### PR TITLE
Fml hydrostatic

### DIFF
--- a/examples/mountain_hydrostatic.py
+++ b/examples/mountain_hydrostatic.py
@@ -56,7 +56,6 @@ diagnostic_fields = [CourantNumber(), VelocityZ(), HydrostaticImbalance()]
 
 state = State(mesh,
               dt=dt,
-              hydrostatic=True,
               output=output,
               parameters=parameters,
               diagnostic_fields=diagnostic_fields)

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -852,9 +852,9 @@ class HydrostaticCompressibleEulerEquations(CompressibleEulerEquations):
     def hydrostatic_projection(self, t):
 
         # TODO: make this more general, i.e. should work on the sphere
+        assert not self.state.on_sphere, "the hydrostatic projection is not yet implemented for spherical geometry"
         k = Constant((*self.state.k, 0, 0))
         X = t.get(subject)
-        u = split(X)[0]
 
         new_subj = X - k * inner(X, k)
         return replace_subject(new_subj)(t)

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -842,10 +842,10 @@ class HydrostaticCompressibleEulerEquations(CompressibleEulerEquations):
 
         k = self.state.k
         u = split(self.X)[0]
-        self.residual -= name(
+        self.residual += name(
             subject(
                 prognostic(
-                    inner(k, self.tests[0]) * inner(k, u) * dx, "u"),
+                    -inner(k, self.tests[0]) * inner(k, u) * dx, "u"),
                 self.X),
             "hydrostatic_form")
 

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -45,6 +45,11 @@ class Forcing(object):
             drop,
             replace_subject(self.x0))
 
+        L_explicit += residual.label_map(
+            lambda t: t.get(name) == "hydrostatic_form",
+            replace_subject(self.x0),
+            drop)
+
         bcs = [DirichletBC(W.sub(0), bc.function_arg, bc.sub_domain) for bc in equation.bcs['u']]
 
         explicit_forcing_problem = LinearVariationalProblem(
@@ -56,7 +61,7 @@ class Forcing(object):
             drop,
             replace_subject(self.x0))
         if any(t.get(name) in implicit_terms for t in residual):
-            L_implicit -= dt*residual.label_map(
+            L_implicit -= residual.label_map(
                 lambda t: t.get(name) in implicit_terms,
                 replace_subject(self.x0),
                 drop)

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -67,8 +67,6 @@ class Forcing(object):
         # the hydrostatic equations require some additional forms:
         if any([t.has_label(hydrostatic) for t in residual]):
 
-            print("hello!")
-            print([t.get(name) == "hydrostatic_form" for t in residual])
             L_explicit += residual.label_map(
                 lambda t: t.get(name) == "hydrostatic_form",
                 replace_subject(self.x0),

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -48,13 +48,13 @@ class Forcing(object):
 
         # the explicit forms are multiplied by (1-alpha) and moved to the rhs
         L_explicit = -(1-alpha)*dt*residual.label_map(
-            lambda t: t.has_label(time_derivative) or t.get(name) in implicit_terms,
+            lambda t: t.has_label(time_derivative) or t.get(name) in implicit_terms or t.get(name) == "hydrostatic_form",
             drop,
             replace_subject(self.x0))
 
         # the implicit forms are multiplied by alpha and moved to the rhs
         L_implicit = -alpha*dt*residual.label_map(
-            lambda t: t.has_label(time_derivative) or t.get(name) in implicit_terms,
+            lambda t: t.has_label(time_derivative) or t.get(name) in implicit_terms or t.get(name) == "hydrostatic_form",
             drop,
             replace_subject(self.x0))
 

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -26,7 +26,7 @@ class Forcing(object):
     def __init__(self, equation, dt, alpha):
 
         self.field_name = equation.field_name
-        implicit_terms = ["divergence_form", "sponge"]
+        implicit_terms = ["divergence_form", "sponge", "hydrostatic_form"]
 
         W = equation.function_space
         self.x0 = Function(W)

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -58,8 +58,9 @@ class Forcing(object):
             drop,
             replace_subject(self.x0))
 
+        # now add the terms that are always fully implicit
         if any(t.get(name) in implicit_terms for t in residual):
-            L_implicit -= alpha*dt*residual.label_map(
+            L_implicit -= dt*residual.label_map(
                 lambda t: t.get(name) in implicit_terms,
                 replace_subject(self.x0),
                 drop)

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -74,6 +74,9 @@ def replace_subject(new, idx=None):
                 for k, v in zip(split(subj), new):
                     replace_dict[k] = v
 
+            elif type(new) == ufl.algebra.Sum:
+                replace_dict[subj] = new
+
             # Otherwise fail if new is not a function
             elif not isinstance(new, Function):
                 raise ValueError(f'new must be a tuple or Function, not type {type(new)}')
@@ -128,3 +131,4 @@ coriolis = Label("coriolis")
 linearisation = Label("linearisation", validator=lambda value: type(value) in [LabelledForm, Term])
 name = Label("name", validator=lambda value: type(value) == str)
 ibp_label = Label("ibp", validator=lambda value: type(value) == IntegrateByParts)
+hydrostatic = Label("hydrostatic", validator=lambda value: type(value) in [LabelledForm, Term])

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -302,14 +302,12 @@ class State(object):
 
     def __init__(self, mesh,
                  dt=None,
-                 hydrostatic=None,
                  output=None,
                  parameters=None,
                  diagnostics=None,
                  diagnostic_fields=None):
 
         self.dt = dt
-        self.hydrostatic = hydrostatic
         if output is None:
             raise RuntimeError("You must provide a directory name for dumping results")
         else:

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -360,12 +360,6 @@ class State(object):
             if dim == 2:
                 self.perp = lambda u: as_vector([-u[1], u[0]])
 
-        # project test function for hydrostatic case
-        if self.hydrostatic:
-            self.h_project = lambda u: u - self.k*inner(u, self.k)
-        else:
-            self.h_project = lambda u: u
-
         #  Constant to hold current time
         self.t = Constant(0.0)
 


### PR DESCRIPTION
This implements the hydrostatic compressible Euler equations.
- This defines a `HydrostaticCompressibleEuler` equation class.
- The `h_project` function has been moved from `state` to `linear_solvers` - this will be redundant when we get the residual directly from the equation class.
- The forcing class checks for the `hydrostatic` label and adds the required forms to the explicit and implicit solvers.

To Do:
- This currently only works in a vertical slice and should be generalised to the sphere.