### PR TITLE
Rename "pi" to "exner" everywhere

### DIFF
--- a/examples/compressible/dcmip_3_1_meanflow_quads.py
+++ b/examples/compressible/dcmip_3_1_meanflow_quads.py
@@ -126,7 +126,7 @@ compressible_hydrostatic_balance(state,
                                  theta_b,
                                  rho_b,
                                  top=False,
-                                 pi_boundary=(p/p_0)**kappa)
+                                 exner_boundary=(p/p_0)**kappa)
 theta0.interpolate(theta_pert)
 theta0 += theta_b
 rho0.assign(rho_b)

--- a/examples/compressible/moist_bryan_fritsch.py
+++ b/examples/compressible/moist_bryan_fritsch.py
@@ -83,8 +83,8 @@ theta_b = Function(Vt).assign(theta0)
 rho_b = Function(Vr).assign(rho0)
 water_vb = Function(Vt).assign(water_v0)
 water_cb = Function(Vt).assign(water_t - water_vb)
-pibar = thermodynamics.pi(state.parameters, rho_b, theta_b)
-Tb = thermodynamics.T(state.parameters, theta_b, pibar, r_v=water_vb)
+exner_b = thermodynamics.exner_pressure(state.parameters, rho_b, theta_b)
+Tb = thermodynamics.T(state.parameters, theta_b, exner_b, r_v=water_vb)
 
 # define perturbation
 xc = L / 2
@@ -121,9 +121,9 @@ rho_recoverer = Recoverer(
     boundary_method=physics_boundary_method)
 rho_recoverer.project()
 
-pi = thermodynamics.pi(state.parameters, rho_averaged, theta0)
-p = thermodynamics.p(state.parameters, pi)
-T = thermodynamics.T(state.parameters, theta0, pi, r_v=w_v)
+exner = thermodynamics.exner_pressure(state.parameters, rho_averaged, theta0)
+p = thermodynamics.p(state.parameters, exner)
+T = thermodynamics.T(state.parameters, theta0, exner, r_v=w_v)
 w_sat = thermodynamics.r_sat(state.parameters, T, p)
 
 w_functional = (phi * w_v * dxp - phi * w_sat * dxp)

--- a/examples/compressible/mountain_hydrostatic.py
+++ b/examples/compressible/mountain_hydrostatic.py
@@ -92,24 +92,24 @@ N = g/sqrt(c_p*Tsurf)
 thetab = Tsurf*exp(N**2*z/g)
 theta_b = Function(Vt).interpolate(thetab)
 
-# Calculate hydrostatic Pi
-Pi = Function(Vr)
+# Calculate hydrostatic exner
+exner = Function(Vr)
 rho_b = Function(Vr)
 
-piparams = {'ksp_type': 'gmres',
-            'ksp_monitor_true_residual': None,
-            'pc_type': 'python',
-            'mat_type': 'matfree',
-            'pc_python_type': 'gusto.VerticalHybridizationPC',
-            # Vertical trace system is only coupled vertically in columns
-            # block ILU is a direct solver!
-            'vert_hybridization': {'ksp_type': 'preonly',
-                                   'pc_type': 'bjacobi',
-                                   'sub_pc_type': 'ilu'}}
+exner_params = {'ksp_type': 'gmres',
+                'ksp_monitor_true_residual': None,
+                'pc_type': 'python',
+                'mat_type': 'matfree',
+                'pc_python_type': 'gusto.VerticalHybridizationPC',
+                # Vertical trace system is only coupled vertically in columns
+                # block ILU is a direct solver!
+                'vert_hybridization': {'ksp_type': 'preonly',
+                                       'pc_type': 'bjacobi',
+                                       'sub_pc_type': 'ilu'}}
 
-compressible_hydrostatic_balance(state, theta_b, rho_b, Pi,
-                                 top=True, pi_boundary=0.5,
-                                 params=piparams)
+compressible_hydrostatic_balance(state, theta_b, rho_b, exner,
+                                 top=True, exner_boundary=0.5,
+                                 params=exner_params)
 
 
 def minimum(f):
@@ -122,16 +122,16 @@ static void minify(double *a, double *b) {
     return fmin.data[0]
 
 
-p0 = minimum(Pi)
-compressible_hydrostatic_balance(state, theta_b, rho_b, Pi,
-                                 top=True, params=piparams)
-p1 = minimum(Pi)
+p0 = minimum(exner)
+compressible_hydrostatic_balance(state, theta_b, rho_b, exner,
+                                 top=True, params=exner_params)
+p1 = minimum(exner)
 alpha = 2.*(p1-p0)
 beta = p1-alpha
-pi_top = (1.-beta)/alpha
-compressible_hydrostatic_balance(state, theta_b, rho_b, Pi,
-                                 top=True, pi_boundary=pi_top, solve_for_rho=True,
-                                 params=piparams)
+exner_top = (1.-beta)/alpha
+compressible_hydrostatic_balance(state, theta_b, rho_b, exner,
+                                 top=True, exner_boundary=exner_top, solve_for_rho=True,
+                                 params=exner_params)
 
 theta0.assign(theta_b)
 rho0.assign(rho_b)

--- a/examples/compressible/mountain_nonhydrostatic.py
+++ b/examples/compressible/mountain_nonhydrostatic.py
@@ -88,24 +88,24 @@ Tsurf = 300.
 thetab = Tsurf*exp(N**2*z/g)
 theta_b = Function(Vt).interpolate(thetab)
 
-# Calculate hydrostatic Pi
-Pi = Function(Vr)
+# Calculate hydrostatic exner
+exner = Function(Vr)
 rho_b = Function(Vr)
 
-piparams = {'ksp_type': 'gmres',
-            'ksp_monitor_true_residual': None,
-            'pc_type': 'python',
-            'mat_type': 'matfree',
-            'pc_python_type': 'gusto.VerticalHybridizationPC',
-            # Vertical trace system is only coupled vertically in columns
-            # block ILU is a direct solver!
-            'vert_hybridization': {'ksp_type': 'preonly',
-                                   'pc_type': 'bjacobi',
-                                   'sub_pc_type': 'ilu'}}
+exner_params = {'ksp_type': 'gmres',
+                'ksp_monitor_true_residual': None,
+                'pc_type': 'python',
+                'mat_type': 'matfree',
+                'pc_python_type': 'gusto.VerticalHybridizationPC',
+                # Vertical trace system is only coupled vertically in columns
+                # block ILU is a direct solver!
+                'vert_hybridization': {'ksp_type': 'preonly',
+                                       'pc_type': 'bjacobi',
+                                       'sub_pc_type': 'ilu'}}
 
-compressible_hydrostatic_balance(state, theta_b, rho_b, Pi,
-                                 top=True, pi_boundary=0.5,
-                                 params=piparams)
+compressible_hydrostatic_balance(state, theta_b, rho_b, exner,
+                                 top=True, exner_boundary=0.5,
+                                 params=exner_params)
 
 
 def minimum(f):
@@ -118,16 +118,16 @@ static void minify(double *a, double *b) {
     return fmin.data[0]
 
 
-p0 = minimum(Pi)
-compressible_hydrostatic_balance(state, theta_b, rho_b, Pi,
-                                 top=True, params=piparams)
-p1 = minimum(Pi)
+p0 = minimum(exner)
+compressible_hydrostatic_balance(state, theta_b, rho_b, exner,
+                                 top=True, params=exner_params)
+p1 = minimum(exner)
 alpha = 2.*(p1-p0)
 beta = p1-alpha
-pi_top = (1.-beta)/alpha
-compressible_hydrostatic_balance(state, theta_b, rho_b, Pi,
-                                 top=True, pi_boundary=pi_top, solve_for_rho=True,
-                                 params=piparams)
+exner_top = (1.-beta)/alpha
+compressible_hydrostatic_balance(state, theta_b, rho_b, exner,
+                                 top=True, exner_boundary=exner_top, solve_for_rho=True,
+                                 params=exner_params)
 
 theta0.assign(theta_b)
 rho0.assign(rho_b)

--- a/examples/compressible/robert_bubble.py
+++ b/examples/compressible/robert_bubble.py
@@ -62,7 +62,7 @@ Tsurf = Constant(300.)
 theta_b = Function(Vt).interpolate(Tsurf)
 rho_b = Function(Vr)
 
-# Calculate hydrostatic Pi
+# Calculate hydrostatic exner
 compressible_hydrostatic_balance(state, theta_b, rho_b, solve_for_rho=True)
 
 x = SpatialCoordinate(mesh)

--- a/examples/compressible/skamarock_klemp_hydrostatic.py
+++ b/examples/compressible/skamarock_klemp_hydrostatic.py
@@ -7,8 +7,7 @@ Potential temperature is transported using SUPG.
 
 from gusto import *
 from firedrake import (as_vector, SpatialCoordinate, PeriodicRectangleMesh,
-                       ExtrudedMesh, exp, sin, Function)
-import numpy as np
+                       ExtrudedMesh, exp, sin, Function, pi)
 import sys
 
 dt = 25.
@@ -83,7 +82,7 @@ rho_b = Function(Vr)
 
 a = 1.0e5
 deltaTheta = 1.0e-2
-theta_pert = deltaTheta*sin(np.pi*z/H)/(1 + (x - L/2)**2/a**2)
+theta_pert = deltaTheta*sin(pi*z/H)/(1 + (x - L/2)**2/a**2)
 theta0.interpolate(theta_b + theta_pert)
 
 compressible_hydrostatic_balance(state, theta_b, rho_b,

--- a/examples/compressible/skamarock_klemp_nonlinear.py
+++ b/examples/compressible/skamarock_klemp_nonlinear.py
@@ -9,7 +9,7 @@ PETSc.Sys.popErrorHandler()
 from gusto import *
 import itertools
 from firedrake import (as_vector, SpatialCoordinate, PeriodicIntervalMesh,
-                       ExtrudedMesh, exp, sin, Function)
+                       ExtrudedMesh, exp, sin, Function, pi)
 import numpy as np
 import sys
 
@@ -91,12 +91,12 @@ thetab = Tsurf*exp(N**2*z/g)
 theta_b = Function(Vt).interpolate(thetab)
 rho_b = Function(Vr)
 
-# Calculate hydrostatic Pi
+# Calculate hydrostatic exner
 compressible_hydrostatic_balance(state, theta_b, rho_b)
 
 a = 5.0e3
 deltaTheta = 1.0e-2
-theta_pert = deltaTheta*sin(np.pi*z/H)/(1 + (x - L/2)**2/a**2)
+theta_pert = deltaTheta*sin(pi*z/H)/(1 + (x - L/2)**2/a**2)
 theta0.interpolate(theta_b + theta_pert)
 rho0.assign(rho_b)
 u0.project(as_vector([20.0, 0.0]))

--- a/examples/compressible/straka_bubble.py
+++ b/examples/compressible/straka_bubble.py
@@ -74,8 +74,8 @@ for delta, dt in res_dt.items():
     rho_b = Function(Vr)
     exner = Function(Vr)
 
-    # Calculate hydrostatic Pi
-    compressible_hydrostatic_balance(state, theta_b, rho_b, pi0=exner,
+    # Calculate hydrostatic exner
+    compressible_hydrostatic_balance(state, theta_b, rho_b, exner0=exner,
                                      solve_for_rho=True)
 
     x = SpatialCoordinate(mesh)

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -79,7 +79,7 @@ physics_boundary_method = Boundary_Method.physics
 # Define constant theta_e and water_t
 Tsurf = 283.0
 psurf = 85000.
-pi_surf = (psurf / state.parameters.p_0) ** state.parameters.kappa
+exner_surf = (psurf / state.parameters.p_0) ** state.parameters.kappa
 humidity = 0.2
 S = 1.3e-5
 theta_surf = thermodynamics.theta(state.parameters, Tsurf, psurf)
@@ -88,7 +88,7 @@ H = Function(Vt).assign(humidity)
 
 # Calculate hydrostatic fields
 unsaturated_hydrostatic_balance(state, theta_d, H,
-                                pi_boundary=Constant(pi_surf))
+                                exner_boundary=Constant(exner_surf))
 
 # make mean fields
 theta_b = Function(Vt).assign(theta0)
@@ -125,19 +125,19 @@ R_v = state.parameters.R_v
 epsilon = R_d / R_v
 
 # make expressions for determining water_v0
-pie = thermodynamics.pi(state.parameters, rho_averaged, theta0)
-p = thermodynamics.p(state.parameters, pie)
-T = thermodynamics.T(state.parameters, theta0, pie, water_v0)
+exner = thermodynamics.exner_pressure(state.parameters, rho_averaged, theta0)
+p = thermodynamics.p(state.parameters, exner)
+T = thermodynamics.T(state.parameters, theta0, exner, water_v0)
 r_v_expr = thermodynamics.r_v(state.parameters, H, T, p)
 
 # make expressions to evaluate residual
-pi_ev = thermodynamics.pi(state.parameters, rho_averaged, theta0)
-p_ev = thermodynamics.p(state.parameters, pi_ev)
-T_ev = thermodynamics.T(state.parameters, theta0, pi_ev, water_v0)
+exner_ev = thermodynamics.exner_pressure(state.parameters, rho_averaged, theta0)
+p_ev = thermodynamics.p(state.parameters, exner_ev)
+T_ev = thermodynamics.T(state.parameters, theta0, exner_ev, water_v0)
 RH_ev = thermodynamics.RH(state.parameters, water_v0, T_ev, p_ev)
 RH = Function(Vt)
 
-# set-up rho problem to keep Pi constant
+# set-up rho problem to keep exner constant
 gamma = TestFunction(Vr)
 rho_trial = TrialFunction(Vr)
 a = gamma * rho_trial * dxp

--- a/examples/incompressible/skamarock_klemp_incompressible.py
+++ b/examples/incompressible/skamarock_klemp_incompressible.py
@@ -7,8 +7,7 @@ Buoyancy is transported using SUPG.
 
 from gusto import *
 from firedrake import (as_vector, PeriodicIntervalMesh, ExtrudedMesh,
-                       sin, SpatialCoordinate, Function)
-import numpy as np
+                       sin, SpatialCoordinate, Function, pi)
 import sys
 
 dt = 6.
@@ -72,7 +71,7 @@ b_b = Function(Vb).interpolate(bref)
 # setup constants
 a = 5.0e3
 deltab = 1.0e-2
-b_pert = deltab*sin(np.pi*z/H)/(1 + (x - L/2)**2/a**2)
+b_pert = deltab*sin(pi*z/H)/(1 + (x - L/2)**2/a**2)
 # interpolate the expression to the function
 b0.interpolate(b_b + b_pert)
 

--- a/examples/shallow_water/linear_williamson_2.py
+++ b/examples/shallow_water/linear_williamson_2.py
@@ -6,8 +6,7 @@ This uses an icosahedral mesh of the sphere.
 """
 
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
-from math import pi
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, pi
 import sys
 
 dt = 3600.

--- a/examples/shallow_water/williamson_2.py
+++ b/examples/shallow_water/williamson_2.py
@@ -7,8 +7,7 @@ to act as a convergence test.
 """
 
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
-from math import pi
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, pi
 import sys
 
 day = 24.*60.*60.

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -13,10 +13,10 @@ __all__ = ["Diagnostics", "CourantNumber", "VelocityX", "VelocityZ", "VelocityY"
            "SphericalComponent", "MeridionalComponent", "ZonalComponent", "RadialComponent",
            "RichardsonNumber", "Energy", "KineticEnergy", "ShallowWaterKineticEnergy",
            "ShallowWaterPotentialEnergy", "ShallowWaterPotentialEnstrophy",
-           "CompressibleKineticEnergy", "ExnerPi", "Sum", "Difference", "SteadyStateError",
+           "CompressibleKineticEnergy", "Exner", "Sum", "Difference", "SteadyStateError",
            "Perturbation", "Theta_e", "InternalEnergy", "PotentialEnergy",
            "ThermodynamicKineticEnergy", "Dewpoint", "Temperature", "Theta_d",
-           "RelativeHumidity", "Pressure", "Pi_Vt", "HydrostaticImbalance", "Precipitation",
+           "RelativeHumidity", "Pressure", "Exner_Vt", "HydrostaticImbalance", "Precipitation",
            "PotentialVorticity", "RelativeVorticity", "AbsoluteVorticity", "Divergence"]
 
 
@@ -377,10 +377,10 @@ class CompressibleKineticEnergy(Energy):
         return self.field.interpolate(energy)
 
 
-class ExnerPi(DiagnosticField):
+class Exner(DiagnosticField):
 
     def __init__(self, reference=False):
-        super(ExnerPi, self).__init__()
+        super(Exner, self).__init__()
         self.reference = reference
         if reference:
             self.rho_name = "rhobar"
@@ -392,20 +392,20 @@ class ExnerPi(DiagnosticField):
     @property
     def name(self):
         if self.reference:
-            return "ExnerPibar"
+            return "Exnerbar"
         else:
-            return "ExnerPi"
+            return "Exner"
 
     def setup(self, state):
         if not self._initialised:
             space = state.spaces("CG1", "CG", 1)
-            super(ExnerPi, self).setup(state, space=space)
+            super(Exner, self).setup(state, space=space)
 
     def compute(self, state):
         rho = state.fields(self.rho_name)
         theta = state.fields(self.theta_name)
-        Pi = thermodynamics.pi(state.parameters, rho, theta)
-        return self.field.interpolate(Pi)
+        exner = thermodynamics.exner_pressure(state.parameters, rho, theta)
+        return self.field.interpolate(exner)
 
 
 class Sum(DiagnosticField):
@@ -511,9 +511,9 @@ class ThermodynamicDiagnostic(DiagnosticField):
                 self.rain = Constant(0.0)
 
             # now let's store the most common expressions
-            self.pi = thermodynamics.pi(state.parameters, self.rho_averaged, self.theta)
-            self.T = thermodynamics.T(state.parameters, self.theta, self.pi, r_v=self.r_v)
-            self.p = thermodynamics.p(state.parameters, self.pi)
+            self.exner = thermodynamics.exner_pressure(state.parameters, self.rho_averaged, self.theta)
+            self.T = thermodynamics.T(state.parameters, self.theta, self.exner, r_v=self.r_v)
+            self.p = thermodynamics.p(state.parameters, self.exner)
             self.r_l = self.r_c + self.rain
             self.r_t = self.r_v + self.r_c + self.rain
 
@@ -606,13 +606,13 @@ class Pressure(ThermodynamicDiagnostic):
         return self.field.assign(self.p)
 
 
-class Pi_Vt(ThermodynamicDiagnostic):
-    name = "Pi_Vt"
+class Exner_Vt(ThermodynamicDiagnostic):
+    name = "Exner_Vt"
 
     def compute(self, state):
         super().compute(state)
 
-        return self.field.assign(self.pi)
+        return self.field.assign(self.exner)
 
 
 class HydrostaticImbalance(DiagnosticField):
@@ -627,8 +627,8 @@ class HydrostaticImbalance(DiagnosticField):
             rhobar = state.fields("rhobar")
             theta = state.fields("theta")
             thetabar = state.fields("thetabar")
-            pi = thermodynamics.pi(state.parameters, rho, theta)
-            pibar = thermodynamics.pi(state.parameters, rhobar, thetabar)
+            exner = thermodynamics.exner_pressure(state.parameters, rho, theta)
+            exnerbar = thermodynamics.exner_pressure(state.parameters, rhobar, thetabar)
 
             cp = Constant(state.parameters.cp)
             n = FacetNormal(state.mesh)
@@ -636,10 +636,10 @@ class HydrostaticImbalance(DiagnosticField):
             F = TrialFunction(space)
             w = TestFunction(space)
             a = inner(w, F)*dx
-            L = (- cp*div((theta-thetabar)*w)*pibar*dx
-                 + cp*jump((theta-thetabar)*w, n)*avg(pibar)*dS_v
-                 - cp*div(thetabar*w)*(pi-pibar)*dx
-                 + cp*jump(thetabar*w, n)*avg(pi-pibar)*dS_v)
+            L = (- cp*div((theta-thetabar)*w)*exnerbar*dx
+                 + cp*jump((theta-thetabar)*w, n)*avg(exnerbar)*dS_v
+                 - cp*div(thetabar*w)*(exner-exnerbar)*dx
+                 + cp*jump(thetabar*w, n)*avg(exner-exnerbar)*dS_v)
 
             bcs = [DirichletBC(space, 0.0, "bottom"),
                    DirichletBC(space, 0.0, "top")]

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -9,7 +9,7 @@ from gusto.labels import (subject, time_derivative, transport, prognostic,
                           transporting_velocity, replace_subject, linearisation,
                           name, pressure_gradient, coriolis,
                           replace_trial_function, hydrostatic)
-from gusto.thermodynamics import pi as Pi
+from gusto.thermodynamics import exner_pressure
 from gusto.transport_forms import (advection_form, continuity_form,
                                    vector_invariant_form,
                                    vector_manifold_advection_form,
@@ -611,7 +611,7 @@ class CompressibleEulerEquations(PrognosticEquationSet):
         rhobar = state.fields("rhobar", space=state.spaces("DG"), dump=False)
         thetabar = state.fields("thetabar", space=state.spaces("theta"), dump=False)
         zero_expr = Constant(0.0)*theta
-        exner_pi = Pi(state.parameters, rho, theta)
+        exner = exner_pressure(state.parameters, rho, theta)
         n = FacetNormal(state.mesh)
 
         # -------------------------------------------------------------------- #
@@ -681,8 +681,8 @@ class CompressibleEulerEquations(PrognosticEquationSet):
         theta_v = theta / (Constant(1.0) + tracer_mr_total)
 
         pressure_gradient_form = name(subject(prognostic(
-            cp*(-div(theta_v*w)*exner_pi*dx
-                + jump(theta_v*w, n)*avg(exner_pi)*dS_v), "u"), self.X), "pressure_gradient")
+            cp*(-div(theta_v*w)*exner*dx
+                + jump(theta_v*w, n)*avg(exner)*dS_v), "u"), self.X), "pressure_gradient")
 
         # -------------------------------------------------------------------- #
         # Gravitational Term

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -90,9 +90,9 @@ class Condensation(Physics):
         R_v = state.parameters.R_v
 
         # make useful fields
-        Pi = thermodynamics.pi(state.parameters, rho_averaged, self.theta)
-        T = thermodynamics.T(state.parameters, self.theta, Pi, r_v=self.water_v)
-        p = thermodynamics.p(state.parameters, Pi)
+        exner = thermodynamics.exner_pressure(state.parameters, rho_averaged, self.theta)
+        T = thermodynamics.T(state.parameters, self.theta, exner, r_v=self.water_v)
+        p = thermodynamics.p(state.parameters, exner)
         L_v = thermodynamics.Lv(state.parameters, T)
         R_m = R_d + R_v * self.water_v
         c_pml = cp + c_pv * self.water_v + c_pl * water_l
@@ -374,9 +374,9 @@ class Evaporation(Physics):
         R_v = state.parameters.R_v
 
         # make useful fields
-        Pi = thermodynamics.pi(state.parameters, rho_averaged, self.theta)
-        T = thermodynamics.T(state.parameters, self.theta, Pi, r_v=self.water_v)
-        p = thermodynamics.p(state.parameters, Pi)
+        exner = thermodynamics.exner_pressure(state.parameters, rho_averaged, self.theta)
+        T = thermodynamics.T(state.parameters, self.theta, exner, r_v=self.water_v)
+        p = thermodynamics.p(state.parameters, exner)
         L_v = thermodynamics.Lv(state.parameters, T)
         R_m = R_d + R_v * self.water_v
         c_pml = cp + c_pv * self.water_v + c_pl * water_l

--- a/gusto/thermodynamics.py
+++ b/gusto/thermodynamics.py
@@ -3,7 +3,7 @@ Some thermodynamic expressions to help declutter the code.
 """
 from firedrake import exp, ln
 
-__all__ = ["theta", "pi", "pi_rho", "pi_theta", "p", "T", "rho", "r_sat", "Lv", "theta_e", "internal_energy", "RH", "e_sat", "r_v", "T_dew"]
+__all__ = ["theta", "exner_pressure", "dexner_drho", "dexner_dtheta", "p", "T", "rho", "r_sat", "Lv", "theta_e", "internal_energy", "RH", "e_sat", "r_v", "T_dew"]
 
 
 def theta(parameters, T, p):
@@ -21,7 +21,7 @@ def theta(parameters, T, p):
     return T * (p_0 / p) ** kappa
 
 
-def pi(parameters, rho, theta_v):
+def exner_pressure(parameters, rho, theta_v):
     """
     Returns an expression for the Exner pressure.
 
@@ -38,7 +38,7 @@ def pi(parameters, rho, theta_v):
     return (rho * R_d * theta_v / p_0) ** (kappa / (1 - kappa))
 
 
-def pi_rho(parameters, rho, theta_v):
+def dexner_drho(parameters, rho, theta_v):
     """
     Returns an expression for the derivative of Exner pressure
     with respect to density.
@@ -56,7 +56,7 @@ def pi_rho(parameters, rho, theta_v):
     return (kappa / (1 - kappa)) * (rho * R_d * theta_v / p_0) ** (kappa / (1 - kappa)) / rho
 
 
-def pi_theta(parameters, rho, theta_v):
+def dexner_dtheta(parameters, rho, theta_v):
     """
     Returns an expression for the deriavtive of Exner pressure
     with respect to potential temperature.
@@ -74,27 +74,27 @@ def pi_theta(parameters, rho, theta_v):
     return (kappa / (1 - kappa)) * (rho * R_d * theta_v / p_0) ** (kappa / (1 - kappa)) / theta_v
 
 
-def p(parameters, pi):
+def p(parameters, exner):
     """
     Returns an expression for the pressure in Pa from the Exner Pi.
 
     :arg parameters: a CompressibleParameters object.
-    :arg pi: the Exner pressure.
+    :arg exner: the Exner pressure.
     """
 
     kappa = parameters.kappa
     p_0 = parameters.p_0
 
-    return p_0 * pi ** (1 / kappa)
+    return p_0 * exner ** (1 / kappa)
 
 
-def T(parameters, theta_v, pi, r_v=None):
+def T(parameters, theta_v, exner, r_v=None):
     """
     Returns an expression for temperature T in K.
 
     :arg parameters: a CompressibleParameters object.
     :arg theta_v: the virtual potential temperature in K.
-    :arg pi: the Exner pressure.
+    :arg exner: the Exner pressure.
     :arg r_v: the mixing ratio of water vapour.
     """
 
@@ -103,27 +103,27 @@ def T(parameters, theta_v, pi, r_v=None):
 
     # if the air is wet, need to divide by (1 + r_v)
     if r_v is not None:
-        return theta_v * pi / (1 + r_v * R_v / R_d)
+        return theta_v * exner / (1 + r_v * R_v / R_d)
     # in the case that r_v is None, theta_v=theta
     else:
-        return theta_v * pi
+        return theta_v * exner
 
 
-def rho(parameters, theta_v, pi):
+def rho(parameters, theta_v, exner):
     """
     Returns an expression for the dry density rho in kg / m^3
     from the (virtual) potential temperature and Exner pressure.
 
     :arg parameters: a CompressibleParameters object.
     :arg theta_v: the virtual potential temperature in K.
-    :arg pi: the Exner pressure.
+    :arg exner: the Exner pressure.
     """
 
     kappa = parameters.kappa
     p_0 = parameters.p_0
     R_d = parameters.R_d
 
-    return p_0 * pi ** (1 / kappa - 1) / (R_d * theta_v)
+    return p_0 * exner ** (1 / kappa - 1) / (R_d * theta_v)
 
 
 def r_sat(parameters, T, p):

--- a/integration-tests/balance/test_compressible_balance.py
+++ b/integration-tests/balance/test_compressible_balance.py
@@ -43,7 +43,7 @@ def setup_balance(dirname):
     Tsurf = Constant(300.)
     theta0.interpolate(Tsurf)
 
-    # Calculate hydrostatic Pi
+    # Calculate hydrostatic exner
     compressible_hydrostatic_balance(state, theta0, rho0, solve_for_rho=True)
 
     state.set_reference_profiles([('rho', rho0),

--- a/integration-tests/balance/test_saturated_balance.py
+++ b/integration-tests/balance/test_saturated_balance.py
@@ -69,7 +69,7 @@ def setup_saturated(dirname, recovered):
     theta_e = Function(Vt).interpolate(Tsurf)
     water_t = Function(Vt).interpolate(total_water)
 
-    # Calculate hydrostatic Pi
+    # Calculate hydrostatic exner
     saturated_hydrostatic_balance(state, theta_e, water_t)
     water_c0.assign(water_t - water_v0)
 

--- a/integration-tests/balance/test_unsaturated_balance.py
+++ b/integration-tests/balance/test_unsaturated_balance.py
@@ -65,7 +65,7 @@ def setup_unsaturated(dirname, recovered):
     theta_d = Function(Vt).interpolate(Tsurf)
     RH = Function(Vt).interpolate(humidity)
 
-    # Calculate hydrostatic Pi
+    # Calculate hydrostatic exner
     unsaturated_hydrostatic_balance(state, theta_d, RH)
 
     state.set_reference_profiles([('rho', rho0),

--- a/integration-tests/equations/test_sw_linear_triangle.py
+++ b/integration-tests/equations/test_sw_linear_triangle.py
@@ -6,8 +6,7 @@ errors in the fields.
 
 from os import path
 from gusto import *
-from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector
-from math import pi
+from firedrake import IcosahedralSphereMesh, SpatialCoordinate, as_vector, pi
 from netCDF4 import Dataset
 
 

--- a/integration-tests/equations/test_sw_triangle.py
+++ b/integration-tests/equations/test_sw_triangle.py
@@ -10,8 +10,7 @@ unit-tests
 from os import path
 from gusto import *
 from firedrake import (IcosahedralSphereMesh, SpatialCoordinate,
-                       as_vector, FunctionSpace)
-from math import pi
+                       as_vector, FunctionSpace, pi)
 from netCDF4 import Dataset
 import pytest
 

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -5,7 +5,7 @@ timesteps, checkpoints and then starts a new run from the checkpoint file.
 
 from gusto import *
 from firedrake import (PeriodicIntervalMesh, ExtrudedMesh,
-                       SpatialCoordinate, exp, sin, Function, as_vector)
+                       SpatialCoordinate, exp, sin, Function, as_vector, pi)
 import numpy as np
 import itertools
 
@@ -62,12 +62,12 @@ def setup_sk(dirname):
     theta_b = Function(Vt).interpolate(thetab)
     rho_b = Function(Vr)
 
-    # Calculate hydrostatic Pi
+    # Calculate hydrostatic exner
     compressible_hydrostatic_balance(state, theta_b, rho_b)
 
     a = 5.0e3
     deltaTheta = 1.0e-2
-    theta_pert = deltaTheta*sin(np.pi*z/H)/(1 + (x - L/2)**2/a**2)
+    theta_pert = deltaTheta*sin(pi*z/H)/(1 + (x - L/2)**2/a**2)
     theta0.interpolate(theta_b + theta_pert)
     rho0.assign(rho_b)
     u0.project(as_vector([20.0, 0.0]))

--- a/integration-tests/physics/test_condensation.py
+++ b/integration-tests/physics/test_condensation.py
@@ -13,9 +13,8 @@ from os import path
 from gusto import *
 from firedrake import (as_vector, Constant, sin, PeriodicIntervalMesh,
                        SpatialCoordinate, ExtrudedMesh, FunctionSpace,
-                       Function, sqrt, conditional, cos)
+                       Function, sqrt, conditional, cos, pi)
 from netCDF4 import Dataset
-from math import pi
 
 
 def setup_condens(dirname):

--- a/integration-tests/physics/test_precipitation.py
+++ b/integration-tests/physics/test_precipitation.py
@@ -8,9 +8,8 @@ from os import path
 from gusto import *
 from firedrake import PeriodicIntervalMesh, Constant, \
     SpatialCoordinate, ExtrudedMesh, sqrt, \
-    conditional, cos, as_vector
+    conditional, cos, as_vector, pi
 from netCDF4 import Dataset
-from math import pi
 
 
 def setup_fallout(dirname):


### PR DESCRIPTION
This just renames `pi` to `exner` everywhere across Gusto when it refers to the Exner pressure, allowing us to close #265 