### PR TITLE
make dt and t Constants that are owned by state

### DIFF
--- a/gusto/fml/form_manipulation_labelling.py
+++ b/gusto/fml/form_manipulation_labelling.py
@@ -114,6 +114,9 @@ class LabelledForm(object):
     def __mul__(self, other):
         if type(other) in (float, int):
             other = Constant(other)
+        # UFL can cancel constants to a Zero type which needs treating separately
+        elif type(other) is ufl.constantvalue.Zero:
+            other = Constant(0.0)
         elif type(other) not in [Constant, ufl.algebra.Product]:
             return NotImplemented
         return self.label_map(all_terms, lambda t: Term(other*t.form, t.labels))

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -23,10 +23,11 @@ class Forcing(object):
     term - these will be multiplied by the appropriate test function.
     """
 
-    def __init__(self, equation, dt, alpha):
+    def __init__(self, equation, alpha):
 
         self.field_name = equation.field_name
         implicit_terms = ["incompressibility", "sponge"]
+        dt = equation.state.dt
 
         W = equation.function_space
         self.x0 = Function(W)

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -153,8 +153,8 @@ class CompressibleSolver(TimesteppingSolver):
         import numpy as np
 
         state = self.state
-        Dt = state.dt
-        beta_ = Dt*self.alpha
+        dt = state.dt
+        beta_ = dt*self.alpha
         cp = state.parameters.cp
         Vu = state.spaces("HDiv")
         Vu_broken = FunctionSpace(state.mesh, BrokenElement(Vu.ufl_element()))
@@ -162,7 +162,6 @@ class CompressibleSolver(TimesteppingSolver):
         Vrho = state.spaces("DG")
 
         # Store time-stepping coefficients as UFL Constants
-        dt = Constant(Dt)
         beta = Constant(beta_)
         beta_cp = Constant(beta_ * cp)
 
@@ -419,14 +418,13 @@ class IncompressibleSolver(TimesteppingSolver):
     @timed_function("Gusto:SolverSetup")
     def _setup_solver(self):
         state = self.state      # just cutting down line length a bit
-        Dt = state.dt
-        beta_ = Dt*self.alpha
+        dt = state.dt
+        beta_ = dt*self.alpha
         Vu = state.spaces("HDiv")
         Vb = state.spaces("theta")
         Vp = state.spaces("DG")
 
         # Store time-stepping coefficients as UFL Constants
-        dt = Constant(Dt)
         beta = Constant(beta_)
 
         # Split up the rhs vector (symbolically)
@@ -538,13 +536,14 @@ class LinearTimesteppingSolver(object):
                                         'sub_pc_type': 'ilu'}}
     }
 
-    def __init__(self, equation, dt, alpha):
+    def __init__(self, equation, alpha):
 
         residual = equation.residual.label_map(
             lambda t: t.has_label(linearisation),
             lambda t: Term(t.get(linearisation).form, t.labels),
             drop)
 
+        dt = equation.state.dt
         W = equation.function_space
         beta = dt*alpha
 

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -373,7 +373,6 @@ class State(object):
         else:
             raise TypeError(f'dt must be a Constant, float or int, not {type(dt)}')
 
-
     def setup_diagnostics(self):
         """
         Add special case diagnostic fields

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -293,21 +293,20 @@ class State(object):
     Build a model state to keep the variables in, and specify parameters.
 
     :arg mesh: The :class:`Mesh` to use.
-    :arg sponge_function: (optional) Function specifying a sponge layer.
+    :arg dt: The time step as a :class:`Constant`. If a float or int is passed,
+             it will be cast to a :class:`Constant`.
     :arg output: class containing output parameters
     :arg parameters: class containing physical parameters
     :arg diagnostics: class containing diagnostic methods
     :arg diagnostic_fields: list of diagnostic field classes
     """
 
-    def __init__(self, mesh,
-                 dt=None,
+    def __init__(self, mesh, dt,
                  output=None,
                  parameters=None,
                  diagnostics=None,
                  diagnostic_fields=None):
 
-        self.dt = dt
         if output is None:
             raise RuntimeError("You must provide a directory name for dumping results")
         else:
@@ -358,15 +357,22 @@ class State(object):
             if dim == 2:
                 self.perp = lambda u: as_vector([-u[1], u[0]])
 
-        #  Constant to hold current time
-        self.t = Constant(0.0)
-
         # setup logger
         logger.setLevel(output.log_level)
         set_log_handler(mesh.comm)
         if parameters is not None:
             logger.info("Physical parameters that take non-default values:")
             logger.info(", ".join("%s: %s" % (k, float(v)) for (k, v) in vars(parameters).items()))
+
+        #  Constant to hold current time
+        self.t = Constant(0.0)
+        if type(dt) is Constant:
+            self.dt = dt
+        elif type(dt) in (float, int):
+            self.dt = Constant(dt)
+        else:
+            raise TypeError(f'dt must be a Constant, float or int, not {type(dt)}')
+
 
     def setup_diagnostics(self):
         """
@@ -460,7 +466,7 @@ class State(object):
         if len(self.output.point_data) > 0:
             # set up point data output
             pointdata_filename = self.dumpdir+"/point_data.nc"
-            ndt = int(tmax/self.dt)
+            ndt = int(tmax/float(self.dt))
             self.pointdata_output = PointDataOutput(pointdata_filename, ndt,
                                                     self.output.point_data,
                                                     self.output.dirname,

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -1,4 +1,4 @@
-from firedrake import Function
+from firedrake import Function, Projector
 from pyop2.profiling import timed_stage
 from gusto.configuration import logger
 from gusto.forcing import Forcing
@@ -115,15 +115,12 @@ class Timestepper(object):
         with timed_stage("Dump output"):
             state.setup_dump(t, tmax, pickup)
 
-        dt = state.dt
+        state.t.assign(t)
 
         self.x.initialise(state)
 
-        while t < tmax - 0.5*dt:
-            logger.info("at start of timestep, t=%s, dt=%s" % (float(t), float(dt)))
-
-            t += dt
-            state.t.assign(t)
+        while float(state.t) < tmax - 0.5*float(state.dt):
+            logger.info(f'at start of timestep, t={float(state.t)}, dt={float(state.dt)}')
 
             self.x.update()
 
@@ -141,13 +138,15 @@ class Timestepper(object):
                 for field in self.x.np1:
                     field.assign(state.fields(field.name()))
 
+            state.t.assign(state.t + state.dt)
+
             with timed_stage("Dump output"):
-                state.dump(t)
+                state.dump(float(state.t))
 
         if state.output.checkpoint:
             state.chkpt.close()
 
-        logger.info("TIMELOOP complete. t=%s, tmax=%s" % (t, tmax))
+        logger.info(f'TIMELOOP complete. t={float(state.t)}, tmax={tmax}')
 
 
 class CrankNicolson(Timestepper):
@@ -226,10 +225,10 @@ class CrankNicolson(Timestepper):
         self.xrhs = Function(W)
         self.dy = Function(W)
         if linear_solver is None:
-            self.linear_solver = LinearTimesteppingSolver(equation_set, state.dt, self.alpha)
+            self.linear_solver = LinearTimesteppingSolver(equation_set, self.alpha)
         else:
             self.linear_solver = linear_solver
-        self.forcing = Forcing(equation_set, state.dt, self.alpha)
+        self.forcing = Forcing(equation_set, self.alpha)
         self.bcs = equation_set.bcs
 
     @property
@@ -312,16 +311,21 @@ class PrescribedTransport(Timestepper):
     def __init__(self, state, problem, physics_list=None,
                  prescribed_transporting_velocity=None):
 
-        self.prescribed_transporting_velocity = prescribed_transporting_velocity
         super().__init__(state, problem,
                          physics_list=physics_list)
+
+        if prescribed_transporting_velocity is not None:
+            self.velocity_projection = Projector(prescribed_transporting_velocity(self.state.t),
+                                                 self.state.fields('u'))
+        else:
+            self.velocity_projection = None
 
     @property
     def transporting_velocity(self):
         return self.state.fields('u')
 
     def timestep(self):
-        if self.prescribed_transporting_velocity is not None:
-            self.state.fields('u').project(self.prescribed_transporting_velocity(self.state.t))
+        if self.velocity_projection is not None:
+            self.velocity_projection.project()
 
         super().timestep()

--- a/integration-tests/equations/test_gw_incompressible.py
+++ b/integration-tests/equations/test_gw_incompressible.py
@@ -55,7 +55,7 @@ def run_gw_incompressible(dirname):
     state, eqns = setup_gw(dirname)
     x = TimeLevelFields(state, [eqns])
     xn = x.n
-    forcing = Forcing(eqns, state.dt, alpha=1.)
+    forcing = Forcing(eqns, alpha=1.)
     forcing.apply(xn, xn, xn(eqns.field_name), label="explicit")
     u = xn('u')
     w = Function(state.spaces("DG")).interpolate(u[2])

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -95,5 +95,5 @@ def test_checkpointing(tmpdir):
     dirname = str(tmpdir)
     stepper, tmax = setup_sk(dirname)
     stepper.run(t=0., tmax=tmax)
-    dt = stepper.state.dt
+    dt = float(stepper.state.dt)
     stepper.run(t=tmax, tmax=2*tmax+dt, pickup=True)


### PR DESCRIPTION
This PR ensures that `state.dt` is a `Constant`, and that the rest of Gusto uses this `dt`. If we need adaptive time stepping then updating `state.dt` will ensure that the correct time step is picked up everywhere.

This addresses #275 

Also:
- the time is updated at the end of the time step (but before outputting)
- the `PrescribedTransport` time stepper updates the transporting velocity with a `Projector`
- when a `Constant` is multiplied by zero, it creates a `ufl.constantvalue.Zero` object. I have added handling of this for `LabelledForm`s, which arises in the `test_gw_incompressible.py` test