### PR TITLE
Return to spectral element variants by default

### DIFF
--- a/examples/compressible/dry_bryan_fritsch.py
+++ b/examples/compressible/dry_bryan_fritsch.py
@@ -99,7 +99,7 @@ state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b)])
 
 # Set up transport schemes
-VDG1 = state.spaces("DG1", "DG", 1)
+VDG1 = state.spaces("DG1_equispaced")
 VCG1 = FunctionSpace(mesh, "CG", 1)
 Vt_brok = FunctionSpace(mesh, BrokenElement(Vt.ufl_element()))
 Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -68,7 +68,7 @@ x, z = SpatialCoordinate(mesh)
 quadrature_degree = (4, 4)
 dxp = dx(degree=(quadrature_degree))
 
-VDG1 = state.spaces("DG1", "DG", 1)
+VDG1 = state.spaces("DG1_equispaced")
 VCG1 = FunctionSpace(mesh, "CG", 1)
 Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())
 Vu_CG1 = VectorFunctionSpace(mesh, "CG", 1)

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -1,4 +1,5 @@
-from firedrake import dx, BrokenElement, Function, FunctionSpace
+from firedrake import (dx, BrokenElement, Function, FunctionSpace, interval,
+                       FiniteElement, TensorProductElement)
 from firedrake.parloops import par_loop, READ, WRITE, INC
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 
@@ -7,137 +8,108 @@ __all__ = ["ThetaLimiter", "NoLimiter"]
 
 class ThetaLimiter(object):
     """
-    A vertex based limiter for fields in the DG1xCG2 space,
-    i.e. temperature variables. This acts like the vertex-based
-    limiter implemented in Firedrake, but in addition corrects
+    A vertex based limiter for fields in the DG1xCG2 space, i.e. temperature
+    variables in the next-to-lowest order set of spaces. This acts like the
+    vertex-based limiter implemented in Firedrake, but in addition corrects
     the central nodes to prevent new maxima or minima forming.
     """
 
     def __init__(self, space):
         """
         Initialise limiter
-        :param space: the space in which theta lies.
-        It should be the DG1xCG2 space.
+        :arg space: the space in which the transported variables lies.
+                    It should be a form of the DG1xCG2 space.
         """
 
-        self.Vt = FunctionSpace(space.mesh(), BrokenElement(space.ufl_element()))
-        # check this is the right space, currently working for 2D and 3D extruded meshes
+        if not space.extruded:
+            raise ValueError('The Theta Limiter can only be used on an extruded mesh')
+
         # check that horizontal degree is 1 and vertical degree is 2
-        if self.Vt.ufl_element().degree()[0] != 1 or \
-           self.Vt.ufl_element().degree()[1] != 2:
-            raise ValueError('This is not the right limiter for this space.')
+        sub_elements = space.ufl_element().sub_elements()
+        if (sub_elements[0].family() not in ['Discontinuous Lagrange','DQ'] or
+            sub_elements[1].family() != 'Lagrange' or
+            space.ufl_element().degree() != (1,2)):
+            raise ValueError('Theta Limiter should only be used with the DG1xCG2 space')
 
-        if not self.Vt.extruded:
-            raise ValueError('This is not the right limiter for this space.')
-        if self.Vt.mesh().topological_dimension() == 2:
-            # check that continuity of the spaces is correct
-            # this will fail if the space does not use broken elements
-            if self.Vt.ufl_element()._element.sobolev_space()[0].name != 'L2' or \
-               self.Vt.ufl_element()._element.sobolev_space()[1].name != 'H1':
-                raise ValueError('This is not the right limiter for this space.')
-        elif self.Vt.mesh().topological_dimension() == 3:
-            # check that continuity of the spaces is correct
-            # this will fail if the space does not use broken elements
-            if self.Vt.ufl_element()._element.sobolev_space()[0].name != 'L2' or \
-               self.Vt.ufl_element()._element.sobolev_space()[2].name != 'H1':
-                raise ValueError('This is not the right limiter for this space.')
-        else:
-            raise ValueError('This is not the right limiter for this space.')
+        # Transport will happen in broken form of Vtheta
+        mesh = space.mesh()
+        self.Vt_brok = FunctionSpace(mesh, BrokenElement(space.ufl_element()))
 
-        self.DG1 = FunctionSpace(self.Vt.mesh(), 'DG', 1)  # space with only vertex DOFs
-        self.vertex_limiter = VertexBasedLimiter(self.DG1)
-        self.theta_hat = Function(self.DG1)  # theta function with only vertex DOFs
-        self.theta_old = Function(self.Vt)
-        self.w = Function(self.Vt)
-        self.result = Function(self.Vt)
+        # if sub_elements[0].variant() == 'equispaced':
+        #     raise ValueError('Theta Limiter can only be used with an equispaced DG1 space in the horizontal')
 
-        shapes = {'nDOFs': self.Vt.finat_element.space_dimension(),
-                  'nDOFs_base': int(self.Vt.finat_element.space_dimension() / 3)}
-        averager_domain = "{{[i]: 0 <= i < {nDOFs}}}".format(**shapes)
+        # Create equispaced DG1 space needed for limiting
+        cell = mesh._base_mesh.ufl_cell().cellname()
+        DG1_hori_elt = FiniteElement("DG", cell, 1, variant="equispaced")
+        DG1_vert_elt = FiniteElement("DG", interval, 1, variant="equispaced")
+        CG2_vert_elt = FiniteElement("CG", interval, 2)
+        DG1_element = TensorProductElement(DG1_hori_elt, DG1_vert_elt)
+        Vt_element = TensorProductElement(DG1_hori_elt, CG2_vert_elt)
+        DG1_equispaced = FunctionSpace(mesh, DG1_element)
+        Vt_equispaced = FunctionSpace(mesh, Vt_element)
+        Vt_brok_equispaced = FunctionSpace(mesh, BrokenElement(Vt_equispaced.ufl_element()))
+
+        self.vertex_limiter = VertexBasedLimiter(DG1_equispaced)
+        self.field_hat = Function(Vt_brok_equispaced)
+        self.field_old = Function(Vt_brok_equispaced)
+        self.field_DG1 = Function(DG1_equispaced)
+
+        # TODO: pull this kernel into its own module and test it
+        shapes = {'nDOFs': self.Vt_brok.finat_element.space_dimension(),
+                  'nDOFs_base': int(self.Vt_brok.finat_element.space_dimension() / 3)}
         theta_domain = "{{[i,j]: 0 <= i < {nDOFs_base} and 0 <= j < 2}}".format(**shapes)
 
-        average_instructions = ("""
-                                for i
-                                    vo[i] = vo[i] + v[i] / w[i]
-                                end
-                                """)
+        limit_midpoints_instrs = ("""
+                                  <float64> max_value = 0.0
+                                  <float64> min_value = 0.0
+                                  for i
+                                      for j
+                                          field_hat[i*3+2*j] = field_DG1[i*2+j]
+                                      end
+                                      max_value = fmax(field_DG1[i*2], field_DG1[i*2+1])
+                                      min_value = fmin(field_DG1[i*2], field_DG1[i*2+1])
+                                      if field_old[i*3+1] > max_value
+                                          field_hat[i*3+1] = 0.5 * (field_DG1[i*2] + field_DG1[i*2+1])
+                                      elif field_old[i*3+1] < min_value
+                                          field_hat[i*3+1] = 0.5 * (field_DG1[i*2] + field_DG1[i*2+1])
+                                      else
+                                          field_hat[i*3+1] = field_old[i*3+1]
+                                      end
+                                  end
+                                  """)
 
-        weight_instructions = ("""
-                               for i
-                                  w[i] = w[i] + 1.0
-                               end
-                               """)
+        self._limit_midpoints_kernel = (theta_domain, limit_midpoints_instrs)
 
-        copy_into_DG1_instrs = ("""
-                                for i
-                                    for j
-                                        theta_hat[i*2+j] = theta[i*3+j]
-                                    end
-                                end
-                                """)
-
-        copy_from_DG1_instrs = ("""
-                                <float64> max_value = 0.0
-                                <float64> min_value = 0.0
-                                for i
-                                    for j
-                                        theta[i*3+j] = theta_hat[i*2+j]
-                                    end
-                                    max_value = fmax(theta_hat[i*2], theta_hat[i*2+1])
-                                    min_value = fmin(theta_hat[i*2], theta_hat[i*2+1])
-                                    if theta_old[i*3+2] > max_value
-                                        theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                    elif theta_old[i*3+2] < min_value
-                                        theta[i*3+2] = 0.5 * (theta_hat[i*2] + theta_hat[i*2+1])
-                                    else
-                                        theta[i*3+2] = theta_old[i*3+2]
-                                    end
-                                end
-                                """)
-
-        self._average_kernel = (averager_domain, average_instructions)
-        _weight_kernel = (averager_domain, weight_instructions)
-        self._copy_into_DG1_kernel = (theta_domain, copy_into_DG1_instrs)
-        self._copy_from_DG1_kernel = (theta_domain, copy_from_DG1_instrs)
-
-        par_loop(_weight_kernel, dx, {"w": (self.w, INC)}, is_loopy_kernel=True)
-
-    def copy_vertex_values(self, field):
+    def limit_midpoints(self):
         """
-        Copies the vertex values from temperature space to
-        DG1 space which only has vertices.
+        Copies the vertex values back from the DG1 space to a broken, equispaced
+        temperature space, while taking the midpoint values from the original
+        field. This checks that the midpoint values are within the minimum and
+        maximum at the adjacent vertices. If outside of the minimu and maximum,
+        correct the values to be the average.
         """
-        par_loop(self._copy_into_DG1_kernel, dx,
-                 {"theta": (field, READ),
-                  "theta_hat": (self.theta_hat, WRITE)},
-                 is_loopy_kernel=True)
-
-    def copy_vertex_values_back(self, field):
-        """
-        Copies the vertex values back from the DG1 space to
-        the original temperature space, and checks that the
-        midpoint values are within the minimum and maximum
-        at the adjacent vertices.
-        If outside of the minimum and maximum, correct the values
-        to be the average.
-        """
-        par_loop(self._copy_from_DG1_kernel, dx,
-                 {"theta": (field, WRITE),
-                  "theta_hat": (self.theta_hat, READ),
-                  "theta_old": (self.theta_old, READ)},
+        par_loop(self._limit_midpoints_kernel, dx,
+                 {"field_hat": (self.field_hat, WRITE),
+                  "field_DG1": (self.field_DG1, READ),
+                  "field_old": (self.field_old, READ)},
                  is_loopy_kernel=True)
 
     def apply(self, field):
         """
         The application of the limiter to the theta-space field.
         """
-        assert field.function_space() == self.Vt, \
-            'Given field does not belong to this objects function space'
+        assert field.function_space() == self.Vt_brok, \
+            "Given field does not belong to this object's function space"
 
-        self.theta_old.assign(field)
-        self.copy_vertex_values(field)
-        self.vertex_limiter.apply(self.theta_hat)
-        self.copy_vertex_values_back(field)
+        # Obtain field in equispaced DG space and save original field
+        self.field_old.interpolate(field)
+        self.field_DG1.interpolate(field)
+        # Use vertex based limiter on DG1 field
+        self.vertex_limiter.apply(self.field_DG1)
+        # Limit midpoints in fully equispaced Vt space
+        self.limit_midpoints()
+        # Return to original space
+        field.interpolate(self.field_hat)
 
 
 class NoLimiter(object):

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -1,6 +1,6 @@
 from firedrake import (dx, BrokenElement, Function, FunctionSpace, interval,
                        FiniteElement, TensorProductElement)
-from firedrake.parloops import par_loop, READ, WRITE, INC
+from firedrake.parloops import par_loop, READ, WRITE
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 
 __all__ = ["ThetaLimiter", "NoLimiter"]
@@ -26,9 +26,9 @@ class ThetaLimiter(object):
 
         # check that horizontal degree is 1 and vertical degree is 2
         sub_elements = space.ufl_element().sub_elements()
-        if (sub_elements[0].family() not in ['Discontinuous Lagrange','DQ'] or
-            sub_elements[1].family() != 'Lagrange' or
-            space.ufl_element().degree() != (1,2)):
+        if (sub_elements[0].family() not in ['Discontinuous Lagrange', 'DQ']
+                or sub_elements[1].family() != 'Lagrange'
+                or space.ufl_element().degree() != (1, 2)):
             raise ValueError('Theta Limiter should only be used with the DG1xCG2 space')
 
         # Transport will happen in broken form of Vtheta

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -171,11 +171,10 @@ class Fallout(Physics):
 
         # determine whether to do recovered space advection scheme
         # if horizontal and vertical degrees are 0 do recovered spac
-        Vrho = state.spaces("DG")
-        h_deg = Vrho.ufl_element().degree()[0]
-        v_deg = Vrho.ufl_element().degree()[1]
+        h_deg = Vt.ufl_element().degree()[0]
+        v_deg = Vt.ufl_element().degree()[1] - 1
         if v_deg == 0 and h_deg == 0:
-            VDG1 = state.spaces("DG1")
+            VDG1 = state.spaces("DG1_equispaced")
             VCG1 = FunctionSpace(Vt.mesh(), "CG", 1)
             Vbrok = FunctionSpace(Vt.mesh(), BrokenElement(Vt.ufl_element()))
             boundary_method = Boundary_Method.dynamics

--- a/gusto/recovery.py
+++ b/gusto/recovery.py
@@ -147,16 +147,16 @@ class Boundary_Recoverer(object):
                 raise NotImplementedError('The physics boundary method only works on extruded meshes')
             # check that function spaces are valid
             sub_elements = v_CG1.function_space().ufl_element().sub_elements()
-            if (sub_elements[0].family() not in ['Discontinuous Lagrange','DQ'] or
-                sub_elements[1].family() != 'Lagrange' or
-                v_CG1.function_space().ufl_element().degree() != (0,1)):
+            if (sub_elements[0].family() not in ['Discontinuous Lagrange', 'DQ']
+                    or sub_elements[1].family() != 'Lagrange'
+                    or v_CG1.function_space().ufl_element().degree() != (0, 1)):
                 raise ValueError("This boundary recovery method requires v_CG1 to be in DG0xCG1 TensorProductSpace.")
 
             brok_elt = v_DG1.function_space().ufl_element()
-            if (brok_elt.degree() != (0,1) or
-                (type(brok_elt) is not BrokenElement and
-                 (brok_elt.sub_elements[0].family() not in ['Discontinuous Lagrange', 'DQ'] or
-                  brok_elt.sub_elements[1].family() != 'Discontinuous Lagrange'))):
+            if (brok_elt.degree() != (0, 1)
+                or (type(brok_elt) is not BrokenElement
+                    and (brok_elt.sub_elements[0].family() not in ['Discontinuous Lagrange', 'DQ']
+                         or brok_elt.sub_elements[1].family() != 'Discontinuous Lagrange'))):
                 raise ValueError("This boundary recovery method requires v_DG1 to be in the broken DG0xCG1 TensorProductSpace.")
         else:
             raise ValueError("Boundary method should be a Boundary Method Enum object.")

--- a/gusto/recovery.py
+++ b/gusto/recovery.py
@@ -145,18 +145,18 @@ class Boundary_Recoverer(object):
             # check that mesh is valid -- must be an extruded mesh
             if not DG0.extruded:
                 raise NotImplementedError('The physics boundary method only works on extruded meshes')
-            # base spaces
-            cell = mesh._base_mesh.ufl_cell().cellname()
-            w_hori = FiniteElement("DG", cell, 0, variant="equispaced")
-            w_vert = FiniteElement("CG", interval, 1, variant="equispaced")
-            # build element
-            theta_element = TensorProductElement(w_hori, w_vert)
-            # spaces
-            Vtheta = FunctionSpace(mesh, theta_element)
-            Vtheta_broken = FunctionSpace(mesh, BrokenElement(theta_element))
-            if v_CG1.function_space() != Vtheta:
+            # check that function spaces are valid
+            sub_elements = v_CG1.function_space().ufl_element().sub_elements()
+            if (sub_elements[0].family() not in ['Discontinuous Lagrange','DQ'] or
+                sub_elements[1].family() != 'Lagrange' or
+                v_CG1.function_space().ufl_element().degree() != (0,1)):
                 raise ValueError("This boundary recovery method requires v_CG1 to be in DG0xCG1 TensorProductSpace.")
-            if v_DG1.function_space() != Vtheta_broken:
+
+            brok_elt = v_DG1.function_space().ufl_element()
+            if (brok_elt.degree() != (0,1) or
+                (type(brok_elt) is not BrokenElement and
+                 (brok_elt.sub_elements[0].family() not in ['Discontinuous Lagrange', 'DQ'] or
+                  brok_elt.sub_elements[1].family() != 'Discontinuous Lagrange'))):
                 raise ValueError("This boundary recovery method requires v_DG1 to be in the broken DG0xCG1 TensorProductSpace.")
         else:
             raise ValueError("Boundary method should be a Boundary Method Enum object.")

--- a/gusto/state.py
+++ b/gusto/state.py
@@ -31,6 +31,8 @@ class SpaceCreator(object):
                 value = self.build_hdiv_space(family, degree)
             elif name == "theta":
                 value = self.build_theta_space(degree)
+            elif name == "DG1_equispaced":
+                value = self.build_dg_space(1, variant='equispaced')
             elif family == "DG":
                 value = self.build_dg_space(degree)
             elif family == "CG":
@@ -60,12 +62,12 @@ class SpaceCreator(object):
         cell = self.mesh._base_mesh.ufl_cell().cellname()
 
         # horizontal base spaces
-        self.S1 = FiniteElement(family, cell, degree+1, variant="equispaced")
-        self.S2 = FiniteElement("DG", cell, degree, variant="equispaced")
+        self.S1 = FiniteElement(family, cell, degree+1)
+        self.S2 = FiniteElement("DG", cell, degree)
 
         # vertical base spaces
-        self.T0 = FiniteElement("CG", interval, degree+1, variant="equispaced")
-        self.T1 = FiniteElement("DG", interval, degree, variant="equispaced")
+        self.T0 = FiniteElement("CG", interval, degree+1)
+        self.T1 = FiniteElement("DG", interval, degree)
 
         self._initialised_base_spaces = True
 
@@ -82,28 +84,28 @@ class SpaceCreator(object):
             V_elt = FiniteElement(family, cell, degree+1)
         return FunctionSpace(self.mesh, V_elt, name='HDiv')
 
-    def build_dg_space(self, degree):
+    def build_dg_space(self, degree, variant=None):
         if self.extruded_mesh:
-            if not self._initialised_base_spaces or self.T1.degree() != degree:
+            if not self._initialised_base_spaces or self.T1.degree() != degree or self.T1.variant() != variant:
                 cell = self.mesh._base_mesh.ufl_cell().cellname()
-                S2 = FiniteElement("DG", cell, degree, variant="equispaced")
-                T1 = FiniteElement("DG", interval, degree, variant="equispaced")
+                S2 = FiniteElement("DG", cell, degree, variant=variant)
+                T1 = FiniteElement("DG", interval, degree, variant=variant)
             else:
                 S2 = self.S2
                 T1 = self.T1
             V_elt = TensorProductElement(S2, T1)
         else:
             cell = self.mesh.ufl_cell().cellname()
-            V_elt = FiniteElement("DG", cell, degree, variant="equispaced")
-        return FunctionSpace(self.mesh, V_elt, name=f'DG{degree}')
+            V_elt = FiniteElement("DG", cell, degree, variant=variant)
+        name = f'DG{degree}_equispaced' if variant == 'equispaced' else f'DG{degree}'
+        return FunctionSpace(self.mesh, V_elt, name=name)
 
     def build_theta_space(self, degree):
         assert self.extruded_mesh
         if not self._initialised_base_spaces:
             cell = self.mesh._base_mesh.ufl_cell().cellname()
-            self.S2 = FiniteElement("DG", cell, degree, variant="equispaced")
-            self.T0 = FiniteElement("CG", interval, degree+1,
-                                    variant="equispaced")
+            self.S2 = FiniteElement("DG", cell, degree)
+            self.T0 = FiniteElement("CG", interval, degree+1)
         V_elt = TensorProductElement(self.S2, self.T0)
         return FunctionSpace(self.mesh, V_elt, name='Vtheta')
 

--- a/integration-tests/balance/test_saturated_balance.py
+++ b/integration-tests/balance/test_saturated_balance.py
@@ -78,7 +78,7 @@ def setup_saturated(dirname, recovered):
 
     # Set up transport schemes
     if recovered:
-        VDG1 = state.spaces("DG1", "DG", 1)
+        VDG1 = state.spaces("DG1_equispaced")
         VCG1 = FunctionSpace(mesh, "CG", 1)
         Vt_brok = FunctionSpace(mesh, BrokenElement(Vt.ufl_element()))
         Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())

--- a/integration-tests/balance/test_unsaturated_balance.py
+++ b/integration-tests/balance/test_unsaturated_balance.py
@@ -73,7 +73,7 @@ def setup_unsaturated(dirname, recovered):
 
     # Set up transport schemes
     if recovered:
-        VDG1 = state.spaces("DG1", "DG", 1)
+        VDG1 = state.spaces("DG1_equispaced")
         VCG1 = FunctionSpace(mesh, "CG", 1)
         Vt_brok = FunctionSpace(mesh, BrokenElement(Vt.ufl_element()))
         Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element())

--- a/integration-tests/physics/test_precipitation.py
+++ b/integration-tests/physics/test_precipitation.py
@@ -37,7 +37,7 @@ def setup_fallout(dirname):
                   parameters=parameters,
                   diagnostic_fields=diagnostic_fields)
 
-    Vrho = state.spaces("DG", "DG", 1)
+    Vrho = state.spaces("DG1_equispaced")
     problem = [(AdvectionEquation(state, Vrho, "rho", ufamily="CG", udegree=1), ForwardEuler(state))]
     state.fields("rho").assign(1.)
 

--- a/integration-tests/transport/test_limiters.py
+++ b/integration-tests/transport/test_limiters.py
@@ -31,7 +31,7 @@ def setup_limiters(dirname):
                   parameters=parameters)
 
     # set up the function spaces:
-    Vr = state.spaces("DG", "DG", 1)
+    Vr = state.spaces("DG1_equispaced")
     Vt = state.spaces("theta", degree=1)
     Vpsi = FunctionSpace(mesh, "CG", 2)
 
@@ -133,7 +133,6 @@ def run_limiters(dirname):
 
     stepper, tmax = setup_limiters(dirname)
     stepper.run(t=0, tmax=tmax)
-    # print(stepper.state.fields('moisture').dat.data[:])
     return
 
 

--- a/integration-tests/transport/test_recovered_transport.py
+++ b/integration-tests/transport/test_recovered_transport.py
@@ -41,7 +41,7 @@ def test_recovered_space_setup(tmpdir):
     # spaces
     Vpsi = FunctionSpace(mesh, "CG", 2)
     VDG0 = FunctionSpace(mesh, "DG", 0)
-    VDG1 = state.spaces("DG", "DG", 1)
+    VDG1 = state.spaces("DG1_equispaced")
     VCG1 = FunctionSpace(mesh, "CG", 1)
 
     tracereqn = ContinuityEquation(state, VDG0, "tracer", ufamily="CG",

--- a/integration-tests/transport/test_vector_recovered_space.py
+++ b/integration-tests/transport/test_vector_recovered_space.py
@@ -41,12 +41,12 @@ def test_vector_recovered_space_setup(tmpdir):
 
     # horizontal base spaces
     cell = mesh._base_mesh.ufl_cell().cellname()
-    u_hori = FiniteElement("CG", cell, 1, variant="equispaced")
-    w_hori = FiniteElement("DG", cell, 0, variant="equispaced")
+    u_hori = FiniteElement("CG", cell, 1)
+    w_hori = FiniteElement("DG", cell, 0)
 
     # vertical base spaces
-    u_vert = FiniteElement("DG", interval, 0, variant="equispaced")
-    w_vert = FiniteElement("CG", interval, 1, variant="equispaced")
+    u_vert = FiniteElement("DG", interval, 0)
+    w_vert = FiniteElement("CG", interval, 1)
 
     # build elements
     u_element = HDiv(TensorProductElement(u_hori, u_vert))
@@ -55,7 +55,7 @@ def test_vector_recovered_space_setup(tmpdir):
 
     # spaces
     Vpsi = FunctionSpace(mesh, "CG", 2)
-    VDG1 = state.spaces("DG", "DG", 1)
+    VDG1 = state.spaces("DG1_equispaced")
     Vu_DG1 = VectorFunctionSpace(mesh, VDG1.ufl_element(), name='Vec_DG1')
     Vu_CG1 = VectorFunctionSpace(mesh, "CG", 1, name='Vec_CG1')
     Vu = FunctionSpace(mesh, v_element)

--- a/unit-tests/recovery_tests/test_recovery_2d_vert_slice.py
+++ b/unit-tests/recovery_tests/test_recovery_2d_vert_slice.py
@@ -59,12 +59,12 @@ def test_vertical_slice_recovery(geometry, mesh, expr):
 
     # horizontal base spaces
     cell = mesh._base_mesh.ufl_cell().cellname()
-    u_hori = FiniteElement("CG", cell, 1, variant="equispaced")
-    w_hori = FiniteElement("DG", cell, 0, variant="equispaced")
+    u_hori = FiniteElement("CG", cell, 1)
+    w_hori = FiniteElement("DG", cell, 0)
 
     # vertical base spaces
-    u_vert = FiniteElement("DG", interval, 0, variant="equispaced")
-    w_vert = FiniteElement("CG", interval, 1, variant="equispaced")
+    u_vert = FiniteElement("DG", interval, 0)
+    w_vert = FiniteElement("CG", interval, 1)
 
     # build elements
     u_element = HDiv(TensorProductElement(u_hori, u_vert))

--- a/unit-tests/recovery_tests/test_recovery_3d_cart.py
+++ b/unit-tests/recovery_tests/test_recovery_3d_cart.py
@@ -80,11 +80,11 @@ def test_3D_cartesian_recovery(geometry, element, mesh, expr):
     # horizontal base spaces
     cell = mesh._base_mesh.ufl_cell().cellname()
     u_hori = FiniteElement(family, cell, 1)
-    w_hori = FiniteElement("DG", cell, 0, variant="equispaced")
+    w_hori = FiniteElement("DG", cell, 0)
 
     # vertical base spaces
-    u_vert = FiniteElement("DG", interval, 0, variant="equispaced")
-    w_vert = FiniteElement("CG", interval, 1, variant="equispaced")
+    u_vert = FiniteElement("DG", interval, 0)
+    w_vert = FiniteElement("CG", interval, 1)
 
     # build elements
     u_element = HDiv(TensorProductElement(u_hori, u_vert))


### PR DESCRIPTION
This PR removes the default option enforcing finite elements to use the `'equispaced'` variant.

The equispaced elements are only needed for the recovery wrapper and for limiters, and so a special `'DG1_equispaced'` space is now stored in `state`.

This change highlighted errors in the `ThetaLimiter` which have been fixed. I'll follow up on improving the testing of the limiters.