### PR TITLE
Use ufl derivative to generate linearisations

### DIFF
--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -758,6 +758,7 @@ class CompressibleEulerEquations(PrognosticEquationSet):
         # Extra Terms (Coriolis, Sponge, Diffusion and others)
         # -------------------------------------------------------------------- #
         if Omega is not None:
+            # TODO: add linearisation and label for this
             residual += subject(prognostic(
                 inner(w, cross(2*Omega, u))*dx, "u"), self.X)
 
@@ -978,6 +979,7 @@ class IncompressibleBoussinesqEquations(PrognosticEquationSet):
         # Extra Terms (Coriolis)
         # -------------------------------------------------------------------- #
         if Omega is not None:
+            # TODO: add linearisation and label for this
             residual += subject(prognostic(
                 inner(w, cross(2*Omega, u))*dx, "u"), self.X)
 


### PR DESCRIPTION
I got it working! As the name suggests, this uses the `ufl.derivative` feature to generate the linearised terms in the equations.

The main problem I had before was that I was using `trials = TrialFunctions(W)` in the `action` call. `TrialFunctions` is a tuple, but replacing this with `trials = TrialFunction(W)` seemed to make everything happy.

In this PR I have restructured the complicated `label_map` that we use to generate the linear terms. Instead I am explicitly looping through the terms in the equation, and it might be possible to replace this later with a better label map. One challenge is that we want all the labels to be copied over from the original term to the linearisation.

I also realised that some terms didn't have a `prognostic` label. We could of course remove the `prognostic` and attempt to use the index of the test function but this is less user-friendly. Or maybe there is a halfway house in which the `prognostic` label is automatically generated from the test function?

One problem was the Coriolis force, I think because of the perp operator? Something about the linearisation or replace did not work here, so the linear shallow water test only worked when I manually added a linearisation of this term. I have only done this for the shallow-water equations and not the other equation sets.