### PR TITLE
fix completely pointless and stupid bug

### DIFF
--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -472,7 +472,8 @@ class ExplicitTimeDiscretisation(TimeDiscretisation):
         else:
             self.dt = self.dt
             self.ncycles = 1
-        self.x = [Function(self.fs)]*(self.ncycles+1)
+        self.x0 = Function(self.fs)
+        self.x1 = Function(self.fs)
 
     @abstractmethod
     def apply_cycle(self, x_in, x_out):
@@ -494,11 +495,11 @@ class ExplicitTimeDiscretisation(TimeDiscretisation):
             x_in (:class:`Function`): the input field.
             x_out (:class:`Function`): the output field to be computed.
         """
-        self.x[0].assign(x_in)
+        self.x0.assign(x_in)
         for i in range(self.ncycles):
-            self.apply_cycle(self.x[i], self.x[i+1])
-            self.x[i].assign(self.x[i+1])
-        x_out.assign(self.x[self.ncycles-1])
+            self.apply_cycle(self.x0, self.x1)
+            self.x0.assign(self.x1)
+        x_out.assign(self.x1)
 
 
 class ForwardEuler(ExplicitTimeDiscretisation):


### PR DESCRIPTION
This was a very silly bug introduced by setting up a list of functions for the sub cycled advection. This was creating a list off references to the *same* function rather than a list of separate functions, meaning that updating one updated them all. The list was unnecessary anyway as we only require the output of the scheme at `t+dt`, not the intermediate data values at `t+dt/ncycles, t+2*dt/ncycles, ...`