### PR TITLE
Implement a DG1 limiter for non-equispaced DG1 spaces

### DIFF
--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -10,8 +10,75 @@ from firedrake import (BrokenElement, Function, FunctionSpace, interval,
                        FiniteElement, TensorProductElement)
 from firedrake.slope_limiter.vertex_based_limiter import VertexBasedLimiter
 from gusto.kernels import LimitMidpoints
+import numpy as np
 
-__all__ = ["ThetaLimiter", "NoLimiter"]
+__all__ = ["DG1Limiter", "ThetaLimiter", "NoLimiter"]
+
+
+class DG1Limiter(object):
+    """
+    A vertex-based limiter for the degree 1 discontinuous Galerkin space.
+
+    A vertex based limiter for fields in the DG1 space. This wraps around the
+    vertex-based limiter implemented in Firedrake, but ensures that this is done
+    in the space using the appropriate "equispaced" elements.
+    """
+
+    def __init__(self, space):
+        """
+        Args:
+            space (:class:`FunctionSpace`): the space in which the transported
+                variables lies. It should be the DG1 space.
+
+        Raises:
+            ValueError: If the space is not appropriate for the limiter.
+        """
+
+        self.space = space
+        mesh = space.mesh()
+
+        # check that space is DG1
+        degree = space.ufl_element().degree()
+        if (space.ufl_element().sobolev_space().name != 'L2'
+            or ((type(degree) is tuple and np.any([deg != 1 for deg in degree]))
+                and degree != 1)):
+            raise ValueError('DG1 limiter can only be applied to DG1 space')
+
+        # Create equispaced DG1 space needed for limiting
+        if space.extruded:
+            cell = mesh._base_mesh.ufl_cell().cellname()
+            DG1_hori_elt = FiniteElement("DG", cell, 1, variant="equispaced")
+            DG1_vert_elt = FiniteElement("DG", interval, 1, variant="equispaced")
+            DG1_element = TensorProductElement(DG1_hori_elt, DG1_vert_elt)
+        else:
+            cell = mesh.ufl_cell().cellname()
+            DG1_element = FiniteElement("DG", cell, 1, variant="equispaced")
+
+        DG1_equispaced = FunctionSpace(mesh, DG1_element)
+
+        self.vertex_limiter = VertexBasedLimiter(DG1_equispaced)
+        self.field_equispaced = Function(DG1_equispaced)
+
+
+    def apply(self, field):
+        """
+        The application of the limiter to the field.
+
+        Args:
+            field (:class:`Function`): the field to apply the limiter to.
+
+        Raises:
+            AssertionError: If the field is not in the correct space.
+        """
+        assert field.function_space() == self.space, \
+            "Given field does not belong to this object's function space"
+
+        # Obtain field in equispaced DG space
+        self.field_equispaced.interpolate(field)
+        # Use vertex based limiter on DG1 field
+        self.vertex_limiter.apply(self.field_equispaced)
+        # Return to original space
+        field.interpolate(self.field_equispaced)
 
 
 class ThetaLimiter(object):

--- a/gusto/limiters.py
+++ b/gusto/limiters.py
@@ -59,7 +59,6 @@ class DG1Limiter(object):
         self.vertex_limiter = VertexBasedLimiter(DG1_equispaced)
         self.field_equispaced = Function(DG1_equispaced)
 
-
     def apply(self, field):
         """
         The application of the limiter to the field.

--- a/integration-tests/transport/test_limiters.py
+++ b/integration-tests/transport/test_limiters.py
@@ -45,6 +45,8 @@ def setup_limiters(dirname, space):
         V_brok = V
         VCG1 = FunctionSpace(mesh, 'CG', 1)
         VDG1 = state.spaces('DG1_equispaced')
+    elif space == 'DG1':
+        V = FunctionSpace(mesh, "DG", 1)
     elif space == 'DG1_equispaced':
         V = state.spaces('DG1_equispaced')
     elif space == 'Vtheta_degree_0':
@@ -163,6 +165,9 @@ def setup_limiters(dirname, space):
         transport_schemes = [(eqn, SSPRK3(state, options=opts,
                                           limiter=VertexBasedLimiter(VDG1)))]
 
+    elif space == 'DG1':
+        transport_schemes = [(eqn, SSPRK3(state, limiter=DG1Limiter(V)))]
+
     elif space == 'DG1_equispaced':
         transport_schemes = [(eqn, SSPRK3(state, limiter=VertexBasedLimiter(V)))]
 
@@ -179,7 +184,7 @@ def setup_limiters(dirname, space):
 
 
 @pytest.mark.parametrize('space', ['Vtheta_degree_0', 'Vtheta_degree_1',
-                                   'DG0', 'DG1_equispaced'])
+                                   'DG0', 'DG1_equispaced', 'DG1'])
 def test_limiters(tmpdir, space):
 
     # Setup and run


### PR DESCRIPTION
We now don't use the equispaced DG1 space by default. If we want to apply the `VertexBasedLimiter` to a field in DG1, then the field needs converting to the equispaced DG1 space.

This PR creates a new limiter that wraps around the `VertexBasedLimiter` for DG1 fields, and includes the conversion to and from the equispaced DG1 space. It should allow us to close #304 