### PR TITLE
Update old microphysics routines to use FML

### DIFF
--- a/examples/compressible/moist_bryan_fritsch.py
+++ b/examples/compressible/moist_bryan_fritsch.py
@@ -152,11 +152,11 @@ transported_fields = [SSPRK3(state, "rho", options=rho_opts),
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
 # define condensation
-physics_list = [Condensation(state)]
+physics_schemes = [(Condensation(state), ForwardEuler(state))]
 
 # build time stepper
 stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver,
-                        physics_list=physics_list)
+                        physics_schemes=physics_schemes)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/compressible/moist_bryan_fritsch.py
+++ b/examples/compressible/moist_bryan_fritsch.py
@@ -152,7 +152,7 @@ transported_fields = [SSPRK3(state, "rho", options=rho_opts),
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
 # define condensation
-physics_schemes = [(Condensation(state), ForwardEuler(state))]
+physics_schemes = [(SaturationAdjustment(eqns, params), ForwardEuler(state))]
 
 # build time stepper
 stepper = CrankNicolson(state, eqns, transported_fields,

--- a/examples/compressible/moist_bryan_fritsch.py
+++ b/examples/compressible/moist_bryan_fritsch.py
@@ -57,9 +57,9 @@ eqns = CompressibleEulerEquations(state, "CG", degree, active_tracers=tracers)
 u0 = state.fields("u")
 rho0 = state.fields("rho")
 theta0 = state.fields("theta")
-water_v0 = state.fields("vapour_mixing_ratio")
-water_c0 = state.fields("cloud_liquid_mixing_ratio")
-moisture = ["vapour_mixing_ratio", "cloud_liquid_mixing_ratio"]
+water_v0 = state.fields("water_vapour")
+water_c0 = state.fields("cloud_water")
+moisture = ["water_vapour", "cloud_water"]
 
 # spaces
 Vu = state.spaces("HDiv")
@@ -136,7 +136,7 @@ water_c0.assign(water_t - water_v0)
 
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b),
-                              ('vapour_mixing_ratio', water_vb)])
+                              ('water_vapour', water_vb)])
 
 rho_opts = None
 theta_opts = EmbeddedDGOptions()
@@ -144,8 +144,8 @@ u_transport = ImplicitMidpoint(state, "u")
 
 transported_fields = [SSPRK3(state, "rho", options=rho_opts),
                       SSPRK3(state, "theta", options=theta_opts),
-                      SSPRK3(state, "vapour_mixing_ratio", options=theta_opts),
-                      SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts),
+                      SSPRK3(state, "water_vapour", options=theta_opts),
+                      SSPRK3(state, "cloud_water", options=theta_opts),
                       u_transport]
 
 # Set up linear solver

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -207,11 +207,11 @@ transported_fields = [SSPRK3(state, "u", options=u_opts),
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
-# define condensation
+# define physics schemes
 physics_schemes = [(Fallout(eqns, 'rain', state), SSPRK3(state, options=theta_opts, limiter=limiter)),
                    (Coalescence(eqns), ForwardEuler(state)),
-                   (Evaporation(state), ForwardEuler(state)),
-                   (SaturationAdjustment(eqns, parameters), ForwardEuler(state))]
+                   (EvaporationOfRain(eqns, params), ForwardEuler(state)),
+                   (SaturationAdjustment(eqns, params), ForwardEuler(state))]
 
 # build time stepper
 stepper = CrankNicolson(state, eqns, transported_fields,

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -208,7 +208,8 @@ transported_fields = [SSPRK3(state, "u", options=u_opts),
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
 # define physics schemes
-physics_schemes = [(Fallout(eqns, 'rain', state), SSPRK3(state, options=theta_opts, limiter=limiter)),
+# NB: to use wrapper options with Fallout, need to pass field name to time discretisation
+physics_schemes = [(Fallout(eqns, 'rain', state), SSPRK3(state, field_name='rain', options=theta_opts, limiter=limiter)),
                    (Coalescence(eqns), ForwardEuler(state)),
                    (EvaporationOfRain(eqns, params), ForwardEuler(state)),
                    (SaturationAdjustment(eqns, params), ForwardEuler(state))]

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -208,12 +208,14 @@ transported_fields = [SSPRK3(state, "u", options=u_opts),
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
 # define condensation
-physics_list = [Fallout(state), Coalescence(state), Evaporation(state),
-                Condensation(state)]
+physics_schemes = [(Fallout(state), ForwardEuler(state)),
+                   (Coalescence(state), ForwardEuler(state)),
+                   (Evaporation(state), ForwardEuler(state)),
+                   (Condensation(state), ForwardEuler(state))]
 
 # build time stepper
 stepper = CrankNicolson(state, eqns, transported_fields,
                         linear_solver=linear_solver,
-                        physics_list=physics_list)
+                        physics_schemes=physics_schemes)
 
 stepper.run(t=0, tmax=tmax)

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -208,7 +208,7 @@ transported_fields = [SSPRK3(state, "u", options=u_opts),
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
 # define condensation
-physics_schemes = [(Fallout(state), ForwardEuler(state)),
+physics_schemes = [(Fallout(eqns, 'rain', state), SSPRK3(state, options=theta_opts, limiter=limiter)),
                    (Coalescence(eqns), ForwardEuler(state)),
                    (Evaporation(state), ForwardEuler(state)),
                    (SaturationAdjustment(eqns, parameters), ForwardEuler(state))]

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -209,9 +209,9 @@ linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
 # define condensation
 physics_schemes = [(Fallout(state), ForwardEuler(state)),
-                   (Coalescence(state), ForwardEuler(state)),
+                   (Coalescence(eqns), ForwardEuler(state)),
                    (Evaporation(state), ForwardEuler(state)),
-                   (Condensation(state), ForwardEuler(state))]
+                   (SaturationAdjustment(eqns, parameters), ForwardEuler(state))]
 
 # build time stepper
 stepper = CrankNicolson(state, eqns, transported_fields,

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -35,7 +35,7 @@ degree = 0
 
 dirname = 'unsaturated_bubble'
 output = OutputParameters(dirname=dirname, dumpfreq=tdump,
-                          perturbation_fields=['theta', 'vapour_mixing_ratio', 'rho'],
+                          perturbation_fields=['theta', 'water_vapour', 'rho'],
                           log_level='INFO')
 params = CompressibleParameters()
 diagnostic_fields = [RelativeHumidity()]
@@ -54,10 +54,10 @@ eqns = CompressibleEulerEquations(state, "CG", degree,
 u0 = state.fields("u")
 rho0 = state.fields("rho")
 theta0 = state.fields("theta")
-water_v0 = state.fields("vapour_mixing_ratio")
-water_c0 = state.fields("cloud_liquid_mixing_ratio")
-rain0 = state.fields("rain_mixing_ratio", theta0.function_space())
-moisture = ["vapour_mixing_ratio", "cloud_liquid_mixing_ratio", "rain_mixing_ratio"]
+water_v0 = state.fields("water_vapour")
+water_c0 = state.fields("cloud_water")
+rain0 = state.fields("rain", theta0.function_space())
+moisture = ["water_vapour", "cloud_water", "rain"]
 
 # spaces
 Vu = state.spaces("HDiv")
@@ -181,7 +181,7 @@ for i in range(max_outer_solve_count):
 # initialise fields
 state.set_reference_profiles([('rho', rho_b),
                               ('theta', theta_b),
-                              ('vapour_mixing_ratio', water_vb)])
+                              ('water_vapour', water_vb)])
 
 # Set up transport schemes
 u_opts = RecoveredOptions(embedding_space=Vu_DG1,
@@ -200,9 +200,9 @@ limiter = VertexBasedLimiter(VDG1)
 transported_fields = [SSPRK3(state, "u", options=u_opts),
                       SSPRK3(state, "rho", options=rho_opts),
                       SSPRK3(state, "theta", options=theta_opts),
-                      SSPRK3(state, "vapour_mixing_ratio", options=theta_opts, limiter=limiter),
-                      SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts, limiter=limiter),
-                      SSPRK3(state, "rain_mixing_ratio", options=theta_opts, limiter=limiter)]
+                      SSPRK3(state, "water_vapour", options=theta_opts, limiter=limiter),
+                      SSPRK3(state, "cloud_water", options=theta_opts, limiter=limiter),
+                      SSPRK3(state, "rain", options=theta_opts, limiter=limiter)]
 
 # Set up linear solver
 linear_solver = CompressibleSolver(state, eqns, moisture=moisture)

--- a/gusto/active_tracers.py
+++ b/gusto/active_tracers.py
@@ -87,12 +87,13 @@ class ActiveTracer(object):
 
 class WaterVapour(ActiveTracer):
     """An object encoding the details of water vapour as a tracer."""
-    def __init__(self, name='vapour', space='theta',
+    def __init__(self, name='water_vapour', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_eqn=TransportEquationType.advective):
         """
         Args:
-            name (str, optional): the variable's name. Defaults to 'vapour'.
+            name (str, optional): the variable's name. Defaults to
+                'water_vapour'.
             space (str, optional): the name for the :class:`FunctionSpace` to be
                 used by the variable. Defaults to 'theta'.
             variable_type (:class:`TracerVariableType`, optional): enumerator
@@ -102,18 +103,18 @@ class WaterVapour(ActiveTracer):
                 indicating the type of transport equation to be solved (e.g.
                 advective). Defaults to `TransportEquationType.advective`.
         """
-        super().__init__(f'{name}_{variable_type.name}', space, variable_type,
+        super().__init__(f'{name}', space, variable_type,
                          transport_eqn=transport_eqn, phase=Phases.gas, chemical='H2O')
 
 
 class CloudWater(ActiveTracer):
     """An object encoding the details of cloud water as a tracer."""
-    def __init__(self, name='cloud_liquid', space='theta',
+    def __init__(self, name='cloud_water', space='theta',
                  variable_type=TracerVariableType.mixing_ratio,
                  transport_eqn=TransportEquationType.advective):
         """
         Args:
-            name (str, optional): the variable name. Default is 'cloud_liquid'.
+            name (str, optional): the variable name. Default is 'cloud_water'.
             space (str, optional): the name for the :class:`FunctionSpace` to be
                 used by the variable. Defaults to 'theta'.
             variable_type (:class:`TracerVariableType`, optional): enumerator
@@ -123,7 +124,7 @@ class CloudWater(ActiveTracer):
                 indicating the type of transport equation to be solved (e.g.
                 advective). Defaults to `TransportEquationType.advective`.
         """
-        super().__init__(f'{name}_{variable_type.name}', space, variable_type,
+        super().__init__(f'{name}', space, variable_type,
                          transport_eqn=transport_eqn, phase=Phases.liquid, chemical='H2O')
 
 
@@ -144,5 +145,5 @@ class Rain(ActiveTracer):
                 indicating the type of transport equation to be solved (e.g.
                 advective). Defaults to `TransportEquationType.advective`.
         """
-        super().__init__(f'{name}_{variable_type.name}', space, variable_type,
+        super().__init__(f'{name}', space, variable_type,
                          transport_eqn=transport_eqn, phase=Phases.liquid, chemical='H2O')

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -886,15 +886,15 @@ class ThermodynamicDiagnostic(DiagnosticField):
             self.rho_averaged = Function(space)
             self.recoverer = Recoverer(self.rho, self.rho_averaged, VDG=broken_space, boundary_method=boundary_method)
             try:
-                self.r_v = state.fields("vapour_mixing_ratio")
+                self.r_v = state.fields("water_vapour")
             except NotImplementedError:
                 self.r_v = Constant(0.0)
             try:
-                self.r_c = state.fields("cloud_liquid_mixing_ratio")
+                self.r_c = state.fields("cloud_water")
             except NotImplementedError:
                 self.r_c = Constant(0.0)
             try:
-                self.rain = state.fields("rain_mixing_ratio")
+                self.rain = state.fields("rain")
             except NotImplementedError:
                 self.rain = Constant(0.0)
 
@@ -1183,7 +1183,7 @@ class Precipitation(DiagnosticField):
             space = state.spaces("DG0", "DG", 0)
             super().setup(state, space=space)
 
-            rain = state.fields('rain_mixing_ratio')
+            rain = state.fields('rain')
             rho = state.fields('rho')
             v = state.fields('rainfall_velocity')
             self.phi = TestFunction(space)

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -326,7 +326,7 @@ def saturated_hydrostatic_balance(state, theta_e, mr_t, exner0=None,
 
     theta0 = state.fields('theta')
     rho0 = state.fields('rho')
-    mr_v0 = state.fields('vapour_mixing_ratio')
+    mr_v0 = state.fields('water_vapour')
 
     # Calculate hydrostatic exner pressure
     Vt = theta0.function_space()
@@ -452,7 +452,7 @@ def unsaturated_hydrostatic_balance(state, theta_d, H, exner0=None,
 
     theta0 = state.fields('theta')
     rho0 = state.fields('rho')
-    mr_v0 = state.fields('vapour_mixing_ratio')
+    mr_v0 = state.fields('water_vapour')
 
     # Calculate hydrostatic exner pressure
     Vt = theta0.function_space()

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -10,7 +10,7 @@ with "apply" methods.
 from abc import ABCMeta, abstractmethod
 from gusto.active_tracers import Phases
 from gusto.recovery import Recoverer, Boundary_Method
-from gusto.equations import  CompressibleEulerEquations
+from gusto.equations import CompressibleEulerEquations
 from gusto.transport_forms import advection_form
 from gusto.fml import identity, Term
 from gusto.labels import subject, physics, transporting_velocity
@@ -101,7 +101,7 @@ class SaturationAdjustment(Physics):
 
         # Indices of variables in mixed function space
         V_idxs = [vap_idx, cloud_idx]
-        V = equation.function_space.sub(vap_idx) # space in which to do the calculation
+        V = equation.function_space.sub(vap_idx)  # space in which to do the calculation
 
         # Get variables used to calculate saturation curve
         if isinstance(equation, CompressibleEulerEquations):
@@ -136,7 +136,7 @@ class SaturationAdjustment(Physics):
         liquid_water = cloud_water
         for active_tracer in equation.active_tracers:
             if (active_tracer.phase == Phases.liquid
-                and active_tracer.chemical == 'H2O' and active_tracer.name != cloud_name):
+                    and active_tracer.chemical == 'H2O' and active_tracer.name != cloud_name):
                 liq_idx = equation.field_names.index(active_tracer.name)
                 liquid_water += self.X.split()[liq_idx]
 
@@ -281,8 +281,9 @@ class Fallout(Physics):
         adv_term = advection_form(state, test, rain, outflow=True)
         # Add rainfall velocity by replacing transport_velocity in term
         adv_term = adv_term.label_map(identity,
-            map_if_true=lambda t: Term(ufl.replace(
-                        t.form, {t.get(transporting_velocity): v}), t.labels))
+                                      map_if_true=lambda t: Term(
+                                          ufl.replace(t.form, {t.get(transporting_velocity): v}),
+                                          t.labels))
 
         equation.residual += physics(subject(adv_term, equation.X), self.evaluate)
 
@@ -495,7 +496,7 @@ class EvaporationOfRain(Physics):
 
         # Indices of variables in mixed function space
         V_idxs = [rain_idx, vap_idx]
-        V = equation.function_space.sub(rain_idx) # space in which to do the calculation
+        V = equation.function_space.sub(rain_idx)  # space in which to do the calculation
 
         # Get variables used to calculate saturation curve
         if isinstance(equation, CompressibleEulerEquations):
@@ -526,7 +527,7 @@ class EvaporationOfRain(Physics):
         liquid_water = rain
         for active_tracer in equation.active_tracers:
             if (active_tracer.phase == Phases.liquid
-                and active_tracer.chemical == 'H2O' and active_tracer.name != rain_name):
+                    and active_tracer.chemical == 'H2O' and active_tracer.name != rain_name):
                 liq_idx = equation.field_names.index(active_tracer.name)
                 liquid_water += self.X.split()[liq_idx]
 
@@ -563,8 +564,8 @@ class EvaporationOfRain(Physics):
         f = Constant(5.4e5)
         g = Constant(2.55e6)
         h = Constant(0.525)
-        evap_rate = ((1 - water_vapour / sat_expr) * C * (rho_averaged * rain) ** h) \
-                      / (rho_averaged * (f + g / (p * sat_expr)))
+        evap_rate = (((1 - water_vapour / sat_expr) * C * (rho_averaged * rain) ** h)
+                     / (rho_averaged * (f + g / (p * sat_expr))))
 
         # adjust evap rate so negative rain doesn't occur
         evap_rate = conditional(evap_rate < 0, 0.0,

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -213,7 +213,6 @@ class SaturationAdjustment(Physics):
         # Evaluate the source
         for interpolator in self.source_interpolators:
             interpolator.interpolate()
-        # self.source.assign(self.source_interpolator.interpolate())
 
 
 class AdvectedMoments(Enum):
@@ -584,7 +583,7 @@ class EvaporationOfRain(Physics):
         # Add terms to equations and make interpolators
         # -------------------------------------------------------------------- #
         self.source = [Function(V) for factor in factors]
-        self.source_interpolators = [Interpolator(sat_adj_expr*factor, source)
+        self.source_interpolators = [Interpolator(evap_rate*factor, source)
                                      for factor, source in zip(factors, self.source)]
 
         tests = [equation.tests[idx] for idx in V_idxs]
@@ -608,7 +607,8 @@ class EvaporationOfRain(Physics):
         if isinstance(self.equation, CompressibleEulerEquations):
             self.rho_recoverer.project()
         # Evaluate the source
-        self.source.assign(self.source_interpolator.interpolate())
+        for interpolator in self.source_interpolators:
+            interpolator.interpolate()
 
 
 class InstantRain(object):

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -128,7 +128,8 @@ class Timestepper(object):
             with timed_stage("Physics"):
 
                 for _, scheme in self.physics_schemes:
-                    scheme.apply(self.x.np1(self.field_name), self.x.np1(self.field_name))
+                    # NB: use the scheme's field name here not the equation's
+                    scheme.apply(self.x.np1(scheme.field_name), self.x.np1(scheme.field_name))
 
             for field in self.x.np1:
                 state.fields(field.name()).assign(field)

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -74,6 +74,7 @@ class Timestepper(object):
             self.physics_schemes = []
 
         for phys, scheme in self.physics_schemes:
+            # TODO: not sure if this should be True?
             apply_bcs = False
             scheme.setup(eqn, self.transporting_velocity, apply_bcs,
                          physics)

--- a/integration-tests/balance/test_saturated_balance.py
+++ b/integration-tests/balance/test_saturated_balance.py
@@ -54,9 +54,9 @@ def setup_saturated(dirname, recovered):
     u0 = state.fields("u")
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    water_v0 = state.fields("vapour_mixing_ratio")
-    water_c0 = state.fields("cloud_liquid_mixing_ratio")
-    moisture = ['vapour_mixing_ratio', 'cloud_liquid_mixing_ratio']
+    water_v0 = state.fields("water_vapour")
+    water_c0 = state.fields("cloud_water")
+    moisture = ['water_vapour', 'cloud_water']
 
     # spaces
     Vu = u0.function_space()
@@ -110,8 +110,8 @@ def setup_saturated(dirname, recovered):
 
     transported_fields = [SSPRK3(state, 'rho', options=rho_opts),
                           SSPRK3(state, 'theta', options=theta_opts),
-                          SSPRK3(state, 'vapour_mixing_ratio', options=wv_opts),
-                          SSPRK3(state, 'cloud_liquid_mixing_ratio', options=wc_opts)]
+                          SSPRK3(state, 'water_vapour', options=wv_opts),
+                          SSPRK3(state, 'cloud_water', options=wc_opts)]
 
     if recovered:
         transported_fields.append(SSPRK3(state, 'u', options=u_opts))

--- a/integration-tests/balance/test_saturated_balance.py
+++ b/integration-tests/balance/test_saturated_balance.py
@@ -121,7 +121,7 @@ def setup_saturated(dirname, recovered):
     linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
     # add physics
-    physics_schemes = [(Condensation(state), ForwardEuler(state))]
+    physics_schemes = [(SaturationAdjustment(eqns, parameters), ForwardEuler(state))]
 
     # build time stepper
     stepper = CrankNicolson(state, eqns, transported_fields,

--- a/integration-tests/balance/test_saturated_balance.py
+++ b/integration-tests/balance/test_saturated_balance.py
@@ -121,12 +121,12 @@ def setup_saturated(dirname, recovered):
     linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
     # add physics
-    physics_list = [Condensation(state)]
+    physics_schemes = [(Condensation(state), ForwardEuler(state))]
 
     # build time stepper
     stepper = CrankNicolson(state, eqns, transported_fields,
                             linear_solver=linear_solver,
-                            physics_list=physics_list)
+                            physics_schemes=physics_schemes)
 
     return stepper, tmax
 

--- a/integration-tests/balance/test_unsaturated_balance.py
+++ b/integration-tests/balance/test_unsaturated_balance.py
@@ -52,7 +52,7 @@ def setup_unsaturated(dirname, recovered):
     u0 = state.fields("u")
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    moisture = ['vapour_mixing_ratio', 'cloud_liquid_mixing_ratio']
+    moisture = ['water_vapour', 'cloud_water']
 
     # spaces
     Vu = u0.function_space()
@@ -96,8 +96,8 @@ def setup_unsaturated(dirname, recovered):
 
     transported_fields = [SSPRK3(state, "rho", options=rho_opts),
                           SSPRK3(state, "theta", options=theta_opts),
-                          SSPRK3(state, "vapour_mixing_ratio", options=theta_opts),
-                          SSPRK3(state, "cloud_liquid_mixing_ratio", options=theta_opts)]
+                          SSPRK3(state, "water_vapour", options=theta_opts),
+                          SSPRK3(state, "cloud_water", options=theta_opts)]
     if recovered:
         transported_fields.append(SSPRK3(state, "u", options=u_opts))
     else:

--- a/integration-tests/balance/test_unsaturated_balance.py
+++ b/integration-tests/balance/test_unsaturated_balance.py
@@ -106,7 +106,7 @@ def setup_unsaturated(dirname, recovered):
     linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
     # Set up physics
-    physics_schemes = [(Condensation(state), ForwardEuler(state))]
+    physics_schemes = [(SaturationAdjustment(eqns, parameters), ForwardEuler(state))]
 
     # build time stepper
     stepper = CrankNicolson(state, eqns, transported_fields,

--- a/integration-tests/balance/test_unsaturated_balance.py
+++ b/integration-tests/balance/test_unsaturated_balance.py
@@ -106,12 +106,12 @@ def setup_unsaturated(dirname, recovered):
     linear_solver = CompressibleSolver(state, eqns, moisture=moisture)
 
     # Set up physics
-    physics_list = [Condensation(state)]
+    physics_schemes = [(Condensation(state), ForwardEuler(state))]
 
     # build time stepper
     stepper = CrankNicolson(state, eqns, transported_fields,
                             linear_solver=linear_solver,
-                            physics_list=physics_list)
+                            physics_schemes=physics_schemes)
 
     return stepper, tmax
 

--- a/integration-tests/equations/test_moist_compressible.py
+++ b/integration-tests/equations/test_moist_compressible.py
@@ -40,7 +40,7 @@ def run_moist_compressible(tmpdir):
     # Initial conditions
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    m_v0 = state.fields("vapour_mixing_ratio")
+    m_v0 = state.fields("water_vapour")
 
     # Approximate hydrostatic balance
     x, z = SpatialCoordinate(mesh)
@@ -66,7 +66,7 @@ def run_moist_compressible(tmpdir):
                           SSPRK3(state, "theta")]
 
     # Set up linear solver for the timestepping scheme
-    linear_solver = CompressibleSolver(state, eqn, moisture=['vapour_mixing_ratio'])
+    linear_solver = CompressibleSolver(state, eqn, moisture=['water_vapour'])
 
     # build time stepper
     stepper = CrankNicolson(state, eqn, transported_fields,
@@ -93,7 +93,7 @@ def test_moist_compressible(tmpdir):
     dirname = str(tmpdir)
     state, check_state = run_moist_compressible(dirname)
 
-    for variable in ['u', 'rho', 'theta', 'vapour_mixing_ratio']:
+    for variable in ['u', 'rho', 'theta', 'water_vapour']:
         new_variable = state.fields(variable)
         check_variable = check_state.fields(variable)
         error = norm(new_variable - check_variable) / norm(check_variable)

--- a/integration-tests/equations/test_moist_compressible.py
+++ b/integration-tests/equations/test_moist_compressible.py
@@ -28,7 +28,7 @@ def run_moist_compressible(tmpdir):
     R_v = parameters.R_v
     g = parameters.g
 
-    tracers = [WaterVapour(), CloudWater()]
+    tracers = [WaterVapour(name='vapour_mixing_ratio'), CloudWater(name='cloud_liquid_mixing_ratio')]
 
     state = State(mesh,
                   dt=dt,
@@ -40,7 +40,7 @@ def run_moist_compressible(tmpdir):
     # Initial conditions
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    m_v0 = state.fields("water_vapour")
+    m_v0 = state.fields("vapour_mixing_ratio")
 
     # Approximate hydrostatic balance
     x, z = SpatialCoordinate(mesh)
@@ -66,7 +66,7 @@ def run_moist_compressible(tmpdir):
                           SSPRK3(state, "theta")]
 
     # Set up linear solver for the timestepping scheme
-    linear_solver = CompressibleSolver(state, eqn, moisture=['water_vapour'])
+    linear_solver = CompressibleSolver(state, eqn, moisture=['vapour_mixing_ratio'])
 
     # build time stepper
     stepper = CrankNicolson(state, eqn, transported_fields,
@@ -93,7 +93,7 @@ def test_moist_compressible(tmpdir):
     dirname = str(tmpdir)
     state, check_state = run_moist_compressible(dirname)
 
-    for variable in ['u', 'rho', 'theta', 'water_vapour']:
+    for variable in ['u', 'rho', 'theta', 'vapour_mixing_ratio']:
         new_variable = state.fields(variable)
         check_variable = check_state.fields(variable)
         error = norm(new_variable - check_variable) / norm(check_variable)

--- a/integration-tests/physics/test_condensation.py
+++ b/integration-tests/physics/test_condensation.py
@@ -89,11 +89,11 @@ def run_cond_evap(dirname, process):
 
     # Have empty problem as only thing is condensation / evaporation
     problem = []
-    physics_list = [Condensation(state)]
+    physics_schemes = [(Condensation(state), ForwardEuler(state))]
 
     # build time stepper
     stepper = PrescribedTransport(state, problem,
-                                  physics_list=physics_list)
+                                  physics_schemes=physics_schemes)
 
     stepper.run(t=0, tmax=tmax)
 

--- a/integration-tests/physics/test_condensation.py
+++ b/integration-tests/physics/test_condensation.py
@@ -37,7 +37,7 @@ def run_cond_evap(dirname, process):
                   dt=dt,
                   output=output,
                   parameters=parameters,
-                  diagnostic_fields=[Sum('vapour_mixing_ratio', 'cloud_liquid_mixing_ratio')])
+                  diagnostic_fields=[Sum('water_vapour', 'cloud_water')])
 
     # spaces
     Vt = state.spaces("theta", degree=1)
@@ -50,8 +50,8 @@ def run_cond_evap(dirname, process):
     # Declare prognostic fields
     rho0 = state.fields("rho")
     theta0 = state.fields("theta")
-    water_v0 = state.fields("vapour_mixing_ratio", Vt)
-    water_c0 = state.fields("cloud_liquid_mixing_ratio", Vt)
+    water_v0 = state.fields("water_vapour", Vt)
+    water_c0 = state.fields("cloud_water", Vt)
 
     # Set a background state with constant pressure and temperature
     pressure = Function(Vr).interpolate(Constant(100000.))
@@ -106,8 +106,8 @@ def test_cond_evap(tmpdir, process):
     dirname = str(tmpdir)
     state, mv_true, mc_true, theta_d_true, mc_init = run_cond_evap(dirname, process)
 
-    water_v = state.fields('vapour_mixing_ratio')
-    water_c = state.fields('cloud_liquid_mixing_ratio')
+    water_v = state.fields('water_vapour')
+    water_c = state.fields('cloud_water')
     theta_vd = state.fields('theta')
     theta_d = Function(theta_vd.function_space())
     theta_d.interpolate(theta_vd/(1 + water_v * state.parameters.R_v / state.parameters.R_d))
@@ -129,7 +129,7 @@ def test_cond_evap(tmpdir, process):
     filename = path.join(dirname, "cond_evap/diagnostics.nc")
     data = Dataset(filename, "r")
 
-    water = data.groups["vapour_mixing_ratio_plus_cloud_liquid_mixing_ratio"]
+    water = data.groups["water_vapour_plus_cloud_water"]
     total = water.variables["total"]
     water_t_0 = total[0]
     water_t_T = total[-1]

--- a/integration-tests/physics/test_condensation.py
+++ b/integration-tests/physics/test_condensation.py
@@ -44,8 +44,8 @@ def run_cond_evap(dirname, process):
     Vr = state.spaces("DG", "DG", degree=1)
 
     # Set up equation -- use compressible to set up these spaces
-    # However the equation itself will be unused
-    _ = CompressibleEulerEquations(state, "CG", 1)
+    tracers = [WaterVapour(), CloudWater()]
+    eqn = CompressibleEulerEquations(state, "CG", 1, active_tracers=tracers)
 
     # Declare prognostic fields
     rho0 = state.fields("rho")
@@ -88,8 +88,8 @@ def run_cond_evap(dirname, process):
     mc_init = Function(Vt).assign(water_c0)
 
     # Have empty problem as only thing is condensation / evaporation
-    problem = []
-    physics_schemes = [(Condensation(state), ForwardEuler(state))]
+    problem = ((eqn, ()),)
+    physics_schemes = [(SaturationAdjustment(eqn, parameters), ForwardEuler(state))]
 
     # build time stepper
     stepper = PrescribedTransport(state, problem,

--- a/integration-tests/physics/test_precipitation.py
+++ b/integration-tests/physics/test_precipitation.py
@@ -27,7 +27,7 @@ def setup_fallout(dirname):
     dt = 0.1
     output = OutputParameters(dirname=dirname+"/fallout",
                               dumpfreq=10,
-                              dumplist=['rain_mixing_ratio'])
+                              dumplist=['rain'])
     parameters = CompressibleParameters()
     diagnostic_fields = [Precipitation()]
     state = State(mesh,
@@ -72,7 +72,7 @@ def test_fallout_setup(tmpdir):
     filename = path.join(dirname, "fallout/diagnostics.nc")
     data = Dataset(filename, "r")
 
-    rain = data.groups["rain_mixing_ratio"]
+    rain = data.groups["rain"]
     final_rain = rain.variables["total"][-1]
     final_rms_rain = rain.variables["rms"][-1]
 

--- a/integration-tests/physics/test_precipitation.py
+++ b/integration-tests/physics/test_precipitation.py
@@ -37,11 +37,14 @@ def setup_fallout(dirname):
                   diagnostic_fields=diagnostic_fields)
 
     Vrho = state.spaces("DG1_equispaced")
-    problem = [(AdvectionEquation(state, Vrho, "rho", ufamily="CG", udegree=1), ForwardEuler(state))]
+    active_tracers = [Rain(space='DG1_equispaced')]
+    eqn = ForcedAdvectionEquation(state, Vrho, "rho", ufamily="CG", udegree=1,
+                                  active_tracers=active_tracers)
+    problem = [(eqn, ForwardEuler(state))]
     state.fields("rho").assign(1.)
 
-    physics_list = [Fallout(state)]
-    rain0 = state.fields("rain_mixing_ratio")
+    physics_schemes = [(Fallout(eqn, 'rain', state), SSPRK3(state))]
+    rain0 = state.fields("rain")
 
     # set up rain
     xc = L / 2
@@ -54,7 +57,7 @@ def setup_fallout(dirname):
 
     # build time stepper
     stepper = PrescribedTransport(state, problem,
-                                  physics_list=physics_list)
+                                  physics_schemes=physics_schemes)
 
     return stepper, 10.0
 


### PR DESCRIPTION
This pull request implements the FML for the old microphysics routines. The parametrisations are `evaluate` methods that are stored in labels to physics terms. The terms themselves are very simple, just a source/sink term. The one exception is precipitation, which is treated like a transport term.

Some other points:
- the names of the moisture variables have been simplified (by changing them to remove `'_mixing_ratio'` from the end)
- two schemes have been renamed, `Condensation` -> `SaturationAdjustment` and `Evaporation` to `EvaporationOfRain`