### PR TITLE
Assign -> interpolate for complicated expressions

### DIFF
--- a/examples/compressible/dry_bryan_fritsch.py
+++ b/examples/compressible/dry_bryan_fritsch.py
@@ -84,7 +84,7 @@ theta_pert = Function(Vt).interpolate(conditional(r > rc,
                                                   Tdash * (cos(pi * r / (2.0 * rc))) ** 2))
 
 # define initial theta
-theta0.assign(theta_b * (theta_pert / 300.0 + 1.0))
+theta0.interpolate(theta_b * (theta_pert / 300.0 + 1.0))
 
 # find perturbed rho
 gamma = TestFunction(Vr)

--- a/examples/compressible/moist_bryan_fritsch.py
+++ b/examples/compressible/moist_bryan_fritsch.py
@@ -97,7 +97,7 @@ theta_pert = Function(Vt).interpolate(
                 Tdash * (cos(pi * r / (2.0 * rc))) ** 2))
 
 # define initial theta
-theta0.assign(theta_b * (theta_pert / 300.0 + 1.0))
+theta0.interpolate(theta_b * (theta_pert / 300.0 + 1.0))
 
 # find perturbed rho
 gamma = TestFunction(Vr)

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -148,7 +148,7 @@ for i in range(max_outer_solve_count):
     # calculate averaged rho
     rho_recoverer.project()
 
-    RH.assign(RH_ev)
+    RH.interpolate(RH_ev)
     if errornorm(RH, H) < 1e-10:
         break
 
@@ -158,7 +158,7 @@ for i in range(max_outer_solve_count):
         water_v0.assign(water_v0 * (1 - delta) + delta * w_h)
 
         # compute theta_vd
-        theta0.assign(theta_d * (1 + water_v0 / epsilon))
+        theta0.interpolate(theta_d * (1 + water_v0 / epsilon))
 
         # test quality of solution by re-evaluating expression
         RH.assign(RH_ev)

--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -161,7 +161,7 @@ for i in range(max_outer_solve_count):
         theta0.interpolate(theta_d * (1 + water_v0 / epsilon))
 
         # test quality of solution by re-evaluating expression
-        RH.assign(RH_ev)
+        RH.interpolate(RH_ev)
         if errornorm(RH, H) < 1e-10:
             break
 

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -930,7 +930,7 @@ class Theta_e(ThermodynamicDiagnostic):
         """
         super().compute(state)
 
-        return self.field.assign(thermodynamics.theta_e(state.parameters, self.T, self.p, self.r_v, self.r_t))
+        return self.field.interpolate(thermodynamics.theta_e(state.parameters, self.T, self.p, self.r_v, self.r_t))
 
 
 class InternalEnergy(ThermodynamicDiagnostic):
@@ -949,7 +949,7 @@ class InternalEnergy(ThermodynamicDiagnostic):
         """
         super().compute(state)
 
-        return self.field.assign(thermodynamics.internal_energy(state.parameters, self.rho_averaged, self.T, r_v=self.r_v, r_l=self.r_l))
+        return self.field.interpolate(thermodynamics.internal_energy(state.parameters, self.rho_averaged, self.T, r_v=self.r_v, r_l=self.r_l))
 
 
 class PotentialEnergy(ThermodynamicDiagnostic):
@@ -1016,7 +1016,7 @@ class Dewpoint(ThermodynamicDiagnostic):
         """
         super().compute(state)
 
-        return self.field.assign(thermodynamics.T_dew(state.parameters, self.p, self.r_v))
+        return self.field.interpolate(thermodynamics.T_dew(state.parameters, self.p, self.r_v))
 
 
 class Temperature(ThermodynamicDiagnostic):
@@ -1054,7 +1054,7 @@ class Theta_d(ThermodynamicDiagnostic):
         """
         super().compute(state)
 
-        return self.field.assign(self.theta / (1 + self.r_v * state.parameters.R_v / state.parameters.R_d))
+        return self.field.interpolate(self.theta / (1 + self.r_v * state.parameters.R_v / state.parameters.R_d))
 
 
 class RelativeHumidity(ThermodynamicDiagnostic):
@@ -1073,7 +1073,7 @@ class RelativeHumidity(ThermodynamicDiagnostic):
         """
         super().compute(state)
 
-        return self.field.assign(thermodynamics.RH(state.parameters, self.r_v, self.T, self.p))
+        return self.field.interpolate(thermodynamics.RH(state.parameters, self.r_v, self.T, self.p))
 
 
 class Pressure(ThermodynamicDiagnostic):

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -368,7 +368,7 @@ def saturated_hydrostatic_balance(state, theta_e, mr_t, exner0=None,
         # damp solution
         rho0.assign(rho0 * (1 - delta) + delta * rho_h)
 
-        theta_e_test.assign(theta_e_expr)
+        theta_e_test.interpolate(theta_e_expr)
         if errornorm(theta_e_test, theta_e) < 1e-8:
             break
 
@@ -388,7 +388,7 @@ def saturated_hydrostatic_balance(state, theta_e, mr_t, exner0=None,
                 mr_v0.assign(mr_v0 * (1 - delta) + delta * w_h)
 
                 # break when close enough
-                theta_e_test.assign(theta_e_expr)
+                theta_e_test.interpolate(theta_e_expr)
                 if errornorm(theta_e_test, theta_e) < 1e-6:
                     break
 
@@ -504,7 +504,7 @@ def unsaturated_hydrostatic_balance(state, theta_d, H, exner0=None,
         # calculate averaged rho
         rho_recoverer.project()
 
-        RH.assign(RH_ev)
+        RH.interpolate(RH_ev)
         if errornorm(RH, H) < 1e-10:
             break
 
@@ -514,10 +514,10 @@ def unsaturated_hydrostatic_balance(state, theta_d, H, exner0=None,
             mr_v0.assign(mr_v0 * (1 - delta) + delta * w_h)
 
             # compute theta_vd
-            theta0.assign(theta_d * (1 + mr_v0 / epsilon))
+            theta0.interpolate(theta_d * (1 + mr_v0 / epsilon))
 
             # test quality of solution by re-evaluating expression
-            RH.assign(RH_ev)
+            RH.interpolate(RH_ev)
             if errornorm(RH, H) < 1e-10:
                 break
 


### PR DESCRIPTION
Following the change to `assign` in Firedrake, we need to change our `assign` to `interpolate` for some complicated expressions.