### PR TITLE
Fix split physics-dynamics time stepper

### DIFF
--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -63,7 +63,7 @@ class PrognosticEquation(object, metaclass=ABCMeta):
                 is used to filter terms.
             label (:class:`Label`): the label to be applied to the terms.
         """
-        assert type(label, Label)
+        assert type(label) == Label
         self.residual = self.residual.label_map(term_filter, map_if_true=label)
 
 


### PR DESCRIPTION
The `SplitPhysicsTimestepper` was broken, most probably by the killing of state, as variables weren't being transported when it was being used.

It turns out that the culprit was the setup of the scheme:
```
active_labels = [transport, ... ]
self.scheme.setup(self.equation, self.transporting_velocity, *active_labels)
```
But the scheme `setup` routine has an optional argument in its third position: the notorious `apply_bcs` argument. As the `transport` label was the first of the active labels, this was being in place of `apply_bcs` and not as an active label, so the transport terms were not being included in the time stepper.

Fixing this also gave the opportunity to fix some other problems:
- now dynamics terms are handled correctly rather than my previous hack to guess at what they should be
- a silly bug was fixed in the `label_terms` routine
- there were a couple of opportunities for removing duplicated code in the `SplitPhysicsTimestepper`