### PR TITLE
Fix instant rain saturation

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -9,8 +9,7 @@ from firedrake import sqrt, Constant
 __all__ = ["WARNING", "INFO", "DEBUG", "IntegrateByParts",
            "TransportEquationType", "OutputParameters",
            "CompressibleParameters", "ShallowWaterParameters",
-           "ConvectiveMoistShallowWaterParameters", "logger",
-           "EmbeddedDGOptions", "RecoveryOptions", "SUPGOptions",
+           "logger", "EmbeddedDGOptions", "RecoveryOptions", "SUPGOptions",
            "SpongeLayerParameters", "DiffusionParameters"]
 
 logger = logging.getLogger("gusto")
@@ -151,17 +150,6 @@ class ShallowWaterParameters(Configuration):
     g = 9.80616
     Omega = 7.292e-5  # rotation rate
     H = None  # mean depth
-
-
-class ConvectiveMoistShallowWaterParameters(ShallowWaterParameters):
-
-    """
-    Physical parameters for the Bouchut et al moist shallow water equations
-    """
-    gamma = None  # condensation proportionality constant
-    tau = None  # timescale of condensation
-    q_0 = None  # factor in the saturation humidity expr
-    alpha = None  # exponential factor in the saturation humidity expr
 
 
 class TransportOptions(Configuration, metaclass=ABCMeta):

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -529,6 +529,10 @@ class ForcedAdvectionEquation(PrognosticEquationSet):
             mass_form + advection_form(domain, self.tests[0], split(self.X)[0], **kwargs), self.X
         )
 
+        # Add transport of tracers
+        if len(active_tracers) > 0:
+            self.residual += self.generate_tracer_transport_terms(domain, active_tracers)
+
 # ============================================================================ #
 # Specified Equation Sets
 # ============================================================================ #

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -6,8 +6,8 @@ from firedrake import MixedFunctionSpace, TrialFunctions, TestFunctions, \
     Function, Constant, \
     LinearVariationalProblem, LinearVariationalSolver, \
     NonlinearVariationalProblem, NonlinearVariationalSolver, split, solve, \
-    sin, cos, sqrt, asin, atan_2, as_vector, Min, Max, FunctionSpace, \
-    errornorm, zero
+    sin, cos, sqrt, asin, atan_2, as_vector, min_value, max_value, \
+    FunctionSpace, errornorm, zero
 from gusto import thermodynamics
 from gusto.configuration import logger
 from gusto.recovery import Recoverer, BoundaryMethod
@@ -32,7 +32,7 @@ def latlon_coords(mesh):
     """
     x0, y0, z0 = SpatialCoordinate(mesh)
     unsafe = z0/sqrt(x0*x0 + y0*y0 + z0*z0)
-    safe = Min(Max(unsafe, -1.0), 1.0)  # avoid silly roundoff errors
+    safe = min_value(max_value(unsafe, -1.0), 1.0)  # avoid silly roundoff errors
     theta = asin(safe)  # latitude
     lamda = atan_2(y0, x0)  # longitude
     return theta, lamda

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -693,12 +693,12 @@ class InstantRain(Physics):
                 self.variable_idx = equation.field_names.index("D")
                 Vvar_space = W.sub(self.variable_idx)
                 self.variable = Function(Vvar_space)
-                self.sat_func = Function(Vvar_space)
+                self.saturation_function = Function(Vvar_space)
             else:
                 raise NotImplementedError(
                     "Saturation function must be either constant in time or a function of depth")
         else:
-            self.sat_func = saturation_curve
+            self.saturation_function = saturation_curve
 
         # depth needed if convective feedback
         if self.convective_feedback:
@@ -744,8 +744,8 @@ class InstantRain(Physics):
 
         # interpolator does the conversion of vapour to rain
         self.source_interpolator = Interpolator(conditional(
-            self.water_v > self.sat_func,
-            (1/self.tau)*(self.water_v - self.sat_func),
+            self.water_v > self.saturation_function,
+            (1/self.tau)*(self.water_v - self.saturation_function),
             0), Vv)
 
     def evaluate(self, x_in, dt):
@@ -764,9 +764,9 @@ class InstantRain(Physics):
             self.D.assign(x_in.split()[self.VD_idx])
         if isinstance(self.saturation, FunctionType):
             self.variable.assign(x_in.split()[self.variable_idx])
-            self.sat_func.interpolate(self.saturation(self.variable))
+            self.saturation_function.interpolate(self.saturation(self.variable))
         else:
-            self.sat_func.interpolate(self.saturation)
+            self.saturation_function.assign(self.saturation)
         if self.set_tau_to_dt:
             self.tau.assign(dt)
         self.water_v.assign(x_in.split()[self.Vv_idx])

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -678,6 +678,15 @@ class InstantRain(Physics):
         Vv = W.sub(self.Vv_idx)
         test_v = equation.tests[self.Vv_idx]
 
+        # check if saturation is a function, and if so what of
+        # Currently this works only when saturation is depth-dependent
+        # TODO: allow other variables, and for saturation to be constant
+        if self.saturation.is_func:
+            if self.saturation.variable == "depth":
+                self.variable_idx = equation.field_names.index("D")
+                Vvar = W.sub(self.variable_idx)
+                self.variable = Function(Vvar)
+
         # depth needed if convective feedback
         if self.convective_feedback:
             self.VD_idx = equation.field_names.index("D")
@@ -741,7 +750,9 @@ class InstantRain(Physics):
         """
         if self.convective_feedback:
             self.D.assign(x_in.split()[self.VD_idx])
-            self.sat_func.interpolate(self.saturation(self.D))
+        if self.saturation.is_func:
+            self.variable.assign(x_in.split()[self.variable_idx])
+            self.sat_func.interpolate(self.saturation.sat_func(self.variable))
         if self.set_tau_to_dt:
             self.tau.assign(dt)
         self.water_v.assign(x_in.split()[self.Vv_idx])

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -640,12 +640,13 @@ class InstantRain(Physics):
         """
         Args:
             equation (:class: 'PrognosticEquationSet'): the model's equation.
-            saturation_curve (ufl.Expr or :class: `function`): the saturation
-                function, above which excess moisture is converted. Can be
-                constant in time or a function of one of the equation fields.
+            saturation_curve (ufl.Expr or :class: `function`, optional): the
+                curve above which excess moisture is converted. Can be constant
+                in time, constant in time and space, or a function of one of
+                the equation's prognostic fields.
             saturation_dependency (str, optional): name of the field that the
                 saturation curve depends on, if the saturation curve changes in
-                time. This field must be one of the equation variables.
+                time. This must be one of the equation's prognostic fields.
             vapour_name (str, optional): name of the water vapour variable.
                 Defaults to "water_vapour".
             rain_name (str, optional): name of the rain variable. Defaults to
@@ -696,7 +697,7 @@ class InstantRain(Physics):
                 self.saturation_function = Function(dependency_space)
             else:
                 raise NotImplementedError(
-                    "Saturation function must be either constant in time or a function of an equation variable")
+                    "Saturation function must be either constant in time or a function of an equation prognostic field")
         else:
             self.saturation_function = self.saturation_curve
 

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -660,6 +660,7 @@ class InstantRain(Physics):
         parameters = self.parameters
         self.convective_feedback = convective_feedback
         self.set_tau_to_dt = set_tau_to_dt
+        self.saturation = saturation_curve
 
         # check for the correct fields
         assert vapour_name in equation.field_names, f"Field {vapour_name} does not exist in the equation set"
@@ -683,6 +684,7 @@ class InstantRain(Physics):
             VD = W.sub(self.VD_idx)
             test_D = equation.tests[self.VD_idx]
             self.D = Function(VD)
+            self.sat_func = Function(VD)
 
         # the source function is the difference between the water vapour and
         # the saturation function
@@ -721,8 +723,8 @@ class InstantRain(Physics):
 
         # interpolator does the conversion of vapour to rain
         self.source_interpolator = Interpolator(conditional(
-            self.water_v > saturation_curve,
-            (1/self.tau)*(self.water_v - saturation_curve),
+            self.water_v > self.sat_func,
+            (1/self.tau)*(self.water_v - self.sat_func),
             0), Vv)
 
     def evaluate(self, x_in, dt):
@@ -739,6 +741,7 @@ class InstantRain(Physics):
         """
         if self.convective_feedback:
             self.D.assign(x_in.split()[self.VD_idx])
+            self.sat_func.interpolate(self.saturation(self.D))
         if self.set_tau_to_dt:
             self.tau.assign(dt)
         self.water_v.assign(x_in.split()[self.Vv_idx])

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -685,18 +685,17 @@ class InstantRain(Physics):
         test_v = equation.tests[self.Vv_idx]
 
         # Check if saturation is a function, and if so what of.
-        # Currently this works only when saturation is depth-dependent or not
-        # changing in time.
-        # TODO: allow saturation to be dependent on other variables
+        # This works if saturation is function of one of the equation variables.
         if isinstance(self.saturation, FunctionType):
-            if self.saturation_variable == "depth":
-                self.variable_idx = equation.field_names.index("D")
+            if self.saturation_variable in equation.field_names:
+                self.variable_idx = equation.field_names.index(
+                    self.saturation_variable)
                 Vvar_space = W.sub(self.variable_idx)
                 self.variable = Function(Vvar_space)
                 self.saturation_function = Function(Vvar_space)
             else:
                 raise NotImplementedError(
-                    "Saturation function must be either constant in time or a function of depth")
+                    "Saturation function must be either constant in time or a function of an equation variable")
         else:
             self.saturation_function = saturation_curve
 

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -684,8 +684,9 @@ class InstantRain(Physics):
         if self.saturation.is_func:
             if self.saturation.variable == "depth":
                 self.variable_idx = equation.field_names.index("D")
-                Vvar = W.sub(self.variable_idx)
-                self.variable = Function(Vvar)
+                Vvar_space = W.sub(self.variable_idx)
+                self.variable = Function(Vvar_space)
+                self.sat_func = Function(Vvar_space)
 
         # depth needed if convective feedback
         if self.convective_feedback:
@@ -693,7 +694,6 @@ class InstantRain(Physics):
             VD = W.sub(self.VD_idx)
             test_D = equation.tests[self.VD_idx]
             self.D = Function(VD)
-            self.sat_func = Function(VD)
 
         # the source function is the difference between the water vapour and
         # the saturation function

--- a/integration-tests/equations/test_forced_advection.py
+++ b/integration-tests/equations/test_forced_advection.py
@@ -50,7 +50,7 @@ def run_forced_advection(tmpdir):
     meqn = ForcedAdvectionEquation(domain, VD, field_name="water_vapour", Vu=Vu,
                                    active_tracers=[rain])
     physics_schemes = [(InstantRain(meqn, msat, rain_name="rain",
-                                    set_tau_to_dt=True, parameters=None), ForwardEuler(domain))]
+                                    parameters=None), ForwardEuler(domain))]
 
     # I/O
     output = OutputParameters(dirname=str(tmpdir), dumpfreq=1)

--- a/integration-tests/physics/test_instant_rain.py
+++ b/integration-tests/physics/test_instant_rain.py
@@ -49,8 +49,7 @@ def run_instant_rain(dirname):
 
     # Physics schemes
     # define saturation function
-    VD = FunctionSpace(mesh, "DG", 1)
-    saturation = Function(VD).assign(0.5)
+    saturation = Constant(0.5)
     physics_schemes = [(InstantRain(eqns, saturation, rain_name="rain",
                                     set_tau_to_dt=True), ForwardEuler(domain))]
 
@@ -73,6 +72,7 @@ def run_instant_rain(dirname):
 
     vapour0.interpolate(vapour_expr)
 
+    VD = FunctionSpace(mesh, "DG", 1)
     initial_vapour = Function(VD).interpolate(vapour_expr)
 
     # define expected solutions; vapour should be equal to saturation and rain

--- a/integration-tests/physics/test_instant_rain.py
+++ b/integration-tests/physics/test_instant_rain.py
@@ -49,7 +49,8 @@ def run_instant_rain(dirname):
 
     # Physics schemes
     # define saturation function
-    saturation = Constant(0.5)
+    VD = FunctionSpace(mesh, "DG", 1)
+    saturation = Function(VD).assign(0.5)
     physics_schemes = [(InstantRain(eqns, saturation, rain_name="rain",
                                     set_tau_to_dt=True), ForwardEuler(domain))]
 
@@ -72,7 +73,6 @@ def run_instant_rain(dirname):
 
     vapour0.interpolate(vapour_expr)
 
-    VD = FunctionSpace(mesh, "DG", 1)
     initial_vapour = Function(VD).interpolate(vapour_expr)
 
     # define expected solutions; vapour should be equal to saturation and rain
@@ -95,7 +95,7 @@ def test_instant_rain_setup(tmpdir):
     r = stepper.fields("rain")
 
     # check that the maximum of the vapour field is equal to the saturation
-    assert v.dat.data.max() - saturation.values() < 0.001, "The maximum of the final vapour field should be equal to saturation"
+    assert v.dat.data.max() - saturation.dat.data.max() < 0.001, "The maximum of the final vapour field should be equal to saturation"
 
     # check that the minimum of the vapour field hasn't changed
     assert v.dat.data.min() - initial_vapour.dat.data.min() < 0.001, "The minimum of the vapour field should not change"

--- a/integration-tests/physics/test_instant_rain.py
+++ b/integration-tests/physics/test_instant_rain.py
@@ -95,7 +95,7 @@ def test_instant_rain_setup(tmpdir):
     r = stepper.fields("rain")
 
     # check that the maximum of the vapour field is equal to the saturation
-    assert v.dat.data.max() - saturation.dat.data.max() < 0.001, "The maximum of the final vapour field should be equal to saturation"
+    assert v.dat.data.max() - saturation.values() < 0.001, "The maximum of the final vapour field should be equal to saturation"
 
     # check that the minimum of the vapour field hasn't changed
     assert v.dat.data.min() - initial_vapour.dat.data.min() < 0.001, "The minimum of the vapour field should not change"

--- a/integration-tests/physics/test_instant_rain.py
+++ b/integration-tests/physics/test_instant_rain.py
@@ -50,8 +50,8 @@ def run_instant_rain(dirname):
     # Physics schemes
     # define saturation function
     saturation = Constant(0.5)
-    physics_schemes = [(InstantRain(eqns, saturation, rain_name="rain",
-                                    set_tau_to_dt=True), ForwardEuler(domain))]
+    physics_schemes = [(InstantRain(eqns, saturation, rain_name="rain"),
+                        ForwardEuler(domain))]
 
     # Time stepper
     stepper = PrescribedTransport(eqns, RK4(domain), io,


### PR DESCRIPTION
This allows the saturation curve for `InstantRain` to be a function of one of the equation variables, or a constant in time. If it is a function, the argument `saturation_variable` with the field name must be passed to `InstantRain`. 
It also corrects the erroneous omission of tracer transport in `ForcedAdvectionEquation`.
