### PR TITLE
Update checkpointing

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -111,6 +111,7 @@ class OutputParameters(Configuration):
     dumplist_latlon = []
     dump_diagnostics = True
     checkpoint = True
+    checkpoint_method = 'old'
     checkpoint_pickup_filename = None
     chkptfreq = 1
     dirname = None

--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -195,7 +195,7 @@ class DiagnosticField(object, metaclass=ABCMeta):
                 f'Diagnostics {self.name} is using a function space which does not have a name'
             domain.spaces(space.name, V=space)
 
-            self.field = state_fields(self.name, space=space, dump=True, pickup=False)
+            self.field = state_fields(self.name, space=space, dump=True, pick_up=False)
 
             if self.method != 'solve':
                 assert self.expr is not None, \
@@ -901,7 +901,7 @@ class SteadyStateError(Difference):
         """
         self.field_name1 = name
         self.field_name2 = name+'_init'
-        DiagnosticField.__init__(self, method='assign', required_fields=(name))
+        DiagnosticField.__init__(self, method='assign', required_fields=(name, self.field_name2))
 
     def setup(self, domain, state_fields):
         """
@@ -911,15 +911,16 @@ class SteadyStateError(Difference):
             domain (:class:`Domain`): the model's domain object.
             state_fields (:class:`StateFields`): the model's field container.
         """
-        # Create and store initial field
-        field1 = state_fields(self.field_name1)
-        field2 = state_fields(self.field_name2, space=field1.function_space(), dump=False)
+        # Check if initial field already exists -- otherwise needs creating
+        if not hasattr(state_fields, self.field_name2):
+            field1 = state_fields(self.field_name1)
+            field2 = state_fields(self.field_name2, space=field1.function_space(),
+                                  pick_up=True, dump=False)
+            # By default set this new field to the current value
+            # This may be overwritten if picking up from a checkpoint
+            field2.assign(field1)
 
-        # TODO: when checkpointing, the initial field should either be picked up
-        # or computed again (picking up can be easily specified if we change the line above)
-        field2.assign(field1)
-
-        super(SteadyStateError, self).setup(domain, state_fields)
+        super().setup(domain, state_fields)
 
     @property
     def name(self):
@@ -934,14 +935,30 @@ class Perturbation(Difference):
         Args:
             name (str): name of the field to take the perturbation of.
         """
-        field_name1 = name
-        field_name2 = name+'_bar'
-        Difference.__init__(self, field_name1, field_name2)
+        self.field_name1 = name
+        self.field_name2 = name+'_bar'
+        DiagnosticField.__init__(self, method='assign', required_fields=(name, self.field_name2))
 
     @property
     def name(self):
         """Gives the name of this diagnostic field."""
         return self.field_name1+"_perturbation"
+
+    def setup(self, domain, state_fields):
+        """
+        Sets up the :class:`Function` for the diagnostic field.
+
+        Args:
+            domain (:class:`Domain`): the model's domain object.
+            state_fields (:class:`StateFields`): the model's field container.
+        """
+        # Check if initial field already exists -- otherwise needs creating
+        if not hasattr(state_fields, self.field_name2):
+            field1 = state_fields(self.field_name1)
+            _ = state_fields(self.field_name2, space=field1.function_space(),
+                             pick_up=True, dump=False)
+
+        super().setup(domain, state_fields)
 
 
 # TODO: unify thermodynamic diagnostics
@@ -1326,7 +1343,7 @@ class Precipitation(DiagnosticField):
         problem = LinearVariationalProblem(a, L, self.flux)
         self.solver = LinearVariationalSolver(problem)
         self.space = space
-        self.field = state_fields(self.name, space=space, dump=True, pickup=False)
+        self.field = state_fields(self.name, space=space, dump=True, pick_up=False)
         # TODO: might we want to pick up this field? Otherwise initialise to zero
         self.field.assign(0.0)
 

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -15,6 +15,7 @@ from gusto.configuration import logger, set_log_handler
 
 __all__ = ["pick_up_mesh", "IO"]
 
+
 def pick_up_mesh(output, mesh_name):
     """
     Picks up a checkpointed mesh. This must be the first step of any model being
@@ -41,6 +42,7 @@ def pick_up_mesh(output, mesh_name):
         mesh = chk.load_mesh(mesh_name)
 
     return mesh
+
 
 class PointDataOutput(object):
     """Object for outputting field point data."""
@@ -563,7 +565,6 @@ class IO(object):
                     chk.set_attr("/", "time", t)
                     if initial_steps is not None:
                         chk.set_attr("/", "initial_steps", initial_steps)
-
 
         if (next(self.dumpcount) % output.dumpfreq) == 0:
             if output.dump_nc:

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -482,9 +482,8 @@ class IO(object):
                     t = chk.read_attribute("/", "time")
 
             else:
-                mesh_name = self.domain.mesh.name
                 with CheckpointFile(chkfile, 'r') as chk:
-                    mesh = chk.load_mesh(mesh_name)
+                    mesh = self.domain.mesh
                     # Recover compulsory fields from the checkpoint
                     for field_name in self.to_pick_up:
                         field = chk.load_function(mesh, field_name)

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -1411,7 +1411,6 @@ class AdamsBashforth(MultilevelTimeDiscretisation):
         """
         if self.initial_timesteps < self.nlevels-1:
             self.initial_timesteps += 1
-            print(self.initial_timesteps)
             solver = self.solver0
         else:
             solver = self.solver

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -110,7 +110,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             with timed_stage("Dump output"):
                 self.io.dump(self.fields, float(self.t), self.get_initial_timesteps())
 
-        if self.io.output.checkpoint:
+        if self.io.output.checkpoint and self.io.output.checkpoint_method == 'old':
             self.io.chkpt.close()
 
         logger.info(f'TIMELOOP complete. t={float(self.t)}, tmax={tmax}')

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -68,12 +68,12 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         """
 
         if pickup:
-            t = self.io.pickup_from_checkpoint(self.fields)
+            t = self.io.pick_up_from_checkpoint(self.fields)
 
         self.io.setup_diagnostics(self.fields)
 
         with timed_stage("Dump output"):
-            self.io.setup_dump(self.fields, t, tmax, pickup)
+            self.io.setup_dump(self.fields, t, pickup)
 
         self.t.assign(t)
 
@@ -447,8 +447,9 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
             pickup: (bool): specify whether to pickup from a previous run
         """
 
-        assert self.reference_profiles_initialised, \
-            'Reference profiles for must be initialised to use Semi-Implicit Timestepper'
+        if not pickup:
+            assert self.reference_profiles_initialised, \
+                'Reference profiles for must be initialised to use Semi-Implicit Timestepper'
 
         super().run(t, tmax, pickup=pickup)
 

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -57,26 +57,47 @@ class BaseTimestepper(object, metaclass=ABCMeta):
         """Defines the timestep. Must be implemented in child classes"""
         return NotImplementedError
 
-    def run(self, t, tmax, pickup=False):
+    def set_initial_timesteps(self, num_steps):
+        """Sets the number of initial time steps for a multi-level scheme."""
+        can_set = (hasattr(self, 'scheme')
+                   and hasattr(self.scheme, 'initial_timesteps')
+                   and num_steps is not None)
+        if can_set:
+            self.scheme.initial_timesteps = num_steps
+
+    def get_initial_timesteps(self):
+        """Gets the number of initial time steps from a multi-level scheme."""
+        can_get = (hasattr(self, 'scheme')
+                   and hasattr(self.scheme, 'initial_timesteps'))
+        # Return None if this is not applicable
+        return self.scheme.initial_timesteps if can_get else None
+
+    def run(self, t, tmax, pick_up=False):
         """
         Runs the model for the specified time, from t to tmax
 
         Args:
             t (float): the start time of the run
             tmax (float): the end time of the run
-            pickup: (bool): specify whether to pickup from a previous run
+            pick_up: (bool): specify whether to pick_up from a previous run
         """
 
-        if pickup:
-            t = self.io.pick_up_from_checkpoint(self.fields)
-
+        # Set up diagnostics, which may set up some fields necessary to pick up
         self.io.setup_diagnostics(self.fields)
 
+        if pick_up:
+            # Pick up fields, and return other info to be picked up
+            t, reference_profiles, initial_timesteps = self.io.pick_up_from_checkpoint(self.fields)
+            self.set_reference_profiles(reference_profiles)
+            self.set_initial_timesteps(initial_timesteps)
+
+        # Set up dump, which may also include an initial dump
         with timed_stage("Dump output"):
-            self.io.setup_dump(self.fields, t, pickup)
+            self.io.setup_dump(self.fields, t, pick_up)
 
         self.t.assign(t)
 
+        # Time loop
         while float(self.t) < tmax - 0.5*float(self.dt):
             logger.info(f'at start of timestep, t={float(self.t)}, dt={float(self.dt)}')
 
@@ -87,7 +108,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             self.t.assign(self.t + self.dt)
 
             with timed_stage("Dump output"):
-                self.io.dump(self.fields, float(self.t))
+                self.io.dump(self.fields, float(self.t), self.get_initial_timesteps())
 
         if self.io.output.checkpoint:
             self.io.chkpt.close()
@@ -111,7 +132,8 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             elif isinstance(profile, Function):
                 # Need to add reference profile to state so profile must be
                 # a Function
-                ref = self.fields(field_name+'_bar', space=profile.function_space(), dump=False)
+                ref = self.fields(field_name+'_bar', space=profile.function_space(),
+                                  pick_up=True, dump=False, field_type='reference')
             else:
                 raise ValueError(f'When initialising reference profile {field_name}'
                                  + ' the passed profile must be a Function')
@@ -150,7 +172,7 @@ class Timestepper(BaseTimestepper):
 
     def setup_fields(self):
         self.x = TimeLevelFields(self.equation, self.scheme.nlevels)
-        self.fields = StateFields(self.x.np1, self.equation.prescribed_fields,
+        self.fields = StateFields(self.x, self.equation.prescribed_fields,
                                   *self.io.output.dumplist)
 
     def setup_scheme(self):
@@ -353,7 +375,7 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
         # Prescribed fields for auxiliary eqns should come from prognostics of
         # other equations, so only the prescribed fields of the main equation
         # need passing to StateFields
-        self.fields = StateFields(self.x.np1, self.equation.prescribed_fields,
+        self.fields = StateFields(self.x, self.equation.prescribed_fields,
                                   *self.io.output.dumplist)
 
     def setup_scheme(self):
@@ -437,21 +459,21 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
             for _, scheme in self.physics_schemes:
                 scheme.apply(xnp1(scheme.field_name), xnp1(scheme.field_name))
 
-    def run(self, t, tmax, pickup=False):
+    def run(self, t, tmax, pick_up=False):
         """
         Runs the model for the specified time, from t to tmax.
 
         Args:
             t (float): the start time of the run
             tmax (float): the end time of the run
-            pickup: (bool): specify whether to pickup from a previous run
+            pick_up: (bool): specify whether to pick_up from a previous run
         """
 
-        if not pickup:
+        if not pick_up:
             assert self.reference_profiles_initialised, \
                 'Reference profiles for must be initialised to use Semi-Implicit Timestepper'
 
-        super().run(t, tmax, pickup=pickup)
+        super().run(t, tmax, pick_up=pick_up)
 
 
 class PrescribedTransport(Timestepper):
@@ -505,7 +527,7 @@ class PrescribedTransport(Timestepper):
 
     def setup_fields(self):
         self.x = TimeLevelFields(self.equation, self.scheme.nlevels)
-        self.fields = StateFields(self.x.np1, self.equation.prescribed_fields,
+        self.fields = StateFields(self.x, self.equation.prescribed_fields,
                                   *self.io.output.dumplist)
 
     def setup_scheme(self):

--- a/integration-tests/equations/test_dry_compressible.py
+++ b/integration-tests/equations/test_dry_compressible.py
@@ -92,7 +92,7 @@ def run_dry_compressible(tmpdir):
     check_io = IO(domain, check_output)
     check_stepper = SemiImplicitQuasiNewton(check_eqn, check_io, [])
     check_stepper.set_reference_profiles([])
-    check_stepper.run(t=0, tmax=0, pickup=True)
+    check_stepper.run(t=0, tmax=0, pick_up=True)
 
     return stepper, check_stepper
 

--- a/integration-tests/equations/test_incompressible.py
+++ b/integration-tests/equations/test_incompressible.py
@@ -87,7 +87,7 @@ def run_incompressible(tmpdir):
     check_io = IO(domain, check_output)
     check_stepper = SemiImplicitQuasiNewton(check_eqn, check_io, [])
     check_stepper.set_reference_profiles([])
-    check_stepper.run(t=0, tmax=0, pickup=True)
+    check_stepper.run(t=0, tmax=0, pick_up=True)
 
     return stepper, check_stepper
 

--- a/integration-tests/equations/test_moist_compressible.py
+++ b/integration-tests/equations/test_moist_compressible.py
@@ -98,7 +98,7 @@ def run_moist_compressible(tmpdir):
     check_io = IO(domain, output=check_output)
     check_stepper = SemiImplicitQuasiNewton(check_eqn, check_io, [])
     check_stepper.set_reference_profiles([])
-    check_stepper.run(t=0, tmax=0, pickup=True)
+    check_stepper.run(t=0, tmax=0, pick_up=True)
 
     return stepper, check_stepper
 

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -38,7 +38,7 @@ def set_up_model_objects(mesh, dt, output, stepper_type):
                                           linear_solver=linear_solver)
 
     elif stepper_type == 'multi_level':
-        scheme = TR_BDF2(domain, gamma=0.5)
+        scheme = AdamsBashforth(domain, order=2)
         stepper = Timestepper(eqns, scheme, io)
 
     else:
@@ -206,5 +206,5 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
         # longer be available so expect a bigger error
         diff_array = stepper_1.fields(field_name).dat.data - stepper_3.fields(field_name).dat.data
         error = np.linalg.norm(diff_array) / np.linalg.norm(stepper_1.fields(field_name).dat.data)
-        assert error < 2e-10, \
+        assert error < 1e-8, \
             f'Checkpointed field {field_name} with new time stepper is not equal to non-checkpointed field'

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -10,6 +10,7 @@ from firedrake import (PeriodicIntervalMesh, ExtrudedMesh, pi,
                        SpatialCoordinate, exp, sin, Function, as_vector)
 import pytest
 
+
 def set_up_model_objects(mesh, dt, output, stepper_type):
 
     domain = Domain(mesh, dt, "CG", 1)
@@ -86,6 +87,7 @@ def initialise_fields(eqns, stepper):
 
     stepper.set_reference_profiles([('rho', rho_b), ('theta', theta_b)])
 
+
 @pytest.mark.parametrize("stepper_type", ["multi_level", "semi_implicit"])
 @pytest.mark.parametrize("checkpoint_method", ["old", "new"])
 def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
@@ -113,7 +115,6 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
     output_2 = OutputParameters(dirname=dirname_2, dumpfreq=1,
                                 checkpoint_method=checkpoint_method,
                                 chkptfreq=2, log_level='INFO')
-
 
     stepper_1, eqns_1 = set_up_model_objects(mesh, dt, output_1, stepper_type)
     stepper_2, eqns_2 = set_up_model_objects(mesh, dt, output_2, stepper_type)

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -143,7 +143,7 @@ def test_checkpointing(tmpdir):
     for field_name in ['rho', 'theta', 'u']:
         diff_array = stepper_2.fields(field_name).dat.data - stepper_3.fields(field_name).dat.data
         error = np.linalg.norm(diff_array)
-        assert error < 5e-10, \
+        assert error < 5e-16, \
             f'Checkpointed and picked up field {field_name} is not equal'
 
     # ------------------------------------------------------------------------ #
@@ -158,6 +158,10 @@ def test_checkpointing(tmpdir):
     # Run *new* timestepper for 2 time steps
     # ------------------------------------------------------------------------ #
 
+    output_3 = OutputParameters(dirname=dirname_3, dumpfreq=1,
+                                chkptfreq=2, log_level='INFO',
+                                checkpoint_pickup_filename=chkpt_2_path)
+    stepper_3, _ = set_up_model_objects(mesh, dt, output_3)
     stepper_3.run(t=2*dt, tmax=4*dt, pickup=True)
 
     # ------------------------------------------------------------------------ #
@@ -170,8 +174,7 @@ def test_checkpointing(tmpdir):
         assert error < 1e-14, \
             f'Checkpointed field {field_name} with same time stepper is not equal to non-checkpointed field'
 
-        if checkpoint_method == 'new':
-            diff_array = stepper_1.fields(field_name).dat.data - stepper_3.fields(field_name).dat.data
-            error = np.linalg.norm(diff_array)
-            assert error < 1e-10, \
-                f'Checkpointed field {field_name} with new time stepper is not equal to non-checkpointed field'
+        diff_array = stepper_1.fields(field_name).dat.data - stepper_3.fields(field_name).dat.data
+        error = np.linalg.norm(diff_array)
+        assert error < 1e-10, \
+            f'Checkpointed field {field_name} with new time stepper is not equal to non-checkpointed field'


### PR DESCRIPTION
This updates the checkpointing to:
- pick up the new `CheckpointFile` capability
- checkpoint initial and reference profiles, allowing diagnostics using these to be repeatable
- checkpoint multiple time steps, when using a multi-time level scheme
- it revamps the checkpointing test
- for now, both checkpointing methods are maintained as the new checkpointing doesn't work with HDiv fields on a 2D sphere (see https://github.com/firedrakeproject/firedrake/discussions/2843)