### PR TITLE
Switch to using sphere degree=2 in some tests

### DIFF
--- a/integration-tests/equations/test_sw_triangle.py
+++ b/integration-tests/equations/test_sw_triangle.py
@@ -30,7 +30,8 @@ def setup_sw(dirname, dt, u_transport_option):
     refinements = 3  # number of horizontal cells = 20*(4^refinements)
 
     mesh = IcosahedralSphereMesh(radius=R,
-                                 refinement_level=refinements)
+                                 refinement_level=refinements,
+                                 degree=2)
     domain = Domain(mesh, dt, family="BDM", degree=1)
     x = SpatialCoordinate(mesh)
 
@@ -105,7 +106,7 @@ def check_results(dirname):
     Derr = data.groups["D_error"]
     D = data.groups["D"]
     Dl2 = Derr["l2"][-1]/D["l2"][0]
-    assert Dl2 < 5.e-4
+    assert Dl2 < 6.e-4
 
     uerr = data.groups["u_error"]
     u = data.groups["u"]

--- a/integration-tests/equations/test_thermal_sw.py
+++ b/integration-tests/equations/test_thermal_sw.py
@@ -32,7 +32,8 @@ def setup_sw(dirname, dt, u_transport_option):
     refinements = 3
 
     mesh = IcosahedralSphereMesh(radius=R,
-                                 refinement_level=refinements)
+                                 refinement_level=refinements,
+                                 degree=2)
     domain = Domain(mesh, dt, family="BDM", degree=1)
     x = SpatialCoordinate(mesh)
 


### PR DESCRIPTION
In a previous PR (#359) I missed a couple of spherical tests that were still using a spherical degree of 1. This changes those and allows us to close #307 