### PR TITLE
JDBetteridge/deadlocks

### DIFF
--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -67,7 +67,7 @@ class Diagnostics(object):
             f (:class:`Function`): field to compute diagnostic for.
         """
 
-        fmin = op2.Global(1, np.finfo(float).max, dtype=float)
+        fmin = op2.Global(1, np.finfo(float).max, dtype=float, comm=f._comm)
         op2.par_loop(op2.Kernel("""
 static void minify(double *a, double *b) {
     a[0] = a[0] > fabs(b[0]) ? fabs(b[0]) : a[0];
@@ -85,7 +85,7 @@ static void minify(double *a, double *b) {
             f (:class:`Function`): field to compute diagnostic for.
         """
 
-        fmax = op2.Global(1, np.finfo(float).min, dtype=float)
+        fmax = op2.Global(1, np.finfo(float).min, dtype=float, comm=f._comm)
         op2.par_loop(op2.Kernel("""
 static void maxify(double *a, double *b) {
     a[0] = a[0] < fabs(b[0]) ? fabs(b[0]) : a[0];

--- a/gusto/domain.py
+++ b/gusto/domain.py
@@ -165,7 +165,7 @@ class Domain(object):
                 else:
                     metadata_value = None
                 for procid in range(1, comm_size):
-                    my_tag = comm_size*j + my_rank
+                    my_tag = comm_size*j + procid
                     comm.send((metadata_key, metadata_value), dest=procid, tag=my_tag)
         else:
             # Need to receive information and store in metadata

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -310,7 +310,10 @@ class IO(object):
 
         if self.output.dump_vtus or self.output.dump_nc:
             # make list of fields to dump
-            self.to_dump = [f for f in state_fields.fields if f.name() in state_fields.to_dump]
+            # FIXME: This is a hack, it shouldn't be necessary to sort this list,
+            # It shouldn't be possible to create the list in different orders on different ranks!!!
+            # Problem: `state_fields.to_dump` is a set()! No guaranteed order
+            self.to_dump = sorted([f for f in state_fields.fields if f.name() in state_fields.to_dump], key=lambda x: x.name())
 
         # make dump counter
         self.dumpcount = itertools.count()
@@ -402,7 +405,10 @@ class IO(object):
 
             # make list of fields to pick_up (this doesn't include
             # diagnostic fields)
-            self.to_pick_up = [fname for fname in state_fields.to_pick_up]
+            # FIXME: This is a hack, it shouldn't be necessary to sort this list,
+            # It shouldn't be possible to create the list in different orders on different ranks!!!
+            # Problem: `state_fields.to_dump` is a set()! No guaranteed order
+            self.to_pick_up = sorted([fname for fname in state_fields.to_pick_up])
 
             # make a checkpoint counter
             self.chkptcount = itertools.count()


### PR DESCRIPTION
Fixes some nasty deadlocks found when running
```
examples/shallow_water/williamson_2.py
```

The workaround in `gusto/io.py` needs a proper fix. Using Python's `Set()` in parallel is not a good idea since there is no guaranteed order (see comment in file).