### PR TITLE
Actually get netcdf output working in parallel

### DIFF
--- a/examples/shallow_water/williamson_2.py
+++ b/examples/shallow_water/williamson_2.py
@@ -55,7 +55,8 @@ for ref_level, dt in ref_dt.items():
     output = OutputParameters(dirname=dirname,
                               dumpfreq=dumpfreq,
                               dumplist_latlon=['D', 'D_error'],
-                              log_level='INFO')
+                              log_level='INFO',
+                              dump_nc=True)
 
     diagnostic_fields = [RelativeVorticity(), PotentialVorticity(),
                          ShallowWaterKineticEnergy(),

--- a/gusto/coordinates.py
+++ b/gusto/coordinates.py
@@ -4,8 +4,7 @@ Coordinate fields are stored in specified VectorFunctionSpaces.
 """
 
 from gusto.configuration import logger
-from firedrake import (SpatialCoordinate, sqrt, atan_2, asin, Function,
-                       VectorElement, TensorElement)
+from firedrake import (SpatialCoordinate, sqrt, atan_2, asin, Function)
 import numpy as np
 
 
@@ -94,10 +93,12 @@ class Coordinates(object):
         space = domain.spaces(space_name)
 
         # Use the appropriate scalar function space if the space is vector
-        if (isinstance(space.ufl_element(), VectorElement)
-                or isinstance(space.ufl_element(), TensorElement)):
-            raise NotImplementedError('Coordinates for vector or tensor function spaces not implemented')
+        if np.prod(space.ufl_element().value_shape()) > 1:
             # TODO: get scalar space, and only compute coordinates if necessary
+            logger.warning(f'Space {space_name} has more than one dimension, '
+                           + 'and coordinates used for netCDF output have not '
+                           + 'yet been implemented for this.')
+            return None
 
         self.chi_coords[space_name] = []
 

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -7,7 +7,7 @@ import sys
 import time
 from gusto.diagnostics import Diagnostics
 from gusto.meshes import get_flat_latlon_mesh
-from firedrake import (VectorElement, Function, functionspaceimpl, File,
+from firedrake import (Function, functionspaceimpl, File,
                        DumbCheckpoint, FILE_CREATE, FILE_READ, CheckpointFile)
 import numpy as np
 from gusto.configuration import logger, set_log_handler
@@ -324,7 +324,7 @@ class IO(object):
 
         if self.output.dump_nc:
             self.nc_filename = path.join(self.dumpdir, "field_output.nc")
-            space_names = set([field.function_space().name for field in self.to_dump])
+            space_names = sorted(set([field.function_space().name for field in self.to_dump]))
             for space_name in space_names:
                 self.domain.coords.register_space(self.domain, space_name)
 
@@ -602,21 +602,35 @@ class IO(object):
 
             # Add coordinates if they are not already in the file
             for space_name in space_names:
-                coord_fields = self.domain.coords.global_chi_coords[space_name]
-                num_points = len(self.domain.coords.global_chi_coords[space_name][0])
+                if space_name not in self.domain.coords.chi_coords.keys():
+                    # Space not registered
+                    # TODO: we should fail here, but currently there are some spaces
+                    # that we can't output for so instead just skip outputting
+                    pass
+                else:
+                    coord_fields = self.domain.coords.global_chi_coords[space_name]
+                    num_points = len(self.domain.coords.global_chi_coords[space_name][0])
 
-                nc_field_file.createDimension('coords_'+space_name, num_points)
+                    nc_field_file.createDimension('coords_'+space_name, num_points)
 
-                for (coord_name, coord_field) in zip(self.domain.coords.coords_name, coord_fields):
-                    nc_field_file.createVariable(coord_name+'_'+space_name, float, 'coords_'+space_name)
-                    nc_field_file.variables[coord_name+'_'+space_name][:] = coord_field[:]
+                    for (coord_name, coord_field) in zip(self.domain.coords.coords_name, coord_fields):
+                        nc_field_file.createVariable(coord_name+'_'+space_name, float, 'coords_'+space_name)
+                        nc_field_file.variables[coord_name+'_'+space_name][:] = coord_field[:]
 
             # Create variable for storing the field values
             for field in self.to_dump:
                 field_name = field.name()
                 space_name = field.function_space().name
-                nc_field_file.createGroup(field_name)
-                nc_field_file[field_name].createVariable('field_values', float, ('coords_'+space_name, 'time'))
+                if space_name not in self.domain.coords.chi_coords.keys():
+                    # Space not registered
+                    # TODO: we should fail here, but currently there are some spaces
+                    # that we can't output for so instead just skip outputting
+                    logger.warning(f'netCDF outputting for space {space_name} '
+                                   + 'not yet implemented, so unable to output'
+                                   + '{field_name} field')
+                else:
+                    nc_field_file.createGroup(field_name)
+                    nc_field_file[field_name].createVariable('field_values', float, ('coords_'+space_name, 'time'))
 
             nc_field_file.close()
 
@@ -637,8 +651,11 @@ class IO(object):
             field_name = field.name()
             space_name = field.function_space().name
 
-            if isinstance(field.ufl_element(), VectorElement):
-                raise NotImplementedError('Vector outputting not yet implemented')
+            if space_name not in self.domain.coords.chi_coords.keys():
+                # Space not registered
+                # TODO: we should fail here, but currently there are some spaces
+                # that we can't output for so instead just skip outputting
+                pass
 
             # -------------------------------------------------------- #
             # Scalar elements


### PR DESCRIPTION
This addresses some issues with our netCDF outputting by:
- fixing another small bug related to using a `set` instead of a `sorted` list for the space names used in outputting
- allowing the model to run when there are diagnostic fields that can't be outputted (e.g. the HDiv wind field or fields in a `VectorFunctionSpace`. Instead of throwing an error with these fields, a warning is printed