### PR TITLE
New solver options for backwards euler - otherwise it fails for shall…

### DIFF
--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -808,6 +808,11 @@ class BackwardEuler(TimeDiscretisation):
         """
         if isinstance(options, (EmbeddedDGOptions, RecoveryOptions)):
             raise NotImplementedError("Only SUPG advection options have been implemented for this time discretisation")
+        if not solver_parameters:
+            # default solver parameters
+            solver_parameters = {'ksp_type': 'gmres',
+                                 'pc_type': 'bjacobi',
+                                 'sub_pc_type': 'ilu'}
         super().__init__(domain=domain, field_name=field_name,
                          solver_parameters=solver_parameters,
                          limiter=limiter, options=options)


### PR DESCRIPTION
When using BackwardEuler as the main time stepper for the shallow water test cases I noticed the solver failed in the first time step. If solver settings are changed to the same as ThetaMethod then this fixes the failure. This is just a quick fix at the moment, but in the long term we should probably investigate the best solver settings for each time stepping method.