### PR TITLE
Only call mesh.init_cell_orientations if it hasn't been called before

### DIFF
--- a/gusto/domain.py
+++ b/gusto/domain.py
@@ -97,7 +97,8 @@ class Domain(object):
                 if hasattr(mesh, "_bash_mesh"):
                     sphere_degree = mesh._base_mesh.coordinates.function_space().ufl_element().degree()
                 else:
-                    mesh.init_cell_orientations(x)
+                    if not hasattr(mesh, "_cell_orientations"):
+                        mesh.init_cell_orientations(x)
                     sphere_degree = mesh.coordinates.function_space().ufl_element().degree()
                 V = VectorFunctionSpace(mesh, "DG", sphere_degree)
                 self.outward_normals = Function(V).interpolate(CellNormal(mesh))


### PR DESCRIPTION
`Domain` assumes that if the mesh is on the sphere then it needs to call `mesh.init_cell_orientations`. However, if the cells orientations have already been initialised before the mesh is passed to `Domain` then Firedrake will raise an error.

This PR just adds a check before calling `init_cell_orientations` to avoid this situation.