### PR TITLE
Firedrake warnings fix

### DIFF
--- a/gusto/fields.py
+++ b/gusto/fields.py
@@ -34,7 +34,7 @@ class Fields(object):
 
         if len(space) > 1:
             assert len(space) == len(subfield_names)
-            for field_name, field in zip(subfield_names, value.subfunctions()):
+            for field_name, field in zip(subfield_names, value.subfunctions):
                 setattr(self, field_name, field)
                 field.rename(field_name)
                 self.fields.append(field)

--- a/gusto/fields.py
+++ b/gusto/fields.py
@@ -34,7 +34,7 @@ class Fields(object):
 
         if len(space) > 1:
             assert len(space) == len(subfield_names)
-            for field_name, field in zip(subfield_names, value.split()):
+            for field_name, field in zip(subfield_names, value.subfunctions()):
                 setattr(self, field_name, field)
                 field.rename(field_name)
                 self.fields.append(field)

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -133,7 +133,7 @@ def incompressible_hydrostatic_balance(equation, b0, p0, top=False, params=None)
 
     solve(a == L, w1, bcs=bcs, solver_parameters=params)
 
-    v, pprime = w1.split()
+    v, pprime = w1.subfunctions()
     p0.project(pprime)
 
 
@@ -235,13 +235,13 @@ def compressible_hydrostatic_balance(equation, theta0, rho0, exner0=None,
                                            options_prefix="exner_solver")
 
     exner_solver.solve()
-    v, exner = w.split()
+    v, exner = w.subfunctions()
     if exner0 is not None:
         exner0.assign(exner)
 
     if solve_for_rho:
         w1 = Function(W)
-        v, rho = w1.split()
+        v, rho = w1.subfunctions()
         rho.interpolate(thermodynamics.rho(parameters, theta0, exner))
         v, rho = split(w1)
         dv, dexner = TestFunctions(W)
@@ -256,7 +256,7 @@ def compressible_hydrostatic_balance(equation, theta0, rho0, exner0=None,
         rhosolver = NonlinearVariationalSolver(rhoproblem, solver_parameters=params,
                                                options_prefix="rhosolver")
         rhosolver.solve()
-        v, rho_ = w1.split()
+        v, rho_ = w1.subfunctions()
         rho0.assign(rho_)
     else:
         rho0.interpolate(thermodynamics.rho(parameters, theta0, exner))

--- a/gusto/initialisation_tools.py
+++ b/gusto/initialisation_tools.py
@@ -133,7 +133,7 @@ def incompressible_hydrostatic_balance(equation, b0, p0, top=False, params=None)
 
     solve(a == L, w1, bcs=bcs, solver_parameters=params)
 
-    v, pprime = w1.subfunctions()
+    v, pprime = w1.subfunctions
     p0.project(pprime)
 
 
@@ -235,13 +235,13 @@ def compressible_hydrostatic_balance(equation, theta0, rho0, exner0=None,
                                            options_prefix="exner_solver")
 
     exner_solver.solve()
-    v, exner = w.subfunctions()
+    v, exner = w.subfunctions
     if exner0 is not None:
         exner0.assign(exner)
 
     if solve_for_rho:
         w1 = Function(W)
-        v, rho = w1.subfunctions()
+        v, rho = w1.subfunctions
         rho.interpolate(thermodynamics.rho(parameters, theta0, exner))
         v, rho = split(w1)
         dv, dexner = TestFunctions(W)
@@ -256,7 +256,7 @@ def compressible_hydrostatic_balance(equation, theta0, rho0, exner0=None,
         rhosolver = NonlinearVariationalSolver(rhoproblem, solver_parameters=params,
                                                options_prefix="rhosolver")
         rhosolver.solve()
-        v, rho_ = w1.subfunctions()
+        v, rho_ = w1.subfunctions
         rho0.assign(rho_)
     else:
         rho0.interpolate(thermodynamics.rho(parameters, theta0, exner))

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -373,7 +373,7 @@ class CompressibleSolver(TimesteppingSolver):
         # Solve the hybridized system
         self.hybridized_solver.solve()
 
-        broken_u, rho1, _ = self.urhol0.subfunctions()
+        broken_u, rho1, _ = self.urhol0.subfunctions
         u1 = self.u_hdiv
 
         # Project broken_u into the HDiv space
@@ -387,7 +387,7 @@ class CompressibleSolver(TimesteppingSolver):
             bc.apply(u1)
 
         # Copy back into u and rho cpts of dy
-        u, rho, theta = dy.subfunctions()[0:3]
+        u, rho, theta = dy.subfunctions[0:3]
         u.assign(u1)
         rho.assign(rho1)
 
@@ -495,7 +495,7 @@ class IncompressibleSolver(TimesteppingSolver):
         b = TrialFunction(Vb)
         gamma = TestFunction(Vb)
 
-        u, p = self.up.subfunctions()
+        u, p = self.up.subfunctions
         self.b = Function(Vb)
 
         b_eqn = gamma*(b - b_in
@@ -522,8 +522,8 @@ class IncompressibleSolver(TimesteppingSolver):
         with timed_region("Gusto:VelocityPressureSolve"):
             self.up_solver.solve()
 
-        u1, p1 = self.up.subfunctions()
-        u, p, b = dy.subfunctions()
+        u1, p1 = self.up.subfunctions
+        u, p, b = dy.subfunctions
         u.assign(u1)
         p.assign(p1)
 

--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -373,7 +373,7 @@ class CompressibleSolver(TimesteppingSolver):
         # Solve the hybridized system
         self.hybridized_solver.solve()
 
-        broken_u, rho1, _ = self.urhol0.split()
+        broken_u, rho1, _ = self.urhol0.subfunctions()
         u1 = self.u_hdiv
 
         # Project broken_u into the HDiv space
@@ -387,7 +387,7 @@ class CompressibleSolver(TimesteppingSolver):
             bc.apply(u1)
 
         # Copy back into u and rho cpts of dy
-        u, rho, theta = dy.split()[0:3]
+        u, rho, theta = dy.subfunctions()[0:3]
         u.assign(u1)
         rho.assign(rho1)
 
@@ -495,7 +495,7 @@ class IncompressibleSolver(TimesteppingSolver):
         b = TrialFunction(Vb)
         gamma = TestFunction(Vb)
 
-        u, p = self.up.split()
+        u, p = self.up.subfunctions()
         self.b = Function(Vb)
 
         b_eqn = gamma*(b - b_in
@@ -522,8 +522,8 @@ class IncompressibleSolver(TimesteppingSolver):
         with timed_region("Gusto:VelocityPressureSolve"):
             self.up_solver.solve()
 
-        u1, p1 = self.up.split()
-        u, p, b = dy.split()
+        u1, p1 = self.up.subfunctions()
+        u, p, b = dy.subfunctions()
         u.assign(u1)
         p.assign(p1)
 

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -108,8 +108,8 @@ class SaturationAdjustment(Physics):
         # Vapour and cloud variables are needed for every form of this scheme
         cloud_idx = equation.field_names.index(cloud_name)
         vap_idx = equation.field_names.index(vapour_name)
-        cloud_water = self.X.split()[cloud_idx]
-        water_vapour = self.X.split()[vap_idx]
+        cloud_water = self.X.subfunctions()[cloud_idx]
+        water_vapour = self.X.subfunctions()[vap_idx]
 
         # Indices of variables in mixed function space
         V_idxs = [vap_idx, cloud_idx]
@@ -119,8 +119,8 @@ class SaturationAdjustment(Physics):
         if isinstance(equation, CompressibleEulerEquations):
             rho_idx = equation.field_names.index('rho')
             theta_idx = equation.field_names.index('theta')
-            rho = self.X.split()[rho_idx]
-            theta = self.X.split()[theta_idx]
+            rho = self.X.subfunctions()[rho_idx]
+            theta = self.X.subfunctions()[theta_idx]
             if latent_heat:
                 V_idxs.append(theta_idx)
 
@@ -146,7 +146,7 @@ class SaturationAdjustment(Physics):
             if (active_tracer.phase == Phases.liquid
                     and active_tracer.chemical == 'H2O' and active_tracer.name != cloud_name):
                 liq_idx = equation.field_names.index(active_tracer.name)
-                liquid_water += self.X.split()[liq_idx]
+                liquid_water += self.X.subfunctions()[liq_idx]
 
         # define some parameters as attributes
         self.dt = Constant(0.0)
@@ -280,7 +280,7 @@ class Fallout(Physics):
         self.X = Function(equation.X.function_space())
 
         rain_idx = equation.field_names.index(rain_name)
-        rain = self.X.split()[rain_idx]
+        rain = self.X.subfunctions()[rain_idx]
 
         Vu = domain.spaces("HDiv")
         # TODO: there must be a better way than forcing this into the equation
@@ -314,7 +314,7 @@ class Fallout(Physics):
             # this advects the third moment M3 of the raindrop
             # distribution, which corresponds to the mean mass
             rho_idx = equation.field_names.index('rho')
-            rho = self.X.split()[rho_idx]
+            rho = self.X.subfunctions()[rho_idx]
             rho_w = Constant(1000.0)  # density of liquid water
             # assume n(D) = n_0 * D^mu * exp(-Lambda*D)
             # n_0 = N_r * Lambda^(1+mu) / gamma(1 + mu)
@@ -451,8 +451,8 @@ class Coalescence(Physics):
         """
         # Update the values of internal variables
         self.dt.assign(dt)
-        self.rain.assign(x_in.split()[self.rain_idx])
-        self.cloud_water.assign(x_in.split()[self.cloud_idx])
+        self.rain.assign(x_in.subfunctions()[self.rain_idx])
+        self.cloud_water.assign(x_in.subfunctions()[self.cloud_idx])
         # Evaluate the source
         self.source.assign(self.source_interpolator.interpolate())
 
@@ -509,8 +509,8 @@ class EvaporationOfRain(Physics):
         # Vapour and cloud variables are needed for every form of this scheme
         rain_idx = equation.field_names.index(rain_name)
         vap_idx = equation.field_names.index(vapour_name)
-        rain = self.X.split()[rain_idx]
-        water_vapour = self.X.split()[vap_idx]
+        rain = self.X.subfunctions()[rain_idx]
+        water_vapour = self.X.subfunctions()[vap_idx]
 
         # Indices of variables in mixed function space
         V_idxs = [rain_idx, vap_idx]
@@ -520,8 +520,8 @@ class EvaporationOfRain(Physics):
         if isinstance(equation, CompressibleEulerEquations):
             rho_idx = equation.field_names.index('rho')
             theta_idx = equation.field_names.index('theta')
-            rho = self.X.split()[rho_idx]
-            theta = self.X.split()[theta_idx]
+            rho = self.X.subfunctions()[rho_idx]
+            theta = self.X.subfunctions()[theta_idx]
             if latent_heat:
                 V_idxs.append(theta_idx)
 
@@ -543,7 +543,7 @@ class EvaporationOfRain(Physics):
             if (active_tracer.phase == Phases.liquid
                     and active_tracer.chemical == 'H2O' and active_tracer.name != rain_name):
                 liq_idx = equation.field_names.index(active_tracer.name)
-                liquid_water += self.X.split()[liq_idx]
+                liquid_water += self.X.subfunctions()[liq_idx]
 
         # define some parameters as attributes
         self.dt = Constant(0.0)
@@ -761,10 +761,10 @@ class InstantRain(Physics):
                 interval for the scheme.
         """
         if self.convective_feedback:
-            self.D.assign(x_in.split()[self.VD_idx])
+            self.D.assign(x_in.subfunctions()[self.VD_idx])
         if self.time_varying_saturation:
             self.saturation_curve.interpolate(self.saturation_computation(x_in))
         if self.set_tau_to_dt:
             self.tau.assign(dt)
-        self.water_v.assign(x_in.split()[self.Vv_idx])
+        self.water_v.assign(x_in.subfunctions()[self.Vv_idx])
         self.source.assign(self.source_interpolator.interpolate())

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -108,8 +108,8 @@ class SaturationAdjustment(Physics):
         # Vapour and cloud variables are needed for every form of this scheme
         cloud_idx = equation.field_names.index(cloud_name)
         vap_idx = equation.field_names.index(vapour_name)
-        cloud_water = self.X.subfunctions()[cloud_idx]
-        water_vapour = self.X.subfunctions()[vap_idx]
+        cloud_water = self.X.subfunctions[cloud_idx]
+        water_vapour = self.X.subfunctions[vap_idx]
 
         # Indices of variables in mixed function space
         V_idxs = [vap_idx, cloud_idx]
@@ -119,8 +119,8 @@ class SaturationAdjustment(Physics):
         if isinstance(equation, CompressibleEulerEquations):
             rho_idx = equation.field_names.index('rho')
             theta_idx = equation.field_names.index('theta')
-            rho = self.X.subfunctions()[rho_idx]
-            theta = self.X.subfunctions()[theta_idx]
+            rho = self.X.subfunctions[rho_idx]
+            theta = self.X.subfunctions[theta_idx]
             if latent_heat:
                 V_idxs.append(theta_idx)
 
@@ -146,7 +146,7 @@ class SaturationAdjustment(Physics):
             if (active_tracer.phase == Phases.liquid
                     and active_tracer.chemical == 'H2O' and active_tracer.name != cloud_name):
                 liq_idx = equation.field_names.index(active_tracer.name)
-                liquid_water += self.X.subfunctions()[liq_idx]
+                liquid_water += self.X.subfunctions[liq_idx]
 
         # define some parameters as attributes
         self.dt = Constant(0.0)
@@ -280,7 +280,7 @@ class Fallout(Physics):
         self.X = Function(equation.X.function_space())
 
         rain_idx = equation.field_names.index(rain_name)
-        rain = self.X.subfunctions()[rain_idx]
+        rain = self.X.subfunctions[rain_idx]
 
         Vu = domain.spaces("HDiv")
         # TODO: there must be a better way than forcing this into the equation
@@ -314,7 +314,7 @@ class Fallout(Physics):
             # this advects the third moment M3 of the raindrop
             # distribution, which corresponds to the mean mass
             rho_idx = equation.field_names.index('rho')
-            rho = self.X.subfunctions()[rho_idx]
+            rho = self.X.subfunctions[rho_idx]
             rho_w = Constant(1000.0)  # density of liquid water
             # assume n(D) = n_0 * D^mu * exp(-Lambda*D)
             # n_0 = N_r * Lambda^(1+mu) / gamma(1 + mu)
@@ -451,8 +451,8 @@ class Coalescence(Physics):
         """
         # Update the values of internal variables
         self.dt.assign(dt)
-        self.rain.assign(x_in.subfunctions()[self.rain_idx])
-        self.cloud_water.assign(x_in.subfunctions()[self.cloud_idx])
+        self.rain.assign(x_in.subfunctions[self.rain_idx])
+        self.cloud_water.assign(x_in.subfunctions[self.cloud_idx])
         # Evaluate the source
         self.source.assign(self.source_interpolator.interpolate())
 
@@ -509,8 +509,8 @@ class EvaporationOfRain(Physics):
         # Vapour and cloud variables are needed for every form of this scheme
         rain_idx = equation.field_names.index(rain_name)
         vap_idx = equation.field_names.index(vapour_name)
-        rain = self.X.subfunctions()[rain_idx]
-        water_vapour = self.X.subfunctions()[vap_idx]
+        rain = self.X.subfunctions[rain_idx]
+        water_vapour = self.X.subfunctions[vap_idx]
 
         # Indices of variables in mixed function space
         V_idxs = [rain_idx, vap_idx]
@@ -520,8 +520,8 @@ class EvaporationOfRain(Physics):
         if isinstance(equation, CompressibleEulerEquations):
             rho_idx = equation.field_names.index('rho')
             theta_idx = equation.field_names.index('theta')
-            rho = self.X.subfunctions()[rho_idx]
-            theta = self.X.subfunctions()[theta_idx]
+            rho = self.X.subfunctions[rho_idx]
+            theta = self.X.subfunctions[theta_idx]
             if latent_heat:
                 V_idxs.append(theta_idx)
 
@@ -543,7 +543,7 @@ class EvaporationOfRain(Physics):
             if (active_tracer.phase == Phases.liquid
                     and active_tracer.chemical == 'H2O' and active_tracer.name != rain_name):
                 liq_idx = equation.field_names.index(active_tracer.name)
-                liquid_water += self.X.subfunctions()[liq_idx]
+                liquid_water += self.X.subfunctions[liq_idx]
 
         # define some parameters as attributes
         self.dt = Constant(0.0)
@@ -761,10 +761,10 @@ class InstantRain(Physics):
                 interval for the scheme.
         """
         if self.convective_feedback:
-            self.D.assign(x_in.subfunctions()[self.VD_idx])
+            self.D.assign(x_in.subfunctions[self.VD_idx])
         if self.time_varying_saturation:
             self.saturation_curve.interpolate(self.saturation_computation(x_in))
         if self.set_tau_to_dt:
             self.tau.assign(dt)
-        self.water_v.assign(x_in.subfunctions()[self.Vv_idx])
+        self.water_v.assign(x_in.subfunctions[self.Vv_idx])
         self.source.assign(self.source_interpolator.interpolate())

--- a/gusto/preconditioners.py
+++ b/gusto/preconditioners.py
@@ -244,8 +244,8 @@ class VerticalHybridizationPC(PCBase):
         K_1 = Tensor(split_trace_op[(0, id1)])
 
         # Split functions and reconstruct each bit separately
-        split_residual = self.broken_residual.split()
-        split_sol = self.broken_solution.split()
+        split_residual = self.broken_residual.subfunctions()
+        split_sol = self.broken_solution.subfunctions()
         g = AssembledVector(split_residual[id0])
         f = AssembledVector(split_residual[id1])
         sigma = split_sol[id0]
@@ -316,8 +316,8 @@ class VerticalHybridizationPC(PCBase):
             # Transfer unbroken_rhs into broken_rhs
             # NOTE: Scalar space is already "broken" so no need for
             # any projections
-            unbroken_scalar_data = self.unbroken_residual.split()[self.pidx]
-            broken_scalar_data = self.broken_residual.split()[self.pidx]
+            unbroken_scalar_data = self.unbroken_residual.subfunctions()[self.pidx]
+            broken_scalar_data = self.broken_residual.subfunctions()[self.pidx]
             unbroken_scalar_data.dat.copy(broken_scalar_data.dat)
 
         with timed_region("VertHybridRHS"):
@@ -328,8 +328,8 @@ class VerticalHybridizationPC(PCBase):
             # basis functions that add together to give unbroken
             # basis functions.
 
-            unbroken_res_hdiv = self.unbroken_residual.split()[self.vidx]
-            broken_res_hdiv = self.broken_residual.split()[self.vidx]
+            unbroken_res_hdiv = self.unbroken_residual.subfunctions()[self.vidx]
+            broken_res_hdiv = self.broken_residual.subfunctions()[self.vidx]
             broken_res_hdiv.assign(0)
             self.average_kernel.apply(broken_res_hdiv, self.weight, unbroken_res_hdiv)
 
@@ -351,13 +351,13 @@ class VerticalHybridizationPC(PCBase):
 
         with timed_region("VertHybridRecover"):
             # Project the broken solution into non-broken spaces
-            broken_pressure = self.broken_solution.split()[self.pidx]
-            unbroken_pressure = self.unbroken_solution.split()[self.pidx]
+            broken_pressure = self.broken_solution.subfunctions()[self.pidx]
+            unbroken_pressure = self.unbroken_solution.subfunctions()[self.pidx]
             broken_pressure.dat.copy(unbroken_pressure.dat)
 
             # Compute the hdiv projection of the broken hdiv solution
-            broken_hdiv = self.broken_solution.split()[self.vidx]
-            unbroken_hdiv = self.unbroken_solution.split()[self.vidx]
+            broken_hdiv = self.broken_solution.subfunctions()[self.vidx]
+            unbroken_hdiv = self.unbroken_solution.subfunctions()[self.vidx]
             unbroken_hdiv.assign(0)
 
             self.average_kernel.apply(unbroken_hdiv, self.weight, broken_hdiv)

--- a/gusto/preconditioners.py
+++ b/gusto/preconditioners.py
@@ -244,8 +244,8 @@ class VerticalHybridizationPC(PCBase):
         K_1 = Tensor(split_trace_op[(0, id1)])
 
         # Split functions and reconstruct each bit separately
-        split_residual = self.broken_residual.subfunctions()
-        split_sol = self.broken_solution.subfunctions()
+        split_residual = self.broken_residual.subfunctions
+        split_sol = self.broken_solution.subfunctions
         g = AssembledVector(split_residual[id0])
         f = AssembledVector(split_residual[id1])
         sigma = split_sol[id0]
@@ -316,8 +316,8 @@ class VerticalHybridizationPC(PCBase):
             # Transfer unbroken_rhs into broken_rhs
             # NOTE: Scalar space is already "broken" so no need for
             # any projections
-            unbroken_scalar_data = self.unbroken_residual.subfunctions()[self.pidx]
-            broken_scalar_data = self.broken_residual.subfunctions()[self.pidx]
+            unbroken_scalar_data = self.unbroken_residual.subfunctions[self.pidx]
+            broken_scalar_data = self.broken_residual.subfunctions[self.pidx]
             unbroken_scalar_data.dat.copy(broken_scalar_data.dat)
 
         with timed_region("VertHybridRHS"):
@@ -328,8 +328,8 @@ class VerticalHybridizationPC(PCBase):
             # basis functions that add together to give unbroken
             # basis functions.
 
-            unbroken_res_hdiv = self.unbroken_residual.subfunctions()[self.vidx]
-            broken_res_hdiv = self.broken_residual.subfunctions()[self.vidx]
+            unbroken_res_hdiv = self.unbroken_residual.subfunctions[self.vidx]
+            broken_res_hdiv = self.broken_residual.subfunctions[self.vidx]
             broken_res_hdiv.assign(0)
             self.average_kernel.apply(broken_res_hdiv, self.weight, unbroken_res_hdiv)
 
@@ -351,13 +351,13 @@ class VerticalHybridizationPC(PCBase):
 
         with timed_region("VertHybridRecover"):
             # Project the broken solution into non-broken spaces
-            broken_pressure = self.broken_solution.subfunctions()[self.pidx]
-            unbroken_pressure = self.unbroken_solution.subfunctions()[self.pidx]
+            broken_pressure = self.broken_solution.subfunctions[self.pidx]
+            unbroken_pressure = self.unbroken_solution.subfunctions[self.pidx]
             broken_pressure.dat.copy(unbroken_pressure.dat)
 
             # Compute the hdiv projection of the broken hdiv solution
-            broken_hdiv = self.broken_solution.subfunctions()[self.vidx]
-            unbroken_hdiv = self.unbroken_solution.subfunctions()[self.vidx]
+            broken_hdiv = self.broken_solution.subfunctions[self.vidx]
+            unbroken_hdiv = self.unbroken_solution.subfunctions[self.vidx]
             unbroken_hdiv.assign(0)
 
             self.average_kernel.apply(unbroken_hdiv, self.weight, broken_hdiv)

--- a/gusto/recovery/recovery_kernels.py
+++ b/gusto/recovery/recovery_kernels.py
@@ -58,8 +58,7 @@ class AverageKernel(object):
         par_loop(self._kernel, dx,
                  {"vo": (v_out, INC),
                   "w": (weighting, READ),
-                  "v": (v_in, READ)},
-                 is_loopy_kernel=True)
+                  "v": (v_in, READ)})
 
 
 class AverageWeightings(object):
@@ -103,8 +102,7 @@ class AverageWeightings(object):
                 lives in the continuous target space.
         """
         par_loop(self._kernel, dx,
-                 {"w": (w, INC)},
-                 is_loopy_kernel=True)
+                 {"w": (w, INC)})
 
 
 class BoundaryRecoveryExtruded():
@@ -167,7 +165,6 @@ class BoundaryRecoveryExtruded():
         par_loop(self._bot_kernel, dx,
                  args={"x_out": (x_out, WRITE),
                        "x_in": (x_in, READ)},
-                 is_loopy_kernel=True,
                  iteration_region=ON_BOTTOM)
 
 
@@ -240,7 +237,6 @@ class BoundaryRecoveryHCurl():
         par_loop(self._top_kernel, dx,
                  args={"x_out": (x_out, WRITE),
                        "x_in": (x_in, READ)},
-                 is_loopy_kernel=True,
                  iteration_region=ON_TOP)
         par_loop(self._bot_kernel, dx,
                  args={"x_out": (x_out, WRITE),
@@ -521,5 +517,4 @@ class BoundaryGaussianElimination(object):
                   "DG1": (v_DG1, WRITE),
                   "ACT_COORDS": (act_coords, READ),
                   "EFF_COORDS": (eff_coords, READ),
-                  "NUM_EXT": (num_ext, READ)},
-                 is_loopy_kernel=True)
+                  "NUM_EXT": (num_ext, READ)})

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -15,7 +15,7 @@ from gusto.time_discretisation import ExplicitTimeDiscretisation
 from gusto.transport_methods import TransportMethod
 import ufl
 
-__all__ = ["Timestepper", "SplitPhysicsTimestepper", "SemiImplicitQuasiNewton",
+__all__ = ["Timestepper", "PhysicsTimestepper", "SemiImplicitQuasiNewton",
            "PrescribedTransport"]
 
 
@@ -210,7 +210,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
                 assert field_name in self.equation.field_names, \
                     f'Cannot set reference profile as field {field_name} not found'
                 idx = self.equation.field_names.index(field_name)
-                X_ref = self.equation.X_ref.split()[idx]
+                X_ref = self.equation.X_ref.subfunctions()[idx]
                 X_ref.assign(ref)
 
         self.reference_profiles_initialised = True

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -210,7 +210,7 @@ class BaseTimestepper(object, metaclass=ABCMeta):
                 assert field_name in self.equation.field_names, \
                     f'Cannot set reference profile as field {field_name} not found'
                 idx = self.equation.field_names.index(field_name)
-                X_ref = self.equation.X_ref.subfunctions()[idx]
+                X_ref = self.equation.X_ref.subfunctions[idx]
                 X_ref.assign(ref)
 
         self.reference_profiles_initialised = True

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -15,7 +15,7 @@ from gusto.time_discretisation import ExplicitTimeDiscretisation
 from gusto.transport_methods import TransportMethod
 import ufl
 
-__all__ = ["Timestepper", "PhysicsTimestepper", "SemiImplicitQuasiNewton",
+__all__ = ["Timestepper", "SplitPhysicsTimestepper", "SemiImplicitQuasiNewton",
            "PrescribedTransport"]
 
 

--- a/unit-tests/fml_tests/test_replace_perp.py
+++ b/unit-tests/fml_tests/test_replace_perp.py
@@ -30,7 +30,7 @@ def test_replace_perp():
 
     # make a function to replace the subject with and give it some values
     U1 = Function(W)
-    u1, _ = U1.split()
+    u1, _ = U1.subfunctions()
     x, y = SpatialCoordinate(mesh)
     u1.interpolate(as_vector([1, 2]))
 
@@ -40,9 +40,9 @@ def test_replace_perp():
     U2 = Function(W)
     solve(a == L.form, U2)
 
-    u2, _ = U2.split()
+    u2, _ = U2.subfunctions()
     U3 = Function(W)
-    u3, _ = U3.split()
+    u3, _ = U3.subfunctions()
     u3.interpolate(as_vector([-2, 1]))
 
     assert errornorm(u2, u3) < 1e-14

--- a/unit-tests/fml_tests/test_replace_perp.py
+++ b/unit-tests/fml_tests/test_replace_perp.py
@@ -30,7 +30,7 @@ def test_replace_perp():
 
     # make a function to replace the subject with and give it some values
     U1 = Function(W)
-    u1, _ = U1.subfunctions()
+    u1, _ = U1.subfunctions
     x, y = SpatialCoordinate(mesh)
     u1.interpolate(as_vector([1, 2]))
 
@@ -40,9 +40,9 @@ def test_replace_perp():
     U2 = Function(W)
     solve(a == L.form, U2)
 
-    u2, _ = U2.subfunctions()
+    u2, _ = U2.subfunctions
     U3 = Function(W)
-    u3, _ = U3.subfunctions()
+    u3, _ = U3.subfunctions
     u3.interpolate(as_vector([-2, 1]))
 
     assert errornorm(u2, u3) < 1e-14


### PR DESCRIPTION
Fixed the issues raised 'Heed Firedrake warnings #386'.
Specifically removes the references to is_loopy_kernel=True and replaces .split() with subfunctions 