### PR TITLE
Fix precipitation

### DIFF
--- a/examples/compressible/unsaturated_bubble.py
+++ b/examples/compressible/unsaturated_bubble.py
@@ -90,9 +90,9 @@ transport_methods = [DGUpwind(eqns, field) for field in ["u", "rho", "theta", "w
 linear_solver = CompressibleSolver(eqns)
 
 # Physics schemes
-# NB: to use wrapper options with Fallout, need to pass field name to time discretisation
+# NB: can't yet use wrapper or limiter options with physics
 rainfall_method = DGUpwind(eqns, 'rain', outflow=True)
-physics_schemes = [(Fallout(eqns, 'rain', domain, rainfall_method), SSPRK3(domain, field_name='rain', options=theta_opts, limiter=limiter)),
+physics_schemes = [(Fallout(eqns, 'rain', domain, rainfall_method), SSPRK3(domain)),
                    (Coalescence(eqns), ForwardEuler(domain)),
                    (EvaporationOfRain(eqns), ForwardEuler(domain)),
                    (SaturationAdjustment(eqns), ForwardEuler(domain))]

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -484,6 +484,31 @@ class PrognosticEquationSet(PrognosticEquation, metaclass=ABCMeta):
         return adv_form
 
 
+    def get_active_tracer(self, field_name):
+        """
+        Returns the active tracer metadata object for a particular field.
+
+        Args:
+            field_name (str): the name of the field to return the metadata for.
+
+        Returns:
+            :class:`ActiveTracer`: the object storing the metadata describing
+                the tracer.
+        """
+
+        active_tracer_to_return = None
+
+        for active_tracer in self.active_tracers:
+            if active_tracer.name == field_name:
+                active_tracer_to_return = active_tracer
+                break
+
+        if active_tracer_to_return is None:
+            raise RuntimeError(f'Unable to find active tracer {field_name}')
+
+        return active_tracer_to_return
+
+
 class ForcedAdvectionEquation(PrognosticEquationSet):
     u"""
     Discretises the advection equation with a source/sink term,               \n

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -483,7 +483,6 @@ class PrognosticEquationSet(PrognosticEquation, metaclass=ABCMeta):
 
         return adv_form
 
-
     def get_active_tracer(self, field_name):
         """
         Returns the active tracer metadata object for a particular field.

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -8,11 +8,11 @@ with "evaluate" methods.
 """
 
 from abc import ABCMeta, abstractmethod
-from gusto.active_tracers import Phases
+from gusto.active_tracers import Phases, TracerVariableType
 from gusto.recovery import Recoverer, BoundaryMethod
 from gusto.equations import CompressibleEulerEquations
 from gusto.fml import identity, Term, subject
-from gusto.labels import physics, transporting_velocity
+from gusto.labels import physics, transporting_velocity, transport, prognostic
 from gusto.logging import logger
 from firedrake import (Interpolator, conditional, Function, dx,
                        min_value, max_value, Constant, pi, Projector)
@@ -274,7 +274,11 @@ class Fallout(Physics):
         # Check that fields exist
         assert rain_name in equation.field_names, f"Field {rain_name} does not exist in the equation set"
 
-        # TODO: check if variable is a mixing ratio
+        # Check if variable is a mixing ratio
+        rain_tracer = equation.get_active_tracer(rain_name)
+        if rain_tracer.variable_type != TracerVariableType.mixing_ratio:
+            raise NotImplementedError('Fallout only implemented when rain ' +
+                                      'variable is a mixing ratio')
 
         # Set up rain and velocity
         self.X = Function(equation.X.function_space())
@@ -299,7 +303,12 @@ class Fallout(Physics):
                                           ufl.replace(t.form, {t.get(transporting_velocity): v}),
                                           t.labels))
 
-        equation.residual += physics(subject(adv_term, equation.X), self.evaluate)
+        # We don't want this term to be picked up by normal transport, so drop
+        # the transport label
+        transport.remove(adv_term)
+
+        adv_term = prognostic(subject(adv_term, equation.X), rain_name)
+        equation.residual += physics(adv_term, self.evaluate)
 
         # -------------------------------------------------------------------- #
         # Expressions for determining rainfall velocity
@@ -340,7 +349,10 @@ class Fallout(Physics):
                                         / (math.gamma(4 + mu) * Lambda0 ** b)
                                         * (rho0 / rho) ** g))
         else:
-            raise NotImplementedError('Currently we only have implementations for zero and one moment schemes for rainfall. Valid options are AdvectedMoments.M0 and AdvectedMoments.M3')
+            raise NotImplementedError(
+                'Currently there are only implementations for zero and one '
+                + 'moment schemes for rainfall. Valid options are '
+                + 'AdvectedMoments.M0 and AdvectedMoments.M3')
 
         if moments != AdvectedMoments.M0:
             self.determine_v = Projector(-v_expression*domain.k, v)

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -305,7 +305,7 @@ class Fallout(Physics):
 
         # We don't want this term to be picked up by normal transport, so drop
         # the transport label
-        transport.remove(adv_term)
+        adv_term = transport.remove(adv_term)
 
         adv_term = prognostic(subject(adv_term, equation.X), rain_name)
         equation.residual += physics(adv_term, self.evaluate)

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -277,8 +277,8 @@ class Fallout(Physics):
         # Check if variable is a mixing ratio
         rain_tracer = equation.get_active_tracer(rain_name)
         if rain_tracer.variable_type != TracerVariableType.mixing_ratio:
-            raise NotImplementedError('Fallout only implemented when rain ' +
-                                      'variable is a mixing ratio')
+            raise NotImplementedError('Fallout only implemented when rain '
+                                      + 'variable is a mixing ratio')
 
         # Set up rain and velocity
         self.X = Function(equation.X.function_space())

--- a/integration-tests/equations/test_forced_advection.py
+++ b/integration-tests/equations/test_forced_advection.py
@@ -50,8 +50,8 @@ def run_forced_advection(tmpdir):
     meqn = ForcedAdvectionEquation(domain, VD, field_name="water_vapour", Vu=Vu,
                                    active_tracers=[rain])
     transport_method = DGUpwind(meqn, "water_vapour")
-    physics_schemes = [(InstantRain(meqn, msat, rain_name="rain",
-                                    parameters=None), ForwardEuler(domain))]
+    physics_parametrisations = [InstantRain(meqn, msat, rain_name="rain",
+                                            parameters=None)]
 
     # I/O
     output = OutputParameters(dirname=str(tmpdir), dumpfreq=1)
@@ -60,7 +60,7 @@ def run_forced_advection(tmpdir):
 
     # Time Stepper
     stepper = PrescribedTransport(meqn, RK4(domain), io, transport_method,
-                                  physics_schemes=physics_schemes)
+                                  physics_parametrisations=physics_parametrisations)
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/physics/test_precipitation.py
+++ b/integration-tests/physics/test_precipitation.py
@@ -43,12 +43,12 @@ def setup_fallout(dirname):
 
     # Physics schemes
     rainfall_method = DGUpwind(eqn, 'rain', outflow=True)
-    physics_schemes = [(Fallout(eqn, 'rain', domain, rainfall_method), SSPRK3(domain, 'rain'))]
+    physics_parametrisations = [Fallout(eqn, 'rain', domain, rainfall_method)]
 
     # build time stepper
-    scheme = ForwardEuler(domain)
+    scheme = SSPRK3(domain)
     stepper = PrescribedTransport(eqn, scheme, io, transport_method,
-                                  physics_schemes=physics_schemes)
+                                  physics_parametrisations=physics_parametrisations)
 
     # ------------------------------------------------------------------------ #
     # Initial conditions


### PR DESCRIPTION
This attempts to fix precipitation (issue #334) by:
- ensuring that the advection term associated with `Fallout` has its `transport` label removed
- adding the `prognostic` label to that term

It also attempts to resolve some outstanding physics problems by:
- allowing the `Timestepper` to take physics schemes
- the `PrescribedTransport` time stepper is now only different in allowing the wind to be time-varying

I also implemented a routine to return an equation's `active_tracer` object for a particular species, which should help with error checking in the physics.