### PR TITLE
Log the Courant number

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -93,6 +93,7 @@ class OutputParameters(Configuration):
     checkpoint_pickup_filename = None
     chkptfreq = 1
     dirname = None
+    log_courant = True
     #: TODO: Should the output fields be interpolated or projected to
     #: a linear space?  Default is interpolation.
     project_fields = False

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -256,10 +256,10 @@ class IO(object):
             courant_name = None if name == 'u' else name
 
             # Set up diagnostic if it hasn't already been
-            if courant_name not in diagnostic_names:
+            if courant_name not in diagnostic_names and 'u' in state_fields._field_names:
                 if expression is None:
                     diagnostic = CourantNumber(to_dump=False)
-                else:
+                elif expression is not None:
                     diagnostic = CourantNumber(velocity=expression, name=courant_name, to_dump=False)
 
                 self.diagnostic_fields.append(diagnostic)
@@ -278,7 +278,7 @@ class IO(object):
                 None.
         """
 
-        if self.output.log_courant:
+        if self.output.log_courant and 'u' in state_fields._field_names:
             diagnostic_names = [diagnostic.name for diagnostic in self.diagnostic_fields]
             courant_name = 'CourantNumber' if name == 'u' else 'CourantNumber_'+name
             courant_idx = diagnostic_names.index(courant_name)

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -5,7 +5,7 @@ import itertools
 from netCDF4 import Dataset
 import sys
 import time
-from gusto.diagnostics import Diagnostics
+from gusto.diagnostics import Diagnostics, CourantNumber
 from gusto.meshes import get_flat_latlon_mesh
 from firedrake import (Function, functionspaceimpl, File,
                        DumbCheckpoint, FILE_CREATE, FILE_READ, CheckpointFile)
@@ -237,6 +237,60 @@ class IO(object):
         if hasattr(equation, 'parameters') and equation.parameters is not None:
             logger.info("Physical parameters that take non-default values:")
             logger.info(", ".join("%s: %s" % (k, float(v)) for (k, v) in vars(equation.parameters).items()))
+
+    def setup_log_courant(self, state_fields, name='u', expression=None):
+        """
+        Sets up Courant number diagnostics to be logged.
+
+        Args:
+            state_fields (:class:`StateFields`): the model's field container.
+            name (str, optional): the name of the field to log the Courant
+                number of. Defaults to 'u'.
+            expression (:class:`ufl.Expr`, optional): expression of velocity
+                field to take Courant number of. Defaults to None, in which case
+
+        """
+
+        if self.output.log_courant:
+            diagnostic_names = [diagnostic.name for diagnostic in self.diagnostic_fields]
+            courant_name = None if name == 'u' else name
+
+            # Set up diagnostic if it hasn't already been
+            if courant_name not in diagnostic_names:
+                if expression is None:
+                    diagnostic = CourantNumber(to_dump=False)
+                else:
+                    diagnostic = CourantNumber(velocity=expression, name=courant_name, to_dump=False)
+
+                self.diagnostic_fields.append(diagnostic)
+                diagnostic.setup(self.domain, state_fields)
+                self.diagnostics.register(diagnostic.name)
+
+    def log_courant(self, state_fields, name='u', message=None):
+        """
+        Logs the maximum Courant number value.
+
+        Args:
+            state_fields (:class:`StateFields`): the model's field container.
+            name (str, optional): the name of the field to log the Courant
+                number of. Defaults to 'u'.
+            message (str, optional): an extra message to be logged. Defaults to
+                None.
+        """
+
+        if self.output.log_courant:
+            diagnostic_names = [diagnostic.name for diagnostic in self.diagnostic_fields]
+            courant_name = 'CourantNumber' if name == 'u' else 'CourantNumber_'+name
+            courant_idx = diagnostic_names.index(courant_name)
+            courant_diagnostic = self.diagnostic_fields[courant_idx]
+            courant_diagnostic.compute()
+            courant_field = state_fields(courant_name)
+            courant_max = self.diagnostics.max(courant_field)
+
+            if message is None:
+                logger.info(f'Max Courant: {courant_max:.2e}')
+            else:
+                logger.info(f'Max Courant {message}: {courant_max:.2e}')
 
     def setup_diagnostics(self, state_fields):
         """

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -248,7 +248,7 @@ class IO(object):
                 number of. Defaults to 'u'.
             expression (:class:`ufl.Expr`, optional): expression of velocity
                 field to take Courant number of. Defaults to None, in which case
-
+                the "name" argument must correspond to an existing field.
         """
 
         if self.output.log_courant:

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -152,6 +152,10 @@ class BaseTimestepper(object, metaclass=ABCMeta):
 
         # Set up diagnostics, which may set up some fields necessary to pick up
         self.io.setup_diagnostics(self.fields)
+        self.io.setup_log_courant(self.fields)
+        if self.transporting_velocity != "prognostic":
+            self.io.setup_log_courant(self.fields, name='transporting_velocity',
+                                      expression=self.transporting_velocity)
 
         if pick_up:
             # Pick up fields, and return other info to be picked up
@@ -170,6 +174,8 @@ class BaseTimestepper(object, metaclass=ABCMeta):
             logger.info(f'at start of timestep, t={float(self.t)}, dt={float(self.dt)}')
 
             self.x.update()
+
+            self.io.log_courant(self.fields)
 
             self.timestep()
 
@@ -551,6 +557,8 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
         for k in range(self.maxk):
 
             with timed_stage("Transport"):
+                self.io.log_courant(self.fields, 'transporting_velocity',
+                                    f'transporting velocity, outer iteration {k}')
                 for name, scheme in self.active_transport:
                     # transports a field from xstar and puts result in xp
                     scheme.apply(xp(name), xstar(name))


### PR DESCRIPTION
This introduces a system to log the Courant number, which will be done by default.

Main points:
- a `log_courant` option is passed to the output configuration
- the `CourantNumber` diagnostic is augmented so that it can be evaluated on an expression, and not just the field named "u" (this is used when the transporting velocity isn't exactly the wind field)
- some plumbing has been added to the IO, so that the Courant number diagnostics are set up if needed. The diagnostics are used to evaluated the maximum value (which is logged)
- the calls to log the Courant number are added to the time loop. The `SemiImplicitQuasiNewton` time stepper logs the Courant number every outer loop