### PR TITLE
Fix the linear shallow-water example

### DIFF
--- a/examples/shallow_water/linear_williamson_2.py
+++ b/examples/shallow_water/linear_williamson_2.py
@@ -54,7 +54,7 @@ io = IO(domain, output, diagnostic_fields=diagnostic_fields)
 
 # Transport schemes
 transport_schemes = [ForwardEuler(domain, "D")]
-transport_methods = [DGUpwind(eqns, "D")]
+transport_methods = [DefaultTransport(eqns, "D")]
 
 # Time stepper
 stepper = SemiImplicitQuasiNewton(eqns, io, transport_schemes, transport_methods)


### PR DESCRIPTION
This fixes the Williamson 2 linear shallow-water example, which had the wrong transport method set.

On main, our example was blowing up after a few time steps (thanks to Benni Buchenau for spotting that!).

With this change it now runs to completion and the output is sensible.