### PR TITLE
Outputting and checkpointing

### DIFF
--- a/gusto/io.py
+++ b/gusto/io.py
@@ -380,6 +380,9 @@ class IO(object):
 
         # make dump counter
         self.dumpcount = itertools.count()
+        # if picking-up, don't do initial dump
+        if pick_up:
+            next(self.dumpcount)
 
         if self.output.dump_vtus:
             # setup pvd output file
@@ -448,6 +451,9 @@ class IO(object):
 
             # make point data dump counter
             self.pddumpcount = itertools.count()
+            # if picking-up, don't do initial dump
+            if pick_up:
+                next(self.pddumpcount)
 
             # set frequency of point data output - defaults to
             # dumpfreq if not set by user
@@ -472,6 +478,9 @@ class IO(object):
 
             # make a checkpoint counter
             self.chkptcount = itertools.count()
+            # if picking-up, don't do initial dump
+            if pick_up:
+                next(self.chkptcount)
 
         # dump initial fields
         if not pick_up:

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -100,7 +100,7 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
 
     # Set up mesh
     nlayers = 5   # horizontal layers
-    columns = 15  # number of columns
+    columns = 5   # number of columns
     L = 3.e5
     m = PeriodicIntervalMesh(columns, L)
     dt = 0.2
@@ -176,16 +176,6 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
             f'Checkpointed and picked up field {field_name} is not equal'
 
     # ------------------------------------------------------------------------ #
-    # Pick up from checkpoint and run *same* timestepper for 2 more time steps
-    # ------------------------------------------------------------------------ #
-
-    # Wipe fields from second time stepper
-    if checkpoint_method == 'dumbcheckpoint':
-        # Get an error when picking up fields with the same stepper with new method
-        initialise_fields(eqns_2, stepper_2)
-        stepper_2.run(t=2*dt, tmax=4*dt, pick_up=True)
-
-    # ------------------------------------------------------------------------ #
     # Run *new* timestepper for 2 time steps
     # ------------------------------------------------------------------------ #
 
@@ -200,6 +190,16 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
         mesh = pick_up_mesh(output_3, mesh_name)
     stepper_3, _ = set_up_model_objects(mesh, dt, output_3, stepper_type)
     stepper_3.run(t=2*dt, tmax=4*dt, pick_up=True)
+
+    # ------------------------------------------------------------------------ #
+    # Pick up from checkpoint and run *same* timestepper for 2 more time steps
+    # ------------------------------------------------------------------------ #
+    # Done after stepper_3, as we don't want to checkpoint again
+    # Wipe fields from second time stepper
+    if checkpoint_method == 'dumbcheckpoint':
+        # Get an error when picking up fields with the same stepper with new method
+        initialise_fields(eqns_2, stepper_2)
+        stepper_2.run(t=2*dt, tmax=4*dt, pick_up=True)
 
     # ------------------------------------------------------------------------ #
     # Compare fields against saved values for run without checkpointing
@@ -225,3 +225,4 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
         error = np.linalg.norm(diff_array) / np.linalg.norm(stepper_1.fields(field_name).dat.data)
         assert error < 1e-8, \
             f'Checkpointed field {field_name} with new time stepper is not equal to non-checkpointed field'
+


### PR DESCRIPTION
I have been testing out our checkpointing more. This PR changes some of the counters for checkpointing / dumping to make the output nicer when we've picked up from a previously checkpointed run.

Our checkpointing test was also only fortuitously working before. I had to change the order in which we test things in order to get this to work now.

As an aside, our checkpointing will work best if `chkptfreq` and `dumpfreq` are the same.