### PR TITLE
Tiny fix to prevent all ranks trying to make directory

### DIFF
--- a/gusto/logging.py
+++ b/gusto/logging.py
@@ -186,7 +186,6 @@ def update_logfile_location(new_path, comm):
         fh.close()
         logger.removeHandler(fh)
 
-        os.makedirs(new_path, exist_ok=True)
         if parallel_log in ["FILE", "BOTH"]:
             # If all ranks are logging wait here in case a directory is being created
             comm.Barrier()


### PR DESCRIPTION
I have been testing out our parallel logging which has been super useful. To get it to work, I had to ensure that we only create the results directory in one place (`io.setup_dump`), so this removes a line to create this directory when the log files are moved. 