### PR TITLE
Change some new python in creating solver parameters

### DIFF
--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -303,8 +303,10 @@ class ExplicitTimeDiscretisation(TimeDiscretisation):
         problem = NonlinearVariationalProblem(self.lhs - self.rhs, self.x_out, bcs=self.bcs)
         solver_name = self.field_name+self.__class__.__name__
         # If snes_type not specified by user, set this to ksp only to avoid outer Newton iteration
-        return NonlinearVariationalSolver(problem, solver_parameters={'snes_type': 'ksponly'}
-                                          | self.solver_parameters, options_prefix=solver_name)
+        if 'snes_type' not in self.solver_parameters.keys():
+            self.solver_parameters['snes_type'] = 'ksponly'
+        return NonlinearVariationalSolver(problem, solver_parameters=self.solver_parameters,
+                                          options_prefix=solver_name)
 
     @abstractmethod
     def apply_cycle(self, x_out, x_in):


### PR DESCRIPTION
This PR removes the | operator for combining solver parameter dicts in `time_discretisation.py` as it is not supported in python3.8 (which I need for Isambard!)