### PR TITLE
Unique physics labels

### DIFF
--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -6,6 +6,85 @@ from gusto.configuration import IntegrateByParts, TransportEquationType
 from gusto.fml.form_manipulation_language import Term, Label, LabelledForm
 from types import MethodType
 
+dynamics_label = Label("dynamics", validator=lambda value: type(value) is str)
+physics_label = Label("physics", validator=lambda value: type(value) is str)
+
+
+class DynamicsLabel(Label):
+    """A label for a fluid dynamics term."""
+    def __call__(self, target, value=None):
+        """
+        Applies the label to a form or term, and additionally labels the term as
+        a dynamics term.
+
+        Args:
+            target (:class:`ufl.Form`, :class:`Term` or :class:`LabelledForm`):
+                the form, term or labelled form to be labelled.
+            value (..., optional): the value to attach to this label. Defaults
+                to None.
+
+        Returns:
+            :class:`Term` or :class:`LabelledForm`: a :class:`Term` is returned
+                if the target is a :class:`Term`, otherwise a
+                :class:`LabelledForm` is returned.
+        """
+
+        new_target = dynamics_label(target, self.label)
+
+        if isinstance(new_target, LabelledForm):
+            # Need to be very careful in using super().__call__ method as the
+            # underlying __call__ method calls itself to act upon multiple terms
+            # in a LabelledForm. We can avoid this by special handling of the
+            # LabelledForm case
+            labelled_terms = (Label.__call__(self, t, value) for t in new_target.terms)
+            return LabelledForm(*labelled_terms)
+        else:
+            super().__call__(new_target, value)
+
+
+class PhysicsLabel(Label):
+    """A label for a physics parametrisation term."""
+    def __init__(self, label, *, value=True, validator=lambda value: type(value) == MethodType):
+        """
+        Args:
+            label (str): the name of the label.
+            value (..., optional): the value for the label to take. Can be any
+                type (subject to the validator). Defaults to True.
+            validator (func, optional): function to check the validity of any
+                value later passed to the label. Defaults to None.
+        """
+        super().__init__(label, value=value, validator=validator)
+
+    def __call__(self, target, value=None):
+        """
+        Applies the label to a form or term, and additionally labels the term as
+        a physics term.
+
+        Args:
+            target (:class:`ufl.Form`, :class:`Term` or :class:`LabelledForm`):
+                the form, term or labelled form to be labelled.
+            value (..., optional): the value to attach to this label. Defaults
+                to None.
+
+        Returns:
+            :class:`Term` or :class:`LabelledForm`: a :class:`Term` is returned
+                if the target is a :class:`Term`, otherwise a
+                :class:`LabelledForm` is returned.
+        """
+
+        new_target = physics_label(target, self.label)
+
+        if isinstance(new_target, LabelledForm):
+            # Need to be very careful in using super().__call__ method as the
+            # underlying __call__ method calls itself to act upon multiple terms
+            # in a LabelledForm. We can avoid this by special handling of the
+            # LabelledForm case
+            labelled_terms = (Label.__call__(self, t, value) for t in new_target.terms)
+            return LabelledForm(*labelled_terms)
+        else:
+            super().__call__(new_target, value)
+
+
 # ---------------------------------------------------------------------------- #
 # Common Labels
 # ---------------------------------------------------------------------------- #
@@ -13,11 +92,10 @@ from types import MethodType
 time_derivative = Label("time_derivative")
 transport = Label("transport", validator=lambda value: type(value) == TransportEquationType)
 diffusion = Label("diffusion")
-physics = Label("physics", validator=lambda value: type(value) == MethodType)
 transporting_velocity = Label("transporting_velocity", validator=lambda value: type(value) in [Function, ufl.tensors.ListTensor])
 prognostic = Label("prognostic", validator=lambda value: type(value) == str)
-pressure_gradient = Label("pressure_gradient")
-coriolis = Label("coriolis")
+pressure_gradient = DynamicsLabel("pressure_gradient")
+coriolis = DynamicsLabel("coriolis")
 linearisation = Label("linearisation", validator=lambda value: type(value) in [LabelledForm, Term])
 ibp_label = Label("ibp", validator=lambda value: type(value) == IntegrateByParts)
 hydrostatic = Label("hydrostatic", validator=lambda value: type(value) in [LabelledForm, Term])

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -216,6 +216,7 @@ class SaturationAdjustment(PhysicsParametrisation):
             x_in (:class:`Function`): the (mixed) field to be evolved.
             dt (:class:`Constant`): the time interval for the scheme.
         """
+        logger.info(f'Evaluating physics parametrisation {self.label.label}')
         # Update the values of internal variables
         self.dt.assign(dt)
         self.X.assign(x_in)
@@ -372,6 +373,7 @@ class Fallout(PhysicsParametrisation):
             x_in (:class:`Function`): the (mixed) field to be evolved.
             dt (:class:`Constant`): the time interval for the scheme.
         """
+        logger.info(f'Evaluating physics parametrisation {self.label.label}')
         self.X.assign(x_in)
         if self.moments != AdvectedMoments.M0:
             self.determine_v.project()
@@ -476,6 +478,7 @@ class Coalescence(PhysicsParametrisation):
             x_in (:class:`Function`): the (mixed) field to be evolved.
             dt (:class:`Constant`): the time interval for the scheme.
         """
+        logger.info(f'Evaluating physics parametrisation {self.label.label}')
         # Update the values of internal variables
         self.dt.assign(dt)
         self.rain.assign(x_in.subfunctions[self.rain_idx])
@@ -644,6 +647,7 @@ class EvaporationOfRain(PhysicsParametrisation):
             x_in (:class:`Function`): the (mixed) field to be evolved.
             dt (:class:`Constant`): the time interval for the scheme.
         """
+        logger.info(f'Evaluating physics parametrisation {self.label.label}')
         # Update the values of internal variables
         self.dt.assign(dt)
         self.X.assign(x_in)
@@ -790,6 +794,7 @@ class InstantRain(PhysicsParametrisation):
             dt: (:class: 'Constant'): the timestep, which can be the time
                 interval for the scheme.
         """
+        logger.info(f'Evaluating physics parametrisation {self.label.label}')
         if self.convective_feedback:
             self.D.assign(x_in.subfunctions[self.VD_idx])
         if self.time_varying_saturation:
@@ -982,7 +987,7 @@ class SWSaturationAdjustment(PhysicsParametrisation):
             dt: (:class: 'Constant'): the timestep, which can be the time
                 interval for the scheme.
         """
-
+        logger.info(f'Evaluating physics parametrisation {self.label.label}')
         if self.convective_feedback:
             self.D.assign(x_in.split()[self.VD_idx])
         if self.thermal_feedback:

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -15,7 +15,7 @@ from gusto.configuration import EmbeddedDGOptions, RecoveryOptions
 from gusto.fml import (
     replace_subject, replace_test_function, Term, all_terms, drop
 )
-from gusto.labels import time_derivative, prognostic, physics
+from gusto.labels import time_derivative, prognostic, physics_label
 from gusto.logging import logger, DEBUG, logging_ksp_monitor_true_residual
 from gusto.wrappers import *
 import numpy as np
@@ -135,9 +135,13 @@ class TimeDiscretisation(object, metaclass=ABCMeta):
                 map_if_false=drop)
 
         self.evaluate_source = []
+        self.physics_names = []
         for t in self.residual:
-            if t.has_label(physics):
-                self.evaluate_source.append(t.get(physics))
+            if t.has_label(physics_label):
+                physics_name = t.get(physics_label)
+                if t.labels[physics_name] not in self.physics_names:
+                    self.evaluate_source.append(t.labels[physics_name])
+                    self.physics_names.append(t.labels[physics_name])
 
         # -------------------------------------------------------------------- #
         # Set up Wrappers
@@ -328,8 +332,6 @@ class ExplicitTimeDiscretisation(TimeDiscretisation):
         """
         self.x0.assign(x_in)
         for i in range(self.ncycles):
-            for evaluate in self.evaluate_source:
-                evaluate(x_in, self.dt)
             self.apply_cycle(self.x1, self.x0)
             self.x0.assign(self.x1)
         x_out.assign(self.x1)

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -9,7 +9,7 @@ from gusto.fields import TimeLevelFields, StateFields
 from gusto.forcing import Forcing
 from gusto.labels import (
     transport, diffusion, time_derivative, linearisation, prognostic,
-    physics, transporting_velocity
+    physics_label, transporting_velocity
 )
 from gusto.linear_solvers import LinearTimesteppingSolver
 from gusto.logging import logger
@@ -249,9 +249,10 @@ class Timestepper(BaseTimestepper):
                 in which case the terms follow the original discretisation in
                 the equation.
             physics_parametrisations: (iter, optional): an iterable of
-                :class:`Physics` objects that describe physical parametrisations to be included
-                to add to the equation. They can only be used when the time
-                discretisation `scheme` is explicit. Defaults to None.
+                :class:`PhysicsParametrisation` objects that describe physical
+                parametrisations to be included to add to the equation. They can
+                only be used when the time discretisation `scheme` is explicit.
+                Defaults to None.
         """
         self.scheme = scheme
         if spatial_methods is not None:
@@ -318,10 +319,10 @@ class SplitPhysicsTimestepper(Timestepper):
                 in which case the terms follow the original discretisation in
                 the equation.
             physics_schemes: (list, optional): a list of tuples of the form
-                (:class:`Physics`, :class:`TimeDiscretisation`), pairing physics
-                parametrisations and timestepping schemes to use for each.
-                Timestepping schemes for physics must be explicit. Defaults to
-                None.
+                (:class:`PhysicsParametrisation`, :class:`TimeDiscretisation`),
+                pairing physics parametrisations and timestepping schemes to use
+                for each. Timestepping schemes for physics must be explicit.
+                Defaults to None.
         """
 
         # As we handle physics differently to the Timestepper, these are not
@@ -338,7 +339,7 @@ class SplitPhysicsTimestepper(Timestepper):
             assert isinstance(phys_scheme, ExplicitTimeDiscretisation), \
                 "Only explicit time discretisations can be used for physics"
             apply_bcs = False
-            phys_scheme.setup(equation, apply_bcs, physics)
+            phys_scheme.setup(equation, apply_bcs, physics_label)
 
     @property
     def transporting_velocity(self):
@@ -348,7 +349,7 @@ class SplitPhysicsTimestepper(Timestepper):
         self.setup_equation(self.equation)
         # Go through and label all non-physics terms with a "dynamics" label
         dynamics = Label('dynamics')
-        self.equation.label_terms(lambda t: not any(t.has_label(time_derivative, physics)), dynamics)
+        self.equation.label_terms(lambda t: not any(t.has_label(time_derivative, physics_label)), dynamics)
         apply_bcs = True
         self.scheme.setup(self.equation, apply_bcs, dynamics)
         self.setup_transporting_velocity(self.scheme)
@@ -395,10 +396,10 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
                 ``(field_name, scheme)`` indicating the fields to diffuse, and the
                 the :class:`~.TimeDiscretisation` to use. Defaults to None.
             physics_schemes: (list, optional): a list of tuples of the form
-                (:class:`Physics`, :class:`TimeDiscretisation`), pairing physics
-                parametrisations and timestepping schemes to use for each.
-                Timestepping schemes for physics must be explicit. Defaults to
-                None.
+                (:class:`PhysicsParametrisation`, :class:`TimeDiscretisation`),
+                pairing physics parametrisations and timestepping schemes to use
+                for each. Timestepping schemes for physics must be explicit.
+                Defaults to None.
 
         :kwargs: maxk is the number of outer iterations, maxi is the number
             of inner iterations and alpha is the offcentering parameter
@@ -530,7 +531,7 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
             scheme.setup(self.equation, apply_bcs, diffusion)
         for _, scheme in self.physics_schemes:
             apply_bcs = True
-            scheme.setup(self.equation, apply_bcs, physics)
+            scheme.setup(self.equation, apply_bcs, physics_label)
 
     def copy_active_tracers(self, x_in, x_out):
         """
@@ -639,9 +640,10 @@ class PrescribedTransport(Timestepper):
                 Timestepping schemes for physics must be explicit. Defaults to
                 None.
             physics_parametrisations: (iter, optional): an iterable of
-                :class:`Physics` objects that describe physical parametrisations to be included
-                to add to the equation. They can only be used when the time
-                discretisation `scheme` is explicit. Defaults to None.
+                :class:`PhysicsParametrisation` objects that describe physical
+                parametrisations to be included to add to the equation. They can
+                only be used when the time discretisation `scheme` is explicit.
+                Defaults to None.
         """
 
         if isinstance(transport_method, TransportMethod):


### PR DESCRIPTION
This fixes our physics capability, to give us real control over which physics schemes are called and when.

This is done by:
- the `Physics` class is renamed as `PhysicsParametrisation` which will help us avoid confusion
- introducing a `PhysicsLabel` which is a type of new type of label, which actually gives a term two labels:
  - `physics`: with the value as a string describing the physics parametrisation
  - the unique label for that parametrisation, which stores the `evaluate` method as before
- ensuring that each `PhysicsParametrisation` object has a label
- when the `TimeDiscretisation` sets up its evaluate methods, it now ensures that they are unique
- a rogue extra call to `evaluate` physics schemes has been removed
