### PR TITLE
Turn off checkpointing by default and allow diagnostic

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -88,7 +88,8 @@ class OutputParameters(Configuration):
     dumplist = None
     dumplist_latlon = []
     dump_diagnostics = True
-    checkpoint = True
+    diagfreq = 1
+    checkpoint = False
     checkpoint_method = 'checkpointfile'
     checkpoint_pickup_filename = None
     chkptfreq = 1

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -434,6 +434,11 @@ class IO(object):
                                                        self.mesh.comm,
                                                        create=to_create)
 
+            # if picking-up, don't do initial dump
+            self.diagcount = itertools.count()
+            if pick_up:
+                next(self.diagcount)
+
         if len(self.output.point_data) > 0:
             # set up point data output
             pointdata_filename = self.dumpdir+"/point_data.nc"
@@ -607,7 +612,7 @@ class IO(object):
         for field in self.diagnostic_fields:
             field.compute()
 
-        if output.dump_diagnostics:
+        if output.dump_diagnostics and (next(self.diagcount) % output.diagfreq) == 0:
             # Output diagnostic data
             self.diagnostic_output.dump(state_fields, t)
 

--- a/integration-tests/equations/test_dry_compressible.py
+++ b/integration-tests/equations/test_dry_compressible.py
@@ -35,7 +35,7 @@ def run_dry_compressible(tmpdir):
 
     # I/O
     output = OutputParameters(dirname=tmpdir+"/dry_compressible",
-                              dumpfreq=2, chkptfreq=2)
+                              dumpfreq=2, chkptfreq=2, checkpoint=True)
     io = IO(domain, output)
 
     # Transport schemes
@@ -93,7 +93,8 @@ def run_dry_compressible(tmpdir):
     checkpoint_name = 'dry_compressible_chkpt.h5'
     new_path = join(abspath(dirname(__file__)), '..', f'data/{checkpoint_name}')
     check_output = OutputParameters(dirname=tmpdir+"/dry_compressible",
-                                    checkpoint_pickup_filename=new_path)
+                                    checkpoint_pickup_filename=new_path,
+                                    checkpoint=True)
     check_mesh = pick_up_mesh(check_output, mesh_name)
     check_domain = Domain(check_mesh, dt, "CG", 1)
     check_eqn = CompressibleEulerEquations(check_domain, parameters)

--- a/integration-tests/equations/test_incompressible.py
+++ b/integration-tests/equations/test_incompressible.py
@@ -34,7 +34,7 @@ def run_incompressible(tmpdir):
 
     # I/O
     output = OutputParameters(dirname=tmpdir+"/incompressible",
-                              dumpfreq=2, chkptfreq=2)
+                              dumpfreq=2, chkptfreq=2, checkpoint=True)
     io = IO(domain, output)
 
     # Transport Schemes
@@ -87,7 +87,8 @@ def run_incompressible(tmpdir):
     checkpoint_name = 'incompressible_chkpt.h5'
     new_path = join(abspath(dirname(__file__)), '..', f'data/{checkpoint_name}')
     check_output = OutputParameters(dirname=tmpdir+"/incompressible",
-                                    checkpoint_pickup_filename=new_path)
+                                    checkpoint_pickup_filename=new_path,
+                                    checkpoint=True)
     check_mesh = pick_up_mesh(check_output, mesh_name)
     check_domain = Domain(check_mesh, dt, "CG", 1)
     check_eqn = IncompressibleBoussinesqEquations(check_domain, parameters)

--- a/integration-tests/equations/test_linear_sw_wave.py
+++ b/integration-tests/equations/test_linear_sw_wave.py
@@ -36,6 +36,7 @@ def run_linear_sw_wave(tmpdir):
     output = OutputParameters(
         dirname=str(tmpdir)+"/linear_sw_wave",
         dumpfreq=1,
+        checkpoint=True
     )
     io = IO(domain, output)
     transport_methods = [DefaultTransport(eqns, "D")]
@@ -70,7 +71,8 @@ def run_linear_sw_wave(tmpdir):
     checkpoint_name = 'linear_sw_wave_chkpt.h5'
     new_path = join(abspath(dirname(__file__)), '..', f'data/{checkpoint_name}')
     check_output = OutputParameters(dirname=tmpdir+"/linear_sw_wave",
-                                    checkpoint_pickup_filename=new_path)
+                                    checkpoint_pickup_filename=new_path,
+                                    checkpoint=True)
     check_mesh = pick_up_mesh(check_output, mesh_name)
     check_domain = Domain(check_mesh, dt, 'BDM', 1)
     check_eqn = ShallowWaterEquations(check_domain, parameters, fexpr=fexpr)

--- a/integration-tests/equations/test_moist_compressible.py
+++ b/integration-tests/equations/test_moist_compressible.py
@@ -36,7 +36,7 @@ def run_moist_compressible(tmpdir):
 
     # I/O
     output = OutputParameters(dirname=tmpdir+"/moist_compressible",
-                              dumpfreq=2, chkptfreq=2)
+                              dumpfreq=2, checkpoint=True, chkptfreq=2)
     io = IO(domain, output)
 
     # Transport schemes
@@ -99,7 +99,8 @@ def run_moist_compressible(tmpdir):
     checkpoint_name = 'moist_compressible_chkpt.h5'
     new_path = join(abspath(dirname(__file__)), '..', f'data/{checkpoint_name}')
     check_output = OutputParameters(dirname=tmpdir+"/moist_compressible",
-                                    checkpoint_pickup_filename=new_path)
+                                    checkpoint_pickup_filename=new_path,
+                                    checkpoint=True)
     check_mesh = pick_up_mesh(check_output, mesh_name)
     check_domain = Domain(check_mesh, dt, "CG", 1)
     check_eqn = CompressibleEulerEquations(check_domain, parameters, active_tracers=tracers)

--- a/integration-tests/equations/test_sw_fplane.py
+++ b/integration-tests/equations/test_sw_fplane.py
@@ -32,6 +32,7 @@ def run_sw_fplane(tmpdir):
     output = OutputParameters(
         dirname=str(tmpdir)+"/sw_fplane",
         dumpfreq=1,
+        checkpoint=True
     )
 
     io = IO(domain, output, diagnostic_fields=[CourantNumber()])
@@ -105,7 +106,8 @@ def run_sw_fplane(tmpdir):
     checkpoint_name = 'sw_fplane_chkpt.h5'
     new_path = join(abspath(dirname(__file__)), '..', f'data/{checkpoint_name}')
     check_output = OutputParameters(dirname=tmpdir+"/sw_fplane",
-                                    checkpoint_pickup_filename=new_path)
+                                    checkpoint_pickup_filename=new_path,
+                                    checkpoint=True)
     check_mesh = pick_up_mesh(check_output, mesh_name)
     check_domain = Domain(check_mesh, dt, 'RTCF', 1)
     check_eqn = ShallowWaterEquations(check_domain, parameters, fexpr=fexpr)

--- a/integration-tests/model/test_checkpointing.py
+++ b/integration-tests/model/test_checkpointing.py
@@ -116,12 +116,14 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
     output_1 = OutputParameters(
         dirname=dirname_1,
         dumpfreq=1,
+        checkpoint=True,
         checkpoint_method=checkpoint_method,
         chkptfreq=4,
     )
     output_2 = OutputParameters(
         dirname=dirname_2,
         dumpfreq=1,
+        checkpoint=True,
         checkpoint_method=checkpoint_method,
         chkptfreq=2,
     )
@@ -154,6 +156,7 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
         dirname=dirname_3,
         dumpfreq=1,
         chkptfreq=2,
+        checkpoint=True,
         checkpoint_method=checkpoint_method,
         checkpoint_pickup_filename=chkpt_2_path,
     )
@@ -193,6 +196,7 @@ def test_checkpointing(tmpdir, stepper_type, checkpoint_method):
         dirname=dirname_3,
         dumpfreq=1,
         chkptfreq=2,
+        checkpoint=True,
         checkpoint_method=checkpoint_method,
         checkpoint_pickup_filename=chkpt_2_path
     )


### PR DESCRIPTION
In an effort to speed up our simulations, I am suggesting that we:
- turn off checkpointing by default (this should make us think about when we want to checkpoint)
- have an option to change the frequency of outputting global diagnostics (since these are presumably quite expensive in parallel)