### PR TITLE
Fix a bug when picking up from a checkpoint restart in parallel

### DIFF
--- a/gusto/io.py
+++ b/gusto/io.py
@@ -426,6 +426,11 @@ class IO(object):
                     nc_field_file = Dataset(self.nc_filename, 'r')
                     self.field_t_idx = len(nc_field_file['time'][:])
                     nc_field_file.close()
+                else:
+                    self.field_t_idx = None
+                # Send information to other processors
+                self.field_t_idx = self.mesh.comm.bcast(self.field_t_idx, root=0)
+
             else:
                 # File needs creating
                 self.create_nc_dump(self.nc_filename, space_names)


### PR DESCRIPTION
This fixes a bug in the way that the time is indexed in the netCDF outputting when picking up from a checkpoint restart in parallel.

This avoids deadlocks when we pick up in parallel (issue #447)