### PR TITLE
Rewrite spaces again

### DIFF
--- a/gusto/domain.py
+++ b/gusto/domain.py
@@ -73,6 +73,8 @@ class Domain(object):
         self.spaces = Spaces(mesh)
         self.spaces.build_compatible_spaces(self.family, self.horizontal_degree,
                                             self.vertical_degree)
+        if self.horizontal_degree == 0 or self.vertical_degree == 0:
+            self.spaces.build_dg1_equispaced()
 
         # -------------------------------------------------------------------- #
         # Determine some useful aspects of domain

--- a/gusto/domain.py
+++ b/gusto/domain.py
@@ -73,8 +73,7 @@ class Domain(object):
         self.spaces = Spaces(mesh)
         self.spaces.build_compatible_spaces(self.family, self.horizontal_degree,
                                             self.vertical_degree)
-        if self.horizontal_degree == 0 or self.vertical_degree == 0:
-            self.spaces.build_dg1_equispaced()
+        self.spaces.build_dg1_equispaced()
 
         # -------------------------------------------------------------------- #
         # Determine some useful aspects of domain

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -84,9 +84,8 @@ class AdvectionEquation(PrognosticEquation):
         super().__init__(domain, function_space, field_name)
 
         if Vu is not None:
-            V = domain.spaces("HDiv", V=Vu, overwrite_space=True)
-        else:
-            V = domain.spaces("HDiv")
+            domain.spaces.add_space("HDiv", Vu, overwrite_space=True)
+        V = domain.spaces("HDiv")
         u = self.prescribed_fields("u", V)
 
         test = self.test
@@ -115,9 +114,8 @@ class ContinuityEquation(PrognosticEquation):
         super().__init__(domain, function_space, field_name)
 
         if Vu is not None:
-            V = domain.spaces("HDiv", V=Vu, overwrite_space=True)
-        else:
-            V = domain.spaces("HDiv")
+            domain.spaces.add_space("HDiv", Vu, overwrite_space=True)
+        V = domain.spaces("HDiv")
         u = self.prescribed_fields("u", V)
 
         test = self.test
@@ -174,9 +172,8 @@ class AdvectionDiffusionEquation(PrognosticEquation):
         super().__init__(domain, function_space, field_name)
 
         if Vu is not None:
-            V = domain.spaces("HDiv", V=Vu, overwrite_space=True)
-        else:
-            V = domain.spaces("HDiv")
+            domain.spaces.add_space("HDiv", Vu, overwrite_space=True)
+        V = domain.spaces("HDiv")
         u = self.prescribed_fields("u", V)
 
         test = self.test
@@ -552,9 +549,8 @@ class CoupledTransportEquation(PrognosticEquationSet):
         PrognosticEquation.__init__(self, domain, W, full_field_name)
 
         if Vu is not None:
-            V = domain.spaces("HDiv", V=Vu, overwrite_space=True)
-        else:
-            V = domain.spaces("HDiv")
+            domain.spaces.add_space("HDiv", Vu, overwrite_space=True)
+        V = domain.spaces("HDiv")
         _ = self.prescribed_fields("u", V)
 
         self.tests = TestFunctions(W)

--- a/gusto/function_spaces.py
+++ b/gusto/function_spaces.py
@@ -147,6 +147,19 @@ class Spaces(object):
                 vertical_degree = degree if vertical_degree is None else vertical_degree
 
                 # Loop through name and family combinations
+                if name in ["HDiv", "HCurl", "theta", "L2", "H1"]:
+                    # This is one of the compatible finite element spaces, so
+                    # look for the space in the de Rham dictionary
+                    degree_pair = (horizontal_degree, vertical_degree)
+                    # If the de Rham complex doesn't exist yet, create it
+                    if degree_pair not in self._de_rham_dict.keys():
+                        self._de_rham_dict[degree_pair] = \
+                            DeRhamComplex(self.mesh, hdiv_family,
+                                          horizontal_degree, vertical_degree)
+
+                    de_rham_complex = self._de_rham_dict[degree_pair]
+                    value = de_rham_complex(name)
+
                 if name == "HDiv" and family in ["BDM", "RT", "CG", "RTCF", "RTF", "BDMF"]:
                     hdiv_family = hcurl_hdiv_dict[family]
                     value = self.build_hdiv_space(hdiv_family, horizontal_degree, vertical_degree)
@@ -496,6 +509,12 @@ class Spaces(object):
         self.base_elt_vert_dg[key] = FiniteElement("DG", interval, vertical_degree)
 
         self._initialised_base_spaces[(horizontal_degree, vertical_degree)] = True
+
+
+class DeRhamComplex(object):
+
+    def __init__(self, mesh, horizontal_degree, vertical_degree=None):
+
 
 
 def check_degree_args(name, mesh, degree, horizontal_degree, vertical_degree):

--- a/gusto/function_spaces.py
+++ b/gusto/function_spaces.py
@@ -188,6 +188,8 @@ class Spaces(object):
         setattr(self, "L2", de_rham_complex.L2)
         # Register L2 space as DG also
         setattr(self, "DG", de_rham_complex.L2)
+        if hasattr(de_rham_complex, 'theta'):
+         setattr(self, "theta", de_rham_complex.theta)
 
     def build_dg1_equispaced(self):
         """

--- a/gusto/function_spaces.py
+++ b/gusto/function_spaces.py
@@ -189,7 +189,7 @@ class Spaces(object):
         # Register L2 space as DG also
         setattr(self, "DG", de_rham_complex.L2)
         if hasattr(de_rham_complex, 'theta'):
-         setattr(self, "theta", de_rham_complex.theta)
+            setattr(self, "theta", de_rham_complex.theta)
 
     def build_dg1_equispaced(self):
         """

--- a/gusto/function_spaces.py
+++ b/gusto/function_spaces.py
@@ -161,15 +161,17 @@ class Spaces(object):
 
         if vertical_degree is not None:
             degree_key = (horizontal_degree, vertical_degree)
-            if complex_name is None:
-                if horizontal_degree != vertical_degree:
-                    complex_name = f'_{horizontal_degree}_{vertical_degree}'
-                else:
-                    complex_name = f'_{horizontal_degree}'
         else:
             degree_key = horizontal_degree
-            if complex_name is None:
-                complex_name = f'_{horizontal_degree}'
+
+        # Determine suffix to spaces
+        if complex_name is None and len(self.de_rham_complex.keys()) > 0:
+            if vertical_degree is not None and horizontal_degree != vertical_degree:
+                complex_name = f'{horizontal_degree}_{vertical_degree}'
+            else:
+                complex_name = f'{horizontal_degree}'
+        else:
+            complex_name = ''
 
         if degree_key in self.de_rham_complex.keys():
             raise RuntimeError(f'de Rham complex for degree {degree_key} has '
@@ -182,14 +184,14 @@ class Spaces(object):
 
         # Set the spaces as attributes of the space container
         self.de_rham_complex[degree_key] = de_rham_complex
-        setattr(self, "H1", de_rham_complex.H1)
-        setattr(self, "HCurl", de_rham_complex.HCurl)
-        setattr(self, "HDiv", de_rham_complex.HDiv)
-        setattr(self, "L2", de_rham_complex.L2)
+        setattr(self, "H1"+complex_name, de_rham_complex.H1)
+        setattr(self, "HCurl"+complex_name, de_rham_complex.HCurl)
+        setattr(self, "HDiv"+complex_name, de_rham_complex.HDiv)
+        setattr(self, "L2"+complex_name, de_rham_complex.L2)
         # Register L2 space as DG also
-        setattr(self, "DG", de_rham_complex.L2)
-        if hasattr(de_rham_complex, 'theta'):
-            setattr(self, "theta", de_rham_complex.theta)
+        setattr(self, "DG"+complex_name, de_rham_complex.L2)
+        if hasattr(de_rham_complex, "theta"+complex_name):
+            setattr(self, "theta"+complex_name, de_rham_complex.theta)
 
     def build_dg1_equispaced(self):
         """

--- a/gusto/function_spaces.py
+++ b/gusto/function_spaces.py
@@ -74,7 +74,7 @@ class Spaces(object):
 
     def __call__(self, name):
         """
-        Returns a space, and also creates it if it is not created yet.
+        Returns a space from the space container.
 
         Args:
             name (str): the name of the space.
@@ -111,19 +111,10 @@ class Spaces(object):
 
     def create_space(self, name, family, degree, overwrite_space=False):
         """
-        Returns a space, and also creates it if it is not created yet.
-
-        If a space needs creating, it may be that more arguments (such as the
-        family and degree) need to be provided. Alternatively a space can be
-        passed in to be stored in the space container.
-
-        For extruded meshes, it is possible to seperately specify the horizontal
-        and vertical degrees of the elements. Alternatively, if these degrees
-        should be the same then this can be specified through the "degree"
-        argument.
+        Creates a space and adds it to the container..
 
         Args:
-            name (str): the name of the space.
+            name (str): the name to give to the space.
             family (str): name of the finite element family to be created.
             degree (int): the element degree used for the space.
             overwrite_space (bool, optional): Logical to allow space existing in
@@ -170,7 +161,7 @@ class Spaces(object):
                 complex_name = f'{horizontal_degree}_{vertical_degree}'
             else:
                 complex_name = f'{horizontal_degree}'
-        else:
+        elif complex_name is None:
             complex_name = ''
 
         if degree_key in self.de_rham_complex.keys():

--- a/gusto/function_spaces.py
+++ b/gusto/function_spaces.py
@@ -19,7 +19,9 @@ hdiv_hcurl_dict = {'RT': 'RTE',
                    'RTCF': 'RTCE',
                    'RTCE': 'RTCE',
                    'CG': 'DG',
-                   'BDFM': None}
+                   'BDFM': None,
+                   'BDMCF': 'BDMCE',
+                   'BDMCE': 'BDMCE'}
 
 # HCurl spaces are keys, HDiv spaces are values
 # Can't just reverse the other dictionary as values are not necessarily unique
@@ -32,7 +34,9 @@ hcurl_hdiv_dict = {'RT': 'RTF',
                    'RTCE': 'RTCF',
                    'RTCF': 'RTCF',
                    'CG': 'CG',
-                   'BDFM': 'BDFM'}
+                   'BDFM': 'BDFM',
+                   'BDMCF': 'BDMCF',
+                   'BDMCE': 'BDMCF'}
 
 
 # Degree to use for H1 space for a particular family
@@ -49,7 +53,7 @@ def h1_degree(family, l2_degree):
     """
     if family in ['CG', 'RT', 'RTE', 'RTF', 'RTCE', 'RTCF']:
         return l2_degree + 1
-    elif family in ['BDM', 'BDME', 'BDMF']:
+    elif family in ['BDM', 'BDME', 'BDMF', 'BDMCE', 'BDMCF']:
         return l2_degree + 2
     elif family == 'BDFM':
         return l2_degree + 1
@@ -66,20 +70,46 @@ class Spaces(object):
         """
         self.mesh = mesh
         self.extruded_mesh = hasattr(mesh, "_base_mesh")
+        self.de_rham_complex = {}
 
-        # Make dictionaries to store base elements for extruded meshes
-        # Here the keys are the horizontal and vertical degrees
-        self._initialised_base_spaces = {}
-        self.base_elt_hori_hdiv = {}
-        self.base_elt_hori_hcurl = {}
-        self.base_elt_hori_dg = {}
-        self.base_elt_hori_cg = {}
-        self.base_elt_vert_cg = {}
-        self.base_elt_vert_dg = {}
+    def __call__(self, name):
+        """
+        Returns a space, and also creates it if it is not created yet.
 
-    def __call__(self, name, family=None, degree=None,
-                 horizontal_degree=None, vertical_degree=None,
-                 V=None, overwrite_space=False):
+        Args:
+            name (str): the name of the space.
+
+        Returns:
+            :class:`FunctionSpace`: the desired function space.
+        """
+
+        if hasattr(self, name):
+            return getattr(self, name)
+
+        else:
+            raise ValueError(f'The space container has no space {name}')
+
+    def add_space(self, name, space, overwrite_space=False):
+        """
+        Adds a function space to the container.
+
+        Args:
+            name (str): the name of the space.
+            space (:class:`FunctionSpace`): the function space to be added to
+                the Space container..
+            overwrite_space (bool, optional): Logical to allow space existing in
+                container to be overwritten by an incoming space. Defaults to
+                False.
+        """
+
+        if hasattr(self, name) and not overwrite_space:
+            raise RuntimeError(f'Space {name} already exists. If you really '
+                               + 'to create it then set `overwrite_space` as '
+                               + 'to be True')
+
+        setattr(self, name, space)
+
+    def create_space(self, name, family, degree, overwrite_space=False):
         """
         Returns a space, and also creates it if it is not created yet.
 
@@ -94,19 +124,8 @@ class Spaces(object):
 
         Args:
             name (str): the name of the space.
-            family (str, optional): name of the finite element family to be
-                created. Defaults to None.
-            degree (int, optional): the element degree used for the space.
-                Defaults to None, in which case the horizontal degree must be
-                provided.
-            horizontal_degree (int, optional): the horizontal degree of the
-                finite element space to be created. Defaults to None.
-            vertical_degree (int, optional): the vertical degree of the
-                finite element space to be created. Defaults to None.
-            V (:class:`FunctionSpace`, optional): an existing space, to be
-                stored in the creator object. If this is provided, it will be
-                added to the creator and no other action will be taken. This
-                space will be returned. Defaults to None.
+            family (str): name of the finite element family to be created.
+            degree (int): the element degree used for the space.
             overwrite_space (bool, optional): Logical to allow space existing in
                 container to be overwritten by an incoming space. Defaults to
                 False.
@@ -115,70 +134,154 @@ class Spaces(object):
             :class:`FunctionSpace`: the desired function space.
         """
 
+        if hasattr(self, name) and not overwrite_space:
+            raise RuntimeError(f'Space {name} already exists. If you really '
+                               + 'to create it then set `overwrite_space` as '
+                               + 'to be True')
+
+        space = FunctionSpace(self.mesh, family, degree, name=name)
+        setattr(self, name, space)
+        return space
+
+    def build_compatible_spaces(self, family, horizontal_degree,
+                                vertical_degree=None, complex_name=None):
+        """
+        Builds the compatible spaces associated with some de Rham complex, and
+        sets the spaces as attributes to the underlying :class:`Spaces` object.
+
+        Args:
+            family (str): the family of the compatible spaces. This is either
+                the horizontal element of the HDiv or HCurl spaces.
+            horizontal_degree (int): the horizontal degree of the L2 space.
+            vertical_degree (int, optional): the vertical degree of the L2
+                space. Defaults to None.
+            complex_name (str, optional): optional name to pass to the
+                :class:`DeRhamComplex` object to be created. Defaults to None.
+        """
+
+        if vertical_degree is not None:
+            degree_key = (horizontal_degree, vertical_degree)
+            if complex_name is None:
+                if horizontal_degree != vertical_degree:
+                    complex_name = f'_{horizontal_degree}_{vertical_degree}'
+                else:
+                    complex_name = f'_{horizontal_degree}'
+        else:
+            degree_key = horizontal_degree
+            if complex_name is None:
+                complex_name = f'_{horizontal_degree}'
+
+        if degree_key in self.de_rham_complex.keys():
+            raise RuntimeError(f'de Rham complex for degree {degree_key} has '
+                               + 'already been created. Cannot create again.')
+
+        # Create the compatible space objects
+        de_rham_complex = DeRhamComplex(self.mesh, family, horizontal_degree,
+                                        vertical_degree=vertical_degree,
+                                        complex_name=complex_name)
+
+        # Set the spaces as attributes of the space container
+        self.de_rham_complex[degree_key] = de_rham_complex
+        setattr(self, "H1", de_rham_complex.H1)
+        setattr(self, "HCurl", de_rham_complex.HCurl)
+        setattr(self, "HDiv", de_rham_complex.HDiv)
+        setattr(self, "L2", de_rham_complex.L2)
+        # Register L2 space as DG also
+        setattr(self, "DG", de_rham_complex.L2)
+
+    def build_dg1_equispaced(self):
+        """
+        Builds the equispaced variant of the DG1 function space, which is used in
+        recovered finite element schemes.
+
+        Returns:
+            (:class:`FunctionSpace`): the equispaced DG1 function space.
+        """
+
+        if self.extruded_mesh:
+            cell = self.mesh._base_mesh.ufl_cell().cellname()
+            hori_elt = FiniteElement('DG', cell, 1, variant='equispaced')
+            vert_elt = FiniteElement('DG', interval, 1, variant='equispaced')
+            V_elt = TensorProductElement(hori_elt, vert_elt)
+        else:
+            cell = self.mesh.ufl_cell().cellname()
+            V_elt = FiniteElement('DG', cell, 1, variant='equispaced')
+
+        space = FunctionSpace(self.mesh, V_elt, name='DG1_equispaced')
+        setattr(self, 'DG1_equispaced', space)
+        return space
+
+
+class DeRhamComplex(object):
+    """Constructs and stores the function spaces forming a de Rham complex."""
+    def __init__(self, mesh, family, horizontal_degree, vertical_degree=None,
+                 complex_name=None):
+        """
+        Args:
+            mesh (:class:`Mesh`): _description_
+            family (str): name of the finite element family to be
+                created. Defaults to None.
+            horizontal_degree (int): the horizontal degree of the finite element
+                space to be created.
+            vertical_degree (int, optional): the vertical degree of the
+                finite element space to be created. Defaults to None.
+            complex_name (str, optional): suffix to give to the spaces created
+                in this complex. Defaults to None.
+        """
+
         implemented_families = ["DG", "CG", "RT", "RTF", "RTE", "RTCF", "RTCE",
-                                "BDM", "BDMF", "BDME", "BDFM"]
+                                "BDM", "BDMF", "BDME", "BDFM", "BDMCE", "BDMCF"]
         if family not in [None]+implemented_families:
             raise NotImplementedError(f'family {family} either not recognised '
                                       + 'or implemented in Gusto')
 
-        if hasattr(self, name) and (V is None or not overwrite_space):
-            # We have requested a space that should already have been created
-            if V is not None:
-                assert getattr(self, name) == V, \
-                    f'There is a conflict between the space {name} already ' + \
-                    'existing in the space container, and the space being passed to it'
-            return getattr(self, name)
+        self.mesh = mesh
+        self.extruded_mesh = hasattr(mesh, '_base_mesh')
+        self.family = family
+        self.complex_name = complex_name
+        self.build_base_spaces(family, horizontal_degree, vertical_degree)
+        self.build_compatible_spaces()
 
+    def build_base_spaces(self, family, horizontal_degree, vertical_degree=None):
+        """
+        Builds the :class:`FiniteElement` objects for the base mesh.
+
+        Args:
+            family (str): the family of the horizontal part of either the HDiv
+                or HCurl space.
+            horizontal_degree (int): the polynomial degree of the horizontal
+                part of the L2 space.
+            vertical_degree (int, optional): the polynomial degree of the
+                vertical part of the L2 space. Defaults to None.
+        """
+
+        if family == 'BDFM':
+            # Need a special implementation of base spaces here as it does not
+            # fit the same pattern as other spaces
+            build_bdfm_base_spaces(self, horizontal_degree, vertical_degree)
+            return
+
+        if self.extruded_mesh:
+            cell = self.mesh._base_mesh.ufl_cell().cellname()
         else:
-            # Space does not exist in creator
-            if V is not None:
-                # The space itself has been provided (to add it to the creator)
-                value = V
+            cell = self.mesh.ufl_cell().cellname()
 
-            elif name == "DG1_equispaced":
-                # Special case as no degree arguments need providing
-                value = self.build_l2_space(1, 1, variant='equispaced', name='DG1_equispaced')
+        hdiv_family = hcurl_hdiv_dict[family]
+        hcurl_family = hdiv_hcurl_dict[family]
 
-            else:
-                check_degree_args('Spaces', self.mesh, degree, horizontal_degree, vertical_degree)
+        # horizontal base spaces
+        self.base_elt_hori_hdiv = FiniteElement(hdiv_family, cell, horizontal_degree+1)
+        if hcurl_family is not None:
+            self.base_elt_hori_hcurl = FiniteElement(hcurl_family, cell, horizontal_degree+1)
+        self.base_elt_hori_dg = FiniteElement("DG", cell, horizontal_degree)
+        self.base_elt_hori_cg = FiniteElement("CG", cell, h1_degree(family, horizontal_degree))
 
-                # Convert to horizontal and vertical degrees
-                horizontal_degree = degree if horizontal_degree is None else horizontal_degree
-                vertical_degree = degree if vertical_degree is None else vertical_degree
+        # vertical base spaces
+        if vertical_degree is not None:
+            self.base_elt_vert_cg = FiniteElement("CG", interval, vertical_degree+1)
+            self.base_elt_vert_dg = FiniteElement("DG", interval, vertical_degree)
 
-                # Loop through name and family combinations
-                if name in ["HDiv", "HCurl", "theta", "L2", "H1"]:
-                    # This is one of the compatible finite element spaces, so
-                    # look for the space in the de Rham dictionary
-                    degree_pair = (horizontal_degree, vertical_degree)
-                    # If the de Rham complex doesn't exist yet, create it
-                    if degree_pair not in self._de_rham_dict.keys():
-                        self._de_rham_dict[degree_pair] = \
-                            DeRhamComplex(self.mesh, hdiv_family,
-                                          horizontal_degree, vertical_degree)
-
-                    de_rham_complex = self._de_rham_dict[degree_pair]
-                    value = de_rham_complex(name)
-
-                if name == "HDiv" and family in ["BDM", "RT", "CG", "RTCF", "RTF", "BDMF"]:
-                    hdiv_family = hcurl_hdiv_dict[family]
-                    value = self.build_hdiv_space(hdiv_family, horizontal_degree, vertical_degree)
-                elif name == "HCurl" and family in ["BDM", "RT", "CG", "RTCE", "RTE", "BDME"]:
-                    hcurl_family = hdiv_hcurl_dict[family]
-                    value = self.build_hcurl_space(hcurl_family, horizontal_degree, vertical_degree)
-                elif name == "theta":
-                    value = self.build_theta_space(horizontal_degree, vertical_degree)
-                elif family == "DG":
-                    value = self.build_l2_space(horizontal_degree, vertical_degree, name=name)
-                elif family == "CG":
-                    value = self.build_h1_space(family, horizontal_degree, vertical_degree, name=name)
-                else:
-                    raise ValueError(f'There is no space corresponding to {name}')
-            setattr(self, name, value)
-            return value
-
-    def build_compatible_spaces(self, family, horizontal_degree,
-                                vertical_degree=None):
+    def build_compatible_spaces(self):
         """
         Builds the sequence of compatible finite element spaces for the mesh.
 
@@ -199,27 +302,19 @@ class Spaces(object):
         Returns:
             tuple: the created compatible :class:`FunctionSpace` objects.
         """
-        if (horizontal_degree, vertical_degree) in self._initialised_base_spaces.keys():
-            pass
 
-        elif self.extruded_mesh:
-            # Base spaces need building, while horizontal and vertical degrees
+        if self.extruded_mesh:
+            # Horizontal and vertical degrees
             # need specifying separately. Vtheta needs returning.
-            self.build_base_spaces(family, horizontal_degree, vertical_degree)
-            Vcg = self.build_h1_space(family,
-                                      h1_degree(family, horizontal_degree),
-                                      vertical_degree+1, name='H1')
+            Vcg = self.build_h1_space()
             setattr(self, "H1", Vcg)
-            hcurl_family = hdiv_hcurl_dict[family]
-            Vcurl = self.build_hcurl_space(hcurl_family, horizontal_degree, vertical_degree)
+            Vcurl = self.build_hcurl_space()
             setattr(self, "HCurl", Vcurl)
-            hdiv_family = hcurl_hdiv_dict[family]
-            Vu = self.build_hdiv_space(hdiv_family, horizontal_degree, vertical_degree)
+            Vu = self.build_hdiv_space()
             setattr(self, "HDiv", Vu)
-            Vdg = self.build_l2_space(horizontal_degree, vertical_degree, name='L2')
+            Vdg = self.build_l2_space()
             setattr(self, "L2", Vdg)
-            setattr(self, "DG", Vdg)  # Register this as "L2" and "DG"
-            Vth = self.build_theta_space(horizontal_degree, vertical_degree)
+            Vth = self.build_theta_space()
             setattr(self, "theta", Vth)
 
             return Vcg, Vcurl, Vu, Vdg, Vth
@@ -228,75 +323,30 @@ class Spaces(object):
             # 2D: two de Rham complexes (hcurl or hdiv) with 3 spaces
             # 3D: one de Rham complexes with 4 spaces
             # either way, build all spaces
-            Vcg = self.build_h1_space(family, h1_degree(family, horizontal_degree), name='H1')
+            Vcg = self.build_h1_space()
             setattr(self, "H1", Vcg)
-            hcurl_family = hdiv_hcurl_dict[family]
-            Vcurl = self.build_hcurl_space(hcurl_family, horizontal_degree)
+            Vcurl = self.build_hcurl_space()
             setattr(self, "HCurl", Vcurl)
-            hdiv_family = hcurl_hdiv_dict[family]
-            Vu = self.build_hdiv_space(family, horizontal_degree)
+            Vu = self.build_hdiv_space()
             setattr(self, "HDiv", Vu)
-            Vdg = self.build_l2_space(horizontal_degree, vertical_degree, name='L2')
+            Vdg = self.build_l2_space()
             setattr(self, "L2", Vdg)
-            setattr(self, "DG", Vdg)  # Register this as "L2" and "DG"
 
             return Vcg, Vcurl, Vu, Vdg
 
         else:
             # 1D domain, de Rham complex has 2 spaces
             # CG, hdiv and hcurl spaces should be the same
-            Vcg = self.build_h1_space(family, horizontal_degree+1, name='H1')
+            Vcg = self.build_h1_space()
             setattr(self, "H1", Vcg)
             setattr(self, "HCurl", None)
             setattr(self, "HDiv", Vcg)
-            Vdg = self.build_l2_space(horizontal_degree, name='L2')
+            Vdg = self.build_l2_space()
             setattr(self, "L2", Vdg)
-            setattr(self, "DG", Vdg)  # Register this as "L2" and "DG"
 
             return Vcg, Vdg
 
-    def build_base_spaces(self, family, horizontal_degree, vertical_degree):
-        """
-        Builds the :class:`FiniteElement` objects for the base mesh.
-
-        Args:
-            family (str): the family of the horizontal part of either the HDiv
-                or HCurl space.
-            horizontal_degree (int): the polynomial degree of the horizontal
-                part of the L2 space.
-            vertical_degree (int): the polynomial degree of the vertical part of
-                the L2 space.
-        """
-
-        if family == 'BDFM':
-            # Need a special implementation of base spaces here as it does not
-            # fit the same pattern as other spaces
-            self.build_bdfm_base_spaces(horizontal_degree, vertical_degree)
-            return
-
-        cell = self.mesh._base_mesh.ufl_cell().cellname()
-
-        hdiv_family = hcurl_hdiv_dict[family]
-        hcurl_family = hdiv_hcurl_dict[family]
-
-        # horizontal base spaces
-        if horizontal_degree not in self.base_elt_hori_dg.keys():
-            key = horizontal_degree
-            self.base_elt_hori_hdiv[key] = FiniteElement(hdiv_family, cell, horizontal_degree+1)
-            self.base_elt_hori_hcurl[key] = FiniteElement(hcurl_family, cell, horizontal_degree+1)
-            self.base_elt_hori_dg[key] = FiniteElement("DG", cell, horizontal_degree)
-            self.base_elt_hori_cg[key] = FiniteElement("CG", cell, h1_degree(family, horizontal_degree))
-
-        # vertical base spaces
-        if vertical_degree not in self.base_elt_vert_dg.keys():
-            key = vertical_degree
-            self.base_elt_vert_cg[key] = FiniteElement("CG", interval, vertical_degree+1)
-            self.base_elt_vert_dg[key] = FiniteElement("DG", interval, vertical_degree)
-
-        degree_pair = (horizontal_degree, vertical_degree)
-        self._initialised_base_spaces[degree_pair] = True
-
-    def build_hcurl_space(self, family, horizontal_degree, vertical_degree=None):
+    def build_hcurl_space(self):
         """
         Builds and returns the HCurl :class:`FunctionSpace`.
 
@@ -311,113 +361,61 @@ class Spaces(object):
         Returns:
             :class:`FunctionSpace`: the HCurl space.
         """
-        if family is None:
+        if hdiv_hcurl_dict[self.family] is None:
             logger.warning('There is no HCurl space for this family. Not creating one')
             return None
 
         if self.extruded_mesh:
-            if (horizontal_degree, vertical_degree) not in self._initialised_base_spaces.keys():
-                if vertical_degree is None:
-                    raise ValueError('vertical_degree must be specified to create HCurl space on an extruded mesh')
-                self.build_base_spaces(family, horizontal_degree, vertical_degree)
-
-            Vh_elt = HCurl(TensorProductElement(self.base_elt_hori_hcurl[horizontal_degree],
-                                                self.base_elt_vert_cg[vertical_degree]))
-            Vv_elt = HCurl(TensorProductElement(self.base_elt_hori_cg[horizontal_degree],
-                                                self.base_elt_vert_dg[vertical_degree]))
+            Vh_elt = HCurl(TensorProductElement(self.base_elt_hori_hcurl,
+                                                self.base_elt_vert_cg))
+            Vv_elt = HCurl(TensorProductElement(self.base_elt_hori_cg,
+                                                self.base_elt_vert_dg))
             V_elt = Vh_elt + Vv_elt
         else:
-            cell = self.mesh.ufl_cell().cellname()
-            hcurl_family = hdiv_hcurl_dict[family]
-            V_elt = FiniteElement(hcurl_family, cell, horizontal_degree)
+            V_elt = self.base_elt_hori_hcurl
 
-        return FunctionSpace(self.mesh, V_elt, name='HCurl')
+        return FunctionSpace(self.mesh, V_elt, name='HCurl'+self.complex_name)
 
-    def build_hdiv_space(self, family, horizontal_degree, vertical_degree=None):
+    def build_hdiv_space(self):
         """
         Builds and returns the HDiv :class:`FunctionSpace`.
-
-        Args:
-            family (str): the family of the horizontal part of the HDiv space.
-            horizontal_degree (int): the polynomial degree of the horizontal
-                part of the L2 space from the de Rham complex.
-            vertical_degree (int, optional): the polynomial degree of the
-                vertical part of the L2 space from the de Rham complex.
-                Defaults to None. Must be specified if the mesh is extruded.
 
         Returns:
             :class:`FunctionSpace`: the HDiv space.
         """
         if self.extruded_mesh:
-            if (horizontal_degree, vertical_degree) not in self._initialised_base_spaces.keys():
-                if vertical_degree is None:
-                    raise ValueError('vertical_degree must be specified to create HDiv space on an extruded mesh')
-                self.build_base_spaces(family, horizontal_degree, vertical_degree)
-            Vh_elt = HDiv(TensorProductElement(self.base_elt_hori_hdiv[horizontal_degree],
-                                               self.base_elt_vert_dg[vertical_degree]))
-            Vt_elt = TensorProductElement(self.base_elt_hori_dg[horizontal_degree],
-                                          self.base_elt_vert_cg[vertical_degree])
+            Vh_elt = HDiv(TensorProductElement(self.base_elt_hori_hdiv,
+                                               self.base_elt_vert_dg))
+            Vt_elt = TensorProductElement(self.base_elt_hori_dg,
+                                          self.base_elt_vert_cg)
             Vv_elt = HDiv(Vt_elt)
             V_elt = Vh_elt + Vv_elt
         else:
-            cell = self.mesh.ufl_cell().cellname()
-            hdiv_family = hcurl_hdiv_dict[family]
-            V_elt = FiniteElement(hdiv_family, cell, horizontal_degree+1)
-        return FunctionSpace(self.mesh, V_elt, name='HDiv')
+            V_elt = self.base_elt_hori_hdiv
+        return FunctionSpace(self.mesh, V_elt, name='HDiv'+self.complex_name)
 
-    def build_l2_space(self, horizontal_degree, vertical_degree=None, variant=None, name='L2'):
+    def build_l2_space(self):
         """
         Builds and returns the discontinuous L2 :class:`FunctionSpace`.
-
-        Args:
-            horizontal_degree (int): the polynomial degree of the horizontal
-                part of the L2 space.
-            vertical_degree (int, optional): the polynomial degree of the
-                vertical part of the L2 space. Defaults to None. Must be
-                specified if the mesh is extruded.
-            variant (str, optional): the variant of the underlying
-                :class:`FiniteElement` to use. Defaults to None, which will call
-                the default variant.
-            name (str, optional): name to assign to the function space. Default
-                is "L2".
 
         Returns:
             :class:`FunctionSpace`: the L2 space.
         """
-        assert not hasattr(self, name), f'There already exists a function space with name {name}'
 
         if self.extruded_mesh:
-            if vertical_degree is None:
-                raise ValueError('vertical_degree must be specified to create L2 space on an extruded mesh')
-            if ((horizontal_degree, vertical_degree) not in self._initialised_base_spaces.keys()
-                    or self.base_elt_vert_dg[vertical_degree].variant() != variant
-                    or self.base_elt_hori_dg[horizontal_degree].degree() != variant):
-                cell = self.mesh._base_mesh.ufl_cell().cellname()
-                base_elt_hori_dg = FiniteElement("DG", cell, horizontal_degree, variant=variant)
-                base_elt_vert_dg = FiniteElement("DG", interval, vertical_degree, variant=variant)
-            else:
-                base_elt_hori_dg = self.base_elt_hori_dg[horizontal_degree]
-                base_elt_vert_dg = self.base_elt_vert_dg[vertical_degree]
-            V_elt = TensorProductElement(base_elt_hori_dg, base_elt_vert_dg)
+            V_elt = TensorProductElement(self.base_elt_hori_dg, self.base_elt_vert_dg)
         else:
-            cell = self.mesh.ufl_cell().cellname()
-            V_elt = FiniteElement("DG", cell, horizontal_degree, variant=variant)
+            V_elt = self.base_elt_hori_dg
 
-        return FunctionSpace(self.mesh, V_elt, name=name)
+        return FunctionSpace(self.mesh, V_elt, name='L2'+self.complex_name)
 
-    def build_theta_space(self, horizontal_degree, vertical_degree):
+    def build_theta_space(self):
         """
         Builds and returns the 'theta' space.
 
         This corresponds to the non-Piola mapped space of the vertical component
         of the velocity. The space will be discontinuous in the horizontal but
         continuous in the vertical.
-
-        Args:
-            horizontal_degree (int): the polynomial degree of the horizontal
-                part of the L2 space from the de Rham complex.
-            vertical_degree (int): the polynomial degree of the vertical part of
-                the L2 space from the de Rham complex.
 
         Raises:
             AssertionError: the mesh is not extruded.
@@ -426,95 +424,65 @@ class Spaces(object):
             :class:`FunctionSpace`: the 'theta' space.
         """
         assert self.extruded_mesh, 'Cannot create theta space if mesh is not extruded'
-        if (horizontal_degree, vertical_degree) not in self._initialised_base_spaces.keys():
-            cell = self.mesh._base_mesh.ufl_cell().cellname()
-            base_elt_hori_dg = FiniteElement("DG", cell, horizontal_degree)
-            base_elt_vert_cg = FiniteElement("CG", interval, vertical_degree+1)
-        else:
-            base_elt_hori_dg = self.base_elt_hori_dg[horizontal_degree]
-            base_elt_vert_cg = self.base_elt_vert_cg[vertical_degree]
-        V_elt = TensorProductElement(base_elt_hori_dg, base_elt_vert_cg)
-        return FunctionSpace(self.mesh, V_elt, name='theta')
 
-    def build_h1_space(self, family, horizontal_degree, vertical_degree=None, name='H1'):
+        V_elt = TensorProductElement(self.base_elt_hori_dg, self.base_elt_vert_cg)
+
+        return FunctionSpace(self.mesh, V_elt, name='theta'+self.complex_name)
+
+    def build_h1_space(self):
         """
         Builds the continuous scalar space at the top of the de Rham complex.
 
         Args:
-            family (str): the family of the horizontal part of the HDiv space.
-            horizontal_degree (int): the polynomial degree of the horizontal
-                part of the H1 space.
-            vertical_degree (int, optional): the polynomial degree of the
-                vertical part of the H1 space. Defaults to None. Must be
-                specified if the mesh is extruded.
             name (str, optional): name to assign to the function space. Default
                 is "H1".
 
         Returns:
             :class:`FunctionSpace`: the continuous space.
         """
-        assert not hasattr(self, name), f'There already exists a function space with name {name}'
 
         if self.extruded_mesh:
-            if vertical_degree is None:
-                raise ValueError('vertical_degree must be specified to create H1 space on an extruded mesh')
-            if (horizontal_degree, vertical_degree) not in self._initialised_base_spaces.keys():
-                cell = self.mesh._base_mesh.ufl_cell().cellname()
-                base_elt_hori_cg = FiniteElement("CG", cell, horizontal_degree)
-                base_elt_vert_cg = FiniteElement("CG", interval, vertical_degree)
-            else:
-                base_elt_hori_cg = self.base_elt_hori_cg[horizontal_degree]
-                base_elt_vert_cg = self.base_elt_vert_cg[vertical_degree]
-            V_elt = TensorProductElement(base_elt_hori_cg, base_elt_vert_cg)
-
-        elif family == 'BDFM':
-            cell = self.mesh.ufl_cell().cellname()
-            V_elt = FiniteElement("CG", cell, horizontal_degree)
-            V_elt += FiniteElement("Bubble", cell, horizontal_degree+1)
+            V_elt = TensorProductElement(self.base_elt_hori_cg, self.base_elt_vert_cg)
 
         else:
-            cell = self.mesh.ufl_cell().cellname()
-            V_elt = FiniteElement("CG", cell, horizontal_degree)
+            V_elt = self.base_elt_hori_cg
 
-        return FunctionSpace(self.mesh, V_elt, name=name)
-
-    def build_bdfm_base_spaces(self, horizontal_degree, vertical_degree=None):
-        """
-        Builds the :class:`FiniteElement` objects for the base mesh when using
-        the .
-
-        Args:
-            horizontal_degree (int): the polynomial degree of the horizontal
-                part of the L2 space.
-            vertical_degree (int): the polynomial degree of the vertical part of
-                the L2 space.
-        """
-
-        cell = self.mesh._base_mesh.ufl_cell().cellname()
-
-        hdiv_family = 'BDFM'
-
-        # horizontal base spaces
-        key = horizontal_degree
-        self.base_elt_hori_hdiv[key] = FiniteElement(hdiv_family, cell, horizontal_degree+1)
-        self.base_elt_hori_dg[key] = FiniteElement("DG", cell, horizontal_degree)
-
-        # Add bubble space
-        self.base_elt_hori_cg[key] = FiniteElement("CG", cell, horizontal_degree+1)
-        self.base_elt_hori_cg[key] += FiniteElement("Bubble", cell, horizontal_degree+2)
-
-        # vertical base spaces
-        key = vertical_degree
-        self.base_elt_vert_cg[key] = FiniteElement("CG", interval, vertical_degree+1)
-        self.base_elt_vert_dg[key] = FiniteElement("DG", interval, vertical_degree)
-
-        self._initialised_base_spaces[(horizontal_degree, vertical_degree)] = True
+        return FunctionSpace(self.mesh, V_elt, name='H1'+self.complex_name)
 
 
-class DeRhamComplex(object):
+def build_bdfm_base_spaces(de_rham_complex, horizontal_degree, vertical_degree=None):
+    """
+    Builds the :class:`FiniteElement` objects for the de Rham complex when using
+    the BDFM space.
 
-    def __init__(self, mesh, horizontal_degree, vertical_degree=None):
+    Args:
+        de_rham_complex (:class:`DeRhamComplex`): the de Rham complex to set up
+            the spaces for.
+        horizontal_degree (int): the polynomial degree of the horizontal
+            part of the L2 space in the complex.
+        vertical_degree (int, optional): the polynomial degree of the vertical
+            part of the L2 space in the complex.
+    """
 
+    if de_rham_complex.extruded_mesh:
+        cell = de_rham_complex.mesh._base_mesh.ufl_cell().cellname()
+    else:
+        cell = de_rham_complex.mesh.ufl_cell().cellname()
+
+    hdiv_family = 'BDFM'
+
+    # horizontal base spaces
+    de_rham_complex.base_elt_hori_hdiv = FiniteElement(hdiv_family, cell, horizontal_degree+1)
+    de_rham_complex.base_elt_hori_dg = FiniteElement("DG", cell, horizontal_degree)
+
+    # Add bubble space
+    de_rham_complex.base_elt_hori_cg = FiniteElement("CG", cell, horizontal_degree+1)
+    de_rham_complex.base_elt_hori_cg += FiniteElement("Bubble", cell, horizontal_degree+2)
+
+    # vertical base spaces
+    if de_rham_complex.extruded_mesh and vertical_degree is not None:
+        de_rham_complex.base_elt_vert_cg = FiniteElement("CG", interval, vertical_degree+1)
+        de_rham_complex.base_elt_vert_dg = FiniteElement("DG", interval, vertical_degree)
 
 
 def check_degree_args(name, mesh, degree, horizontal_degree, vertical_degree):

--- a/integration-tests/diffusion/test_diffusion.py
+++ b/integration-tests/diffusion/test_diffusion.py
@@ -26,9 +26,9 @@ def test_scalar_diffusion(tmpdir, DG, tracer_setup):
     f_end_expr = (1/(1+4*tmax))*f_init**(1/(1+4*tmax))
 
     if DG:
-        V = domain.spaces("DG", "DG", degree=1)
+        V = domain.spaces("DG")
     else:
-        V = domain.spaces("theta", degree=1)
+        V = domain.spaces("theta")
 
     mu = 5.
 
@@ -60,7 +60,7 @@ def test_vector_diffusion(tmpdir, DG, tracer_setup):
     if DG:
         V = VectorFunctionSpace(domain.mesh, "DG", 1)
     else:
-        V = domain.spaces("HDiv", "CG", 1)
+        V = domain.spaces("HDiv")
     f_init = as_vector([f_init, 0.])
     f_end_expr = as_vector([f_end_expr, 0.])
 

--- a/integration-tests/model/test_time_discretisation.py
+++ b/integration-tests/model/test_time_discretisation.py
@@ -39,7 +39,8 @@ def test_time_discretisation(tmpdir, scheme, tracer_setup):
         transport_scheme = TR_BDF2(domain, gamma=0.5)
     elif scheme == "Leapfrog":
         # Leapfrog unstable with DG
-        Vf = domain.spaces("CG", "CG", 1)
+        domain.spaces.create_space("CG1", "CG", 1)
+        Vf = domain.spaces("CG1")
         eqn = AdvectionEquation(domain, Vf, "f")
         transport_scheme = Leapfrog(domain)
     elif scheme == "AdamsBashforth":

--- a/integration-tests/physics/test_saturation_adjustment.py
+++ b/integration-tests/physics/test_saturation_adjustment.py
@@ -60,8 +60,8 @@ def run_cond_evap(dirname, process):
     # Initial conditions
     # ------------------------------------------------------------------------ #
 
-    Vt = domain.spaces("theta", degree=1)
-    Vr = domain.spaces("DG", "DG", degree=1)
+    Vt = domain.spaces("theta")
+    Vr = domain.spaces("DG")
 
     # Declare prognostic fields
     rho0 = stepper.fields("rho")

--- a/integration-tests/transport/test_limiters.py
+++ b/integration-tests/transport/test_limiters.py
@@ -53,7 +53,7 @@ def setup_limiters(dirname, space):
     else:
         raise NotImplementedError
 
-    Vpsi = domain.spaces('CG', 'CG', degree+1)
+    Vpsi = domain.spaces('H1')
 
     # Equation
     eqn = AdvectionEquation(domain, V, 'tracer')

--- a/unit-tests/test_function_spaces.py
+++ b/unit-tests/test_function_spaces.py
@@ -75,11 +75,13 @@ def test_de_rham_spaces(domain, family):
     # Work out correct CG degree
     if family in ['BDM', 'BDME', 'BDMF']:
         if domain in ['vertical_slice', 'extruded_plane']:
-            cg_degree = (degree[0]+2, degree[1]+2)
+            cg_degree = (degree[0]+2, degree[1]+1)
         else:
             cg_degree = degree + 2
     elif domain in ['vertical_slice', 'extruded_plane']:
         cg_degree = (degree[0]+1, degree[1]+1)
+    elif family == 'BDFM':
+        cg_degree = degree + 2
     else:
         cg_degree = degree + 1
 

--- a/unit-tests/test_h1_spaces.py
+++ b/unit-tests/test_h1_spaces.py
@@ -1,0 +1,89 @@
+"""
+Check that the H1 spaces are correct by:
+- creating HDiv spaces from a stream function in H1, and checking that their
+  divergence in L2 is zero
+- checking that this velocity gives a sensible answer
+- projecting the velocity back to obtain the vorticity field, and checking
+  that this is correct
+"""
+
+from firedrake import (PeriodicRectangleMesh, SpatialCoordinate, norm,
+                       Function, sin, cos, pi, as_vector, grad, div,
+                       TestFunction, TrialFunction, dx, inner, errornorm,
+                       LinearVariationalProblem, LinearVariationalSolver)
+from gusto import Domain
+import pytest
+
+hdiv_families = ["RTF", "BDMF", "BDFM", "RTCF", "BDMCF"]
+degrees = [1, 2]
+
+
+def combos(families, degs):
+    # Form all combinations of families/degrees
+    # This is done because for BDFM family, only degree 1 is possible
+    all_combos = []
+    for family in families:
+        for deg in degs:
+            if not (family == 'BDFM' and deg != 1):
+                all_combos.append((family, deg))
+    return all_combos
+
+
+@pytest.mark.parametrize("hdiv_family, degree", combos(hdiv_families, degrees))
+def test_h1_spaces(hdiv_family, degree):
+    # Set up mesh and domain
+    dt = 2.0
+    Lx = 10
+    Ly = 10
+    nx = int(20 / degree)
+    ny = int(20 / degree)
+    quadrilateral = True if hdiv_family in ['RTCF', 'BDMCF'] else False
+    mesh = PeriodicRectangleMesh(nx, ny, Lx, Ly, quadrilateral=quadrilateral)
+    domain = Domain(mesh, dt, hdiv_family, degree)
+    x, y = SpatialCoordinate(mesh)
+
+    # Declare spaces and functions
+    H1_space = domain.spaces('H1')
+    HDiv_space = domain.spaces('HDiv')
+    L2_space = domain.spaces('L2')
+    streamfunc = Function(H1_space)
+    velocity = Function(HDiv_space)
+    velocity_true = Function(HDiv_space)
+    vorticity = Function(H1_space)
+    vorticity_true = Function(H1_space)
+    divergence = Function(L2_space)
+    test = TestFunction(H1_space)
+    trial = TrialFunction(H1_space)
+
+    # Expressions
+    streamfunc_expr = sin(2*pi*x/Lx)*cos(4*pi*y/Ly)
+    velocity_expr = as_vector([4*pi/Ly*sin(4*pi*y/Ly)*sin(2*pi*x/Lx),
+                               2*pi/Lx*cos(2*pi*x/Lx)*cos(4*pi*y/Ly)])
+    vorticity_expr = - ((2*pi/Lx)**2 + (4*pi/Ly)**2)*streamfunc_expr
+
+    # Evaluate velocity from stream function
+    gradperp = lambda q: domain.perp(grad(q))
+    streamfunc.project(streamfunc_expr)
+    velocity.project(gradperp(streamfunc))
+    velocity_true.project(velocity_expr)
+    divergence.project(div(velocity))
+    velocity_norm = errornorm(velocity, velocity_true) / norm(velocity_true)
+    divergence_norm = norm(divergence) / (Lx*Ly)
+
+    # Evaluate vorticity from velocity
+    velocity.project(velocity_expr)
+    vorticity_true.project(vorticity_expr)
+    eqn_lhs = trial * test * dx
+    eqn_rhs = -inner(gradperp(test), velocity) * dx
+    problem = LinearVariationalProblem(eqn_lhs, eqn_rhs, vorticity)
+    solver = LinearVariationalSolver(problem)
+    solver.solve()
+    vorticity_norm = errornorm(vorticity, vorticity_true) / norm(vorticity_true)
+
+    # Check values
+    assert divergence_norm < 1e-8, \
+        f'Divergence for family {hdiv_family} degree {degree} is too large'
+    assert velocity_norm < 0.015, \
+        f'Error in velocity for family {hdiv_family} degree {degree} is too large'
+    assert vorticity_norm < 2e-6, \
+        f'Error in vorticity for family {hdiv_family} degree {degree} is too large'


### PR DESCRIPTION
I have had another attempt at writing `function_spaces.py` and the `Spaces` object. In its current guise we can only one `"HDiv"` or `"HCurl"` space, but when using recovery options we might want more than one. The aim here was to facilitate that.

There are two main changes:
1. The building of the base and compatible spaces has been pulled out to a new `DeRhamComplex` object. The code here is essentially the same as before.
2. I have broken up the `Spaces.__call__` routine. Previously this was a single interface that (a) returned a field already created, (b) created a field otherwise or (c) added an existing field to the `Spaces` container. I have now separated these into three different routines. I am hoping that this makes the code much simpler.

I have also added in the BDMCE/BDMCF spaces...