### PR TITLE
Include b in the list of fields to linearise in the ShallowWaterEquations

### DIFF
--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -645,7 +645,7 @@ class ShallowWaterEquations(PrognosticEquationSet):
             # Default linearisation is time derivatives, pressure gradient and
             # transport term from depth equation. Don't include active tracers
             linearisation_map = lambda t: \
-                t.get(prognostic) in ['u', 'D'] \
+                t.get(prognostic) in ['u', 'D', 'b'] \
                 and (any(t.has_label(time_derivative, pressure_gradient))
                      or (t.get(prognostic) in ['D', 'b'] and t.has_label(transport)))
         super().__init__(field_names, domain, space_names,


### PR DESCRIPTION
This pull request fixes a bug that meant that the buoyancy variable `b` in the thermal shallow water equations was being treated as an active tracer. 
It adds b to the list of fields in the linearisation in the `ShallowWaterEquations` class so that `b` is recognised as a prognostic field.