### PR TITLE
New explicit Runge-Kutta schemes

### DIFF
--- a/gusto/active_tracers.py
+++ b/gusto/active_tracers.py
@@ -85,12 +85,15 @@ class ActiveTracer(object):
         self.phase = phase
         self.chemical = chemical
 
-        if (variable_type == TracerVariableType.density and transport_eqn == TransportEquationType.advective):
+        if (variable_type == TracerVariableType.density
+                and transport_eqn == TransportEquationType.advective):
             logger.warning('Active tracer initialised which describes a '
                            + 'density but solving the advective transport eqn')
-                           
-        if (transport_eqn == TransportEquationType.tracer_conservative and density_name == None):
-            raise ValueError(f'Active tracer {name} using tracer conservative transport needs an associated density.')
+
+        if (transport_eqn == TransportEquationType.tracer_conservative
+                and density_name is None):
+            raise ValueError(f'Active tracer {name} using tracer conservative '
+                             + 'transport needs an associated density.')
 
 
 class WaterVapour(ActiveTracer):

--- a/gusto/common_forms.py
+++ b/gusto/common_forms.py
@@ -262,12 +262,13 @@ def split_continuity_form(equation):
                 map_if_true=drop)
 
     return equation
-    
+
+
 def tracer_conservative_form(test, q, rho, ubar):
     u"""
     The form corresponding to the continuity transport operator.
 
-    This describes ∇.(u*q*rho) for transporting velocity u and a 
+    This describes ∇.(u*q*rho) for transporting velocity u and a
     transported tracer (mixing ratio), q, with an associated density, rho.
 
     Args:
@@ -280,9 +281,9 @@ def tracer_conservative_form(test, q, rho, ubar):
     Returns:
         class:`LabelledForm`: a labelled transport form.
     """
+
     q_rho = q*rho
     L = inner(test, div(outer(q_rho, ubar)))*dx
     form = transporting_velocity(L, ubar)
-    
+
     return transport(form, TransportEquationType.tracer_conservative)
-    

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -514,10 +514,9 @@ class PrognosticEquationSet(PrognosticEquation, metaclass=ABCMeta):
                 elif tracer.transport_eqn == TransportEquationType.tracer_conservative:
                     ref_density_idx = self.field_names.index(tracer.density_name)
                     ref_density = split(self.X)[ref_density_idx]
-                    #q = tracer_prog*ref_density
                     tracer_adv = prognostic(
-                        tracer_conservative_form(tracer_test, tracer_prog, ref_density, u),
-                        tracer.name)
+                        tracer_conservative_form(tracer_test, tracer_prog,
+                                                 ref_density, u), tracer.name)
 
                 else:
                     raise ValueError(f'Transport eqn {tracer.transport_eqn} not recognised')
@@ -613,18 +612,17 @@ class CoupledTransportEquation(PrognosticEquationSet):
         # Add transport of tracers
         self.residual += self.generate_tracer_transport_terms(active_tracers)
 
+
 class ConservativeCoupledTransportEquation(PrognosticEquationSet):
     u"""
-    Discretises the transport equation,               \n
-    ∂q/∂t + (u.∇)q = F,
-    with the application of active tracers.
-    As there are multiple tracers or species that are
-    interacting, q and F are vectors.
-    This equation can be enhanced through the addition of
-    sources or sinks (F) by applying it with physics schemes.
-    This takes in tracers that might obey different forms
-    of the transport equation (i.e. advective, conservative)
-    but will evolve all the fields in a conservative manner.
+    Discretises the transport equation,                                       \n
+    ∂q/∂t + (u.∇)q = F,                                                       \n
+    with the application of active tracers. As there are multiple tracers or
+    species that are interacting, q and F are vectors. This equation can be
+    enhanced through the addition of sources or sinks (F) by applying it with
+    physics schemes. This takes in tracers that might obey different forms of
+    the transport equation (i.e. advective, conservative) but will evolve all
+    the fields in a conservative manner.
     """
     def __init__(self, domain, active_tracers, Vu=None):
         """
@@ -674,11 +672,9 @@ class ConservativeCoupledTransportEquation(PrognosticEquationSet):
         self.residual += self.generate_tracer_transport_terms(active_tracers)
 
 
-
 # ============================================================================ #
 # Specified Equation Sets
 # ============================================================================ #
-
 
 class ShallowWaterEquations(PrognosticEquationSet):
     u"""

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -90,7 +90,6 @@ class PhysicsLabel(Label):
 # ---------------------------------------------------------------------------- #
 
 time_derivative = Label("time_derivative")
-mass_weighted = Label("mass_weighted", validator=lambda value: type(value) == str)
 implicit = Label("implicit")
 explicit = Label("explicit")
 transport = Label("transport", validator=lambda value: type(value) == TransportEquationType)

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -90,7 +90,7 @@ class PhysicsLabel(Label):
 # ---------------------------------------------------------------------------- #
 
 time_derivative = Label("time_derivative")
-mass_weighted = Label("mass_weighted", validator=lambda value: type(value) == tuple)
+mass_weighted = Label("mass_weighted", validator=lambda value: type(value) == str)
 implicit = Label("implicit")
 explicit = Label("explicit")
 transport = Label("transport", validator=lambda value: type(value) == TransportEquationType)

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -823,13 +823,15 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
 
             for stage in range(self.nStages):
                 # setup linear solver using lhs and rhs defined in derived class
-                problem = NonlinearVariationalProblem(self.lhs[stage].form - self.rhs[stage].form, self.field_i[stage+1], bcs=self.bcs)
+                problem = NonlinearVariationalProblem(
+                    self.lhs[stage].form - self.rhs[stage].form,
+                    self.field_i[stage+1], bcs=self.bcs)
                 solver_name = self.field_name+self.__class__.__name__+str(stage)
-                solver =  NonlinearVariationalSolver(problem, solver_parameters=self.solver_parameters,
-                                                     options_prefix=solver_name)
+                solver = NonlinearVariationalSolver(
+                    problem, solver_parameters=self.solver_parameters,
+                    options_prefix=solver_name)
                 solver_list.append(solver)
             return solver_list
-
 
     @cached_property
     def lhs(self):
@@ -854,7 +856,6 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
 
             return lhs_list
 
-
     @cached_property
     def rhs(self):
         """Set up the time discretisation's right hand side."""
@@ -873,7 +874,7 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
             # So that we can still do xnp1 = xn, put in a zero term here
             if self.increment_form and len(r.terms) == 0:
                 logger.warning('No terms detected for RHS of explicit problem. '
-                            + 'Adding a zero term to avoid failure.')
+                               + 'Adding a zero term to avoid failure.')
                 null_term = Constant(0.0)*self.residual.label_map(
                     lambda t: t.has_label(time_derivative),
                     # Drop label from this
@@ -962,7 +963,6 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
                 self.x1.assign(self.field_i[stage+1])
                 if self.limiter is not None:
                     self.limiter.apply(self.x1)
-
 
     def apply_cycle(self, x_out, x_in):
         """

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -21,7 +21,7 @@ from firedrake.utils import cached_property
 
 from gusto.configuration import EmbeddedDGOptions, RecoveryOptions
 from gusto.labels import (time_derivative, prognostic, physics_label,
-                          implicit, explicit, mass_weighted)
+                          implicit, explicit)
 from gusto.logging import logger, DEBUG, logging_ksp_monitor_true_residual
 from gusto.wrappers import *
 
@@ -519,17 +519,6 @@ class ExplicitTimeDiscretisation(TimeDiscretisation):
         self.x0 = Function(self.fs)
         self.x1 = Function(self.fs)
 
-        # Work out if any sub-functions need special mass weighted handling
-        self.mass_weighted_idxs = []
-        self.density_idxs = []
-        for t in self.residual.terms:
-            if t.has_label(mass_weighted):
-                # Get the index in the mixed function space of this term,
-                # from the prognostic field name
-                idx = self.equation.field_names.index(t.get(prognostic))
-                self.mass_weighted_idxs.append(idx)
-                self.density_idxs.append(t.get(mass_weighted)[0])
-
     @cached_property
     def lhs(self):
         """Set up the discretisation's left hand side (the time derivative)."""
@@ -761,8 +750,9 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
     #  [ b_0  b_1  .       b_s]
     # ---------------------------------------------------------------------------
 
-    def __init__(self, domain, butcher_matrix, field_name=None, fixed_subcycles=None,
-                 subcycle_by_courant=None, solver_parameters=None,
+    def __init__(self, domain, butcher_matrix, field_name=None,
+                 fixed_subcycles=None, subcycle_by_courant=None,
+                 increment_form=True, solver_parameters=None,
                  limiter=None, options=None):
         """
         Args:
@@ -781,6 +771,9 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
                 for one sub-cycle. Defaults to None, in which case adaptive
                 sub-cycling is not used. This option cannot be specified with the
                 `fixed_subcycles` argument.
+            increment_form (bool, optional): whether to write the RK scheme in
+                "increment form", solving for increments rather than updated
+                fields. Defaults to True.
             solver_parameters (dict, optional): dictionary of parameters to
                 pass to the underlying solver. Defaults to None.
             limiter (:class:`Limiter` object, optional): a limiter to apply to
@@ -797,6 +790,7 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
                          limiter=limiter, options=options)
         self.butcher_matrix = butcher_matrix
         self.nbutcher = int(np.shape(self.butcher_matrix)[0])
+        self.increment_form = increment_form
 
     @property
     def nStages(self):
@@ -813,109 +807,162 @@ class ExplicitMultistage(ExplicitTimeDiscretisation):
         """
         super().setup(equation, apply_bcs, *active_labels)
 
-        self.k = [Function(self.fs) for i in range(self.nStages)]
+        if not self.increment_form:
+            self.field_i = [Function(self.fs) for i in range(self.nStages+1)]
+        else:
+            self.k = [Function(self.fs) for i in range(self.nStages)]
+
+    @cached_property
+    def solver(self):
+        if self.increment_form:
+            return super().solver
+        else:
+            # In this case, don't set snes_type to ksp only, as we do want the
+            # outer Newton iteration
+            solver_list = []
+
+            for stage in range(self.nStages):
+                # setup linear solver using lhs and rhs defined in derived class
+                problem = NonlinearVariationalProblem(self.lhs[stage].form - self.rhs[stage].form, self.field_i[stage+1], bcs=self.bcs)
+                solver_name = self.field_name+self.__class__.__name__+str(stage)
+                solver =  NonlinearVariationalSolver(problem, solver_parameters=self.solver_parameters,
+                                                     options_prefix=solver_name)
+                solver_list.append(solver)
+            return solver_list
+
 
     @cached_property
     def lhs(self):
         """Set up the discretisation's left hand side (the time derivative)."""
 
-        # Special handling for mass weighted time derivatives
-        # Explicit multi-stage solves for "k", which should be linear increment
-        # in the prognostic variables -- so we need to drop the mass weighted
-        # part to make the LHS linear. The non-mass weighted time derivative is
-        # (for now) stored in the mass weighted label
-        self.residual = self.residual.label_map(
-            lambda t: t.has_label(mass_weighted),
-            map_if_true=lambda t: Term(t.get(mass_weighted)[1], t.labels),
-            map_if_false=keep)
+        if self.increment_form:
+            l = self.residual.label_map(
+                lambda t: t.has_label(time_derivative),
+                map_if_true=replace_subject(self.x_out, self.idx),
+                map_if_false=drop)
 
-        l = self.residual.label_map(
-            lambda t: t.has_label(time_derivative),
-            map_if_true=replace_subject(self.x_out, self.idx),
-            map_if_false=drop)
+            return l.form
 
-        return l.form
+        else:
+            lhs_list = []
+            for stage in range(self.nStages):
+                l = self.residual.label_map(
+                    lambda t: t.has_label(time_derivative),
+                    map_if_true=replace_subject(self.field_i[stage+1], self.idx),
+                    map_if_false=drop)
+                lhs_list.append(l)
+
+            return lhs_list
+
 
     @cached_property
     def rhs(self):
         """Set up the time discretisation's right hand side."""
-        r = self.residual.label_map(
-            all_terms,
-            map_if_true=replace_subject(self.x1, old_idx=self.idx))
 
-        r = r.label_map(
-            lambda t: t.has_label(time_derivative),
-            map_if_true=drop,
-            map_if_false=lambda t: -1*t)
+        if self.increment_form:
+            r = self.residual.label_map(
+                all_terms,
+                map_if_true=replace_subject(self.x1, old_idx=self.idx))
 
-        # If there are no active labels, we may have no terms at this point
-        # So that we can still do xnp1 = xn, put in a zero term here
-        if len(r.terms) == 0:
-            logger.warning('No terms detected for RHS of explicit problem. '
-                           + 'Adding a zero term to avoid failure.')
-            null_term = Constant(0.0)*self.residual.label_map(
+            r = r.label_map(
                 lambda t: t.has_label(time_derivative),
-                # Drop label from this
-                map_if_true=lambda t: time_derivative.remove(t),
-                map_if_false=drop)
-            r += null_term
+                map_if_true=drop,
+                map_if_false=lambda t: -1*t)
 
-        return r.form
+            # If there are no active labels, we may have no terms at this point
+            # So that we can still do xnp1 = xn, put in a zero term here
+            if self.increment_form and len(r.terms) == 0:
+                logger.warning('No terms detected for RHS of explicit problem. '
+                            + 'Adding a zero term to avoid failure.')
+                null_term = Constant(0.0)*self.residual.label_map(
+                    lambda t: t.has_label(time_derivative),
+                    # Drop label from this
+                    map_if_true=lambda t: time_derivative.remove(t),
+                    map_if_false=drop)
+                r += null_term
 
-    def print_stats(self, mixed_field, message):
-        min1 = np.min(mixed_field.dat[0].data)
-        max1 = np.max(mixed_field.dat[0].data)
-        min2 = np.min(mixed_field.dat[1].data)
-        max2 = np.max(mixed_field.dat[1].data)
-        logger.info(f'{message}: {min1} {max1} {min2} {max2}')
+            return r.form
+
+        else:
+            rhs_list = []
+
+            for stage in range(self.nStages):
+                r = self.residual.label_map(
+                    lambda t: t.has_label(time_derivative),
+                    map_if_true=replace_subject(self.field_i[0], old_idx=self.idx),
+                    map_if_false=replace_subject(self.field_i[0], old_idx=self.idx))
+
+                r = r.label_map(
+                    lambda t: t.has_label(time_derivative),
+                    map_if_true=keep,
+                    map_if_false=lambda t: -self.butcher_matrix[stage, 0]*self.dt*t)
+
+                for i in range(1, stage+1):
+                    r_i = self.residual.label_map(
+                        lambda t: t.has_label(time_derivative),
+                        map_if_true=drop,
+                        map_if_false=replace_subject(self.field_i[i], old_idx=self.idx)
+                    )
+
+                    r -= self.butcher_matrix[stage, i]*self.dt*r_i
+
+                rhs_list.append(r)
+
+            return rhs_list
 
     def solve_stage(self, x0, stage):
-        self.x1.assign(x0)
 
-        # Use x0 as a first guess (otherwise may not converge)
-        self.x_out.assign(x0)
-
-        for i in range(stage):
-            self.x1.assign(self.x1 + self.dt*self.butcher_matrix[stage-1, i]*self.k[i])
-        for evaluate in self.evaluate_source:
-            evaluate(self.x1, self.dt)
-        if self.limiter is not None:
-            self.limiter.apply(self.x1)
-        self.solver.solve()
-
-        self.print_stats(self.x1, f'x1 {stage}')
-
-        self.print_stats(self.x_out, 'x_out before')
-
-        # Need to divide by the updated density field if the LHS has a mass
-        # weighted time derivative
-        if len(self.mass_weighted_idxs) > 0:
-            # Loop through mixing ratios and the corresponding densities
-            for rho_idx, m_idx in zip(self.density_idxs, self.mass_weighted_idxs):
-                # Calculate updated density
-                rho = Function(self.fs[rho_idx])
-                rho.assign(x0.subfunctions[rho_idx])
-                for i in range(stage):
-                    rho.assign(rho + self.dt*self.butcher_matrix[stage, i]*self.k[i].subfunctions[rho_idx])
-                rho.assign(rho + self.dt*self.butcher_matrix[stage, stage]*self.x_out.subfunctions[rho_idx])
-                logger.info(f'rho updated: {np.min(rho.dat.data)} {np.max(rho.dat.data)}')
-                # Divide mixing ratio increment by updated density
-                k_m = self.x_out.subfunctions[m_idx]
-                k_m.interpolate(k_m / rho)
-        self.print_stats(self.x_out, 'x_out_after')
-
-        self.k[stage].assign(self.x_out)
-
-        if (stage == self.nStages - 1):
+        if self.increment_form:
             self.x1.assign(x0)
-            for i in range(self.nStages):
-                self.x1.assign(self.x1 + self.dt*self.butcher_matrix[stage, i]*self.k[i])
-            self.x1.assign(self.x1)
 
+            # Use x0 as a first guess (otherwise may not converge)
+            self.x_out.assign(x0)
+
+            for i in range(stage):
+                self.x1.assign(self.x1 + self.dt*self.butcher_matrix[stage-1, i]*self.k[i])
+            for evaluate in self.evaluate_source:
+                evaluate(self.x1, self.dt)
             if self.limiter is not None:
                 self.limiter.apply(self.x1)
+            self.solver.solve()
 
-            self.print_stats(self.x1, f'x1 end')
+            self.k[stage].assign(self.x_out)
+
+            if (stage == self.nStages - 1):
+                self.x1.assign(x0)
+                for i in range(self.nStages):
+                    self.x1.assign(self.x1 + self.dt*self.butcher_matrix[stage, i]*self.k[i])
+                self.x1.assign(self.x1)
+
+                if self.limiter is not None:
+                    self.limiter.apply(self.x1)
+
+        else:
+            # Set initial field
+            if stage == 0:
+                self.field_i[0].assign(x0)
+
+            # Use x0 as a first guess (otherwise may not converge)
+            self.field_i[stage+1].assign(x0)
+
+            # Update field_i for physics / limiters
+            for evaluate in self.evaluate_source:
+                # TODO: not implemented! Here we need to evaluate the m-th term
+                # in the i-th RHS with field_m
+                raise NotImplementedError(
+                    'Physics not implemented with RK schemes that do not use '
+                    + 'the increment form')
+            if self.limiter is not None:
+                self.limiter.apply(self.field_i[stage])
+
+            # Obtain field_ip1 = field_n - dt* sum_m{c_im*F[field_m]}
+            self.solver[stage].solve()
+
+            if (stage == self.nStages - 1):
+                self.x1.assign(self.field_i[stage+1])
+                if self.limiter is not None:
+                    self.limiter.apply(self.x1)
+
 
     def apply_cycle(self, x_out, x_in):
         """
@@ -944,8 +991,8 @@ class ForwardEuler(ExplicitMultistage):
     y^(n+1) = y^n + dt*k0                                                       \n
     """
     def __init__(self, domain, field_name=None, fixed_subcycles=None,
-                 subcycle_by_courant=None, solver_parameters=None,
-                 limiter=None, options=None):
+                 subcycle_by_courant=None, increment_form=True,
+                 solver_parameters=None, limiter=None, options=None):
         """
         Args:
             domain (:class:`Domain`): the model's domain object, containing the
@@ -961,6 +1008,9 @@ class ForwardEuler(ExplicitMultistage):
                 for one sub-cycle. Defaults to None, in which case adaptive
                 sub-cycling is not used. This option cannot be specified with the
                 `fixed_subcycles` argument.
+            increment_form (bool, optional): whether to write the RK scheme in
+                "increment form", solving for increments rather than updated
+                fields. Defaults to True.
             solver_parameters (dict, optional): dictionary of parameters to
                 pass to the underlying solver. Defaults to None.
             limiter (:class:`Limiter` object, optional): a limiter to apply to
@@ -974,6 +1024,7 @@ class ForwardEuler(ExplicitMultistage):
         super().__init__(domain, butcher_matrix, field_name=field_name,
                          fixed_subcycles=fixed_subcycles,
                          subcycle_by_courant=subcycle_by_courant,
+                         increment_form=increment_form,
                          solver_parameters=solver_parameters,
                          limiter=limiter, options=options)
 
@@ -989,8 +1040,8 @@ class SSPRK3(ExplicitMultistage):
     y^(n+1) = y^n + (1/6)*dt*(k0 + k1 + 4*k2)                                 \n
     """
     def __init__(self, domain, field_name=None, fixed_subcycles=None,
-                 subcycle_by_courant=None, solver_parameters=None,
-                 limiter=None, options=None):
+                 subcycle_by_courant=None, increment_form=True,
+                 solver_parameters=None, limiter=None, options=None):
         """
         Args:
             domain (:class:`Domain`): the model's domain object, containing the
@@ -1006,6 +1057,9 @@ class SSPRK3(ExplicitMultistage):
                 for one sub-cycle. Defaults to None, in which case adaptive
                 sub-cycling is not used. This option cannot be specified with the
                 `fixed_subcycles` argument.
+            increment_form (bool, optional): whether to write the RK scheme in
+                "increment form", solving for increments rather than updated
+                fields. Defaults to True.
             solver_parameters (dict, optional): dictionary of parameters to
                 pass to the underlying solver. Defaults to None.
             limiter (:class:`Limiter` object, optional): a limiter to apply to
@@ -1016,9 +1070,11 @@ class SSPRK3(ExplicitMultistage):
                 recovery method. Defaults to None.
         """
         butcher_matrix = np.array([[1., 0., 0.], [1./4., 1./4., 0.], [1./6., 1./6., 2./3.]])
+
         super().__init__(domain, butcher_matrix, field_name=field_name,
                          fixed_subcycles=fixed_subcycles,
                          subcycle_by_courant=subcycle_by_courant,
+                         increment_form=increment_form,
                          solver_parameters=solver_parameters,
                          limiter=limiter, options=options)
 
@@ -1039,7 +1095,8 @@ class RK4(ExplicitMultistage):
     where superscripts indicate the time-level.                               \n
     """
     def __init__(self, domain, field_name=None, fixed_subcycles=None,
-                 subcycle_by_courant=None, solver_parameters=None,
+                 subcycle_by_courant=None, increment_form=True,
+                 solver_parameters=None,
                  limiter=None, options=None):
         """
         Args:
@@ -1056,6 +1113,9 @@ class RK4(ExplicitMultistage):
                 for one sub-cycle. Defaults to None, in which case adaptive
                 sub-cycling is not used. This option cannot be specified with the
                 `fixed_subcycles` argument.
+            increment_form (bool, optional): whether to write the RK scheme in
+                "increment form", solving for increments rather than updated
+                fields. Defaults to True.
             solver_parameters (dict, optional): dictionary of parameters to
                 pass to the underlying solver. Defaults to None.
             limiter (:class:`Limiter` object, optional): a limiter to apply to
@@ -1069,6 +1129,7 @@ class RK4(ExplicitMultistage):
         super().__init__(domain, butcher_matrix, field_name=field_name,
                          fixed_subcycles=fixed_subcycles,
                          subcycle_by_courant=subcycle_by_courant,
+                         increment_form=increment_form,
                          solver_parameters=solver_parameters,
                          limiter=limiter, options=options)
 
@@ -1087,8 +1148,8 @@ class Heun(ExplicitMultistage):
     number.
     """
     def __init__(self, domain, field_name=None, fixed_subcycles=None,
-                 subcycle_by_courant=None, solver_parameters=None,
-                 limiter=None, options=None):
+                 subcycle_by_courant=None, increment_form=True,
+                 solver_parameters=None, limiter=None, options=None):
         """
         Args:
             domain (:class:`Domain`): the model's domain object, containing the
@@ -1104,6 +1165,9 @@ class Heun(ExplicitMultistage):
                 for one sub-cycle. Defaults to None, in which case adaptive
                 sub-cycling is not used. This option cannot be specified with the
                 `fixed_subcycles` argument.
+            increment_form (bool, optional): whether to write the RK scheme in
+                "increment form", solving for increments rather than updated
+                fields. Defaults to True.
             solver_parameters (dict, optional): dictionary of parameters to
                 pass to the underlying solver. Defaults to None.
             limiter (:class:`Limiter` object, optional): a limiter to apply to
@@ -1117,6 +1181,7 @@ class Heun(ExplicitMultistage):
         super().__init__(domain, butcher_matrix, field_name=field_name,
                          fixed_subcycles=fixed_subcycles,
                          subcycle_by_courant=subcycle_by_courant,
+                         increment_form=increment_form,
                          solver_parameters=solver_parameters,
                          limiter=limiter, options=options)
 
@@ -1919,7 +1984,6 @@ class AdamsMoulton(MultilevelTimeDiscretisation):
         """
         if self.initial_timesteps < self.nlevels-1:
             self.initial_timesteps += 1
-            print(self.initial_timesteps)
             solver = self.solver0
         else:
             solver = self.solver

--- a/gusto/transport_methods.py
+++ b/gusto/transport_methods.py
@@ -309,7 +309,9 @@ def upwind_continuity_form(domain, test, q, ibp=IntegrateByParts.ONCE, outflow=F
 
     return ibp_label(transport(form, TransportEquationType.conservative), ibp)
 
-def upwind_tracer_conservative_form(domain, test, q, rho, ibp=IntegrateByParts.ONCE, outflow=False):
+
+def upwind_tracer_conservative_form(domain, test, q, rho,
+                                    ibp=IntegrateByParts.ONCE, outflow=False):
     u"""
     The form corresponding to the DG upwind continuity transport operator.
 
@@ -344,9 +346,9 @@ def upwind_tracer_conservative_form(domain, test, q, rho, ibp=IntegrateByParts.O
     ubar = Function(Vu)
 
     if ibp == IntegrateByParts.ONCE:
-        L = -inner(grad(test), outer(inner(q,rho), ubar))*dx
+        L = -inner(grad(test), outer(inner(q, rho), ubar))*dx
     else:
-        L = inner(test, div(outer(inner(q,rho), ubar)))*dx
+        L = inner(test, div(outer(inner(q, rho), ubar)))*dx
 
     if ibp != IntegrateByParts.NEVER:
         n = FacetNormal(domain.mesh)

--- a/gusto/transport_methods.py
+++ b/gusto/transport_methods.py
@@ -35,7 +35,7 @@ class TransportMethod(SpatialMethod):
         super().__init__(equation, variable, transport)
 
         self.transport_equation_type = self.original_form.terms[0].get(transport)
-        
+
         if self.transport_equation_type == TransportEquationType.tracer_conservative:
             # Extract associated density variable:
             # This does assume the same ordering of tracers and fields...
@@ -308,14 +308,14 @@ def upwind_continuity_form(domain, test, q, ibp=IntegrateByParts.ONCE, outflow=F
     form = transporting_velocity(L, ubar)
 
     return ibp_label(transport(form, TransportEquationType.conservative), ibp)
-    
+
 def upwind_tracer_conservative_form(domain, test, q, rho, ibp=IntegrateByParts.ONCE, outflow=False):
     u"""
     The form corresponding to the DG upwind continuity transport operator.
 
     This discretises ∇.(u*q*rho), for transporting velocity u, transported
     variable q, and its reference density, rho. Although the tracer q obeys an advection
-    equation, the transport term is in a conservative form. 
+    equation, the transport term is in a conservative form.
 
     Args:
         domain (:class:`Domain`): the model's domain object, containing the
@@ -364,8 +364,6 @@ def upwind_tracer_conservative_form(domain, test, q, rho, ibp=IntegrateByParts.O
         L += test*un*q*rho*(ds_v + ds_t + ds_b)
 
     form = transporting_velocity(L, ubar)
-    
-    print('DGUpwind with tracer conservative, called')
 
     return ibp_label(transport(form, TransportEquationType.tracer_conservative), ibp)
 

--- a/integration-tests/model/test_time_discretisation.py
+++ b/integration-tests/model/test_time_discretisation.py
@@ -8,8 +8,10 @@ def run(timestepper, tmax, f_end):
     return norm(timestepper.fields("f") - f_end) / norm(f_end)
 
 
-@pytest.mark.parametrize("scheme", ["ssprk", "TrapeziumRule", "ImplicitMidpoint", "QinZhang",
-                                    "RK4", "Heun", "BDF2", "TR_BDF2", "AdamsBashforth", "Leapfrog", "AdamsMoulton"])
+@pytest.mark.parametrize("scheme",
+    ["ssprk3_increment", "TrapeziumRule", "ImplicitMidpoint", "QinZhang", "RK4",
+     "Heun", "BDF2", "TR_BDF2", "AdamsBashforth", "Leapfrog", "AdamsMoulton",
+     "ssprk3_predictor"])
 def test_time_discretisation(tmpdir, scheme, tracer_setup):
     if (scheme == "AdamsBashforth"):
         # Tighter stability constraints
@@ -25,8 +27,10 @@ def test_time_discretisation(tmpdir, scheme, tracer_setup):
         V = domain.spaces("DG")
         eqn = AdvectionEquation(domain, V, "f")
 
-    if scheme == "ssprk":
-        transport_scheme = SSPRK3(domain)
+    if scheme == "ssprk3_increment":
+        transport_scheme = SSPRK3(domain, increment_form=True)
+    elif scheme == "ssprk3_predictor":
+        transport_scheme = SSPRK3(domain, increment_form=False)
     elif scheme == "TrapeziumRule":
         transport_scheme = TrapeziumRule(domain)
     elif scheme == "ImplicitMidpoint":

--- a/integration-tests/model/test_time_discretisation.py
+++ b/integration-tests/model/test_time_discretisation.py
@@ -8,10 +8,10 @@ def run(timestepper, tmax, f_end):
     return norm(timestepper.fields("f") - f_end) / norm(f_end)
 
 
-@pytest.mark.parametrize("scheme",
-    ["ssprk3_increment", "TrapeziumRule", "ImplicitMidpoint", "QinZhang", "RK4",
-     "Heun", "BDF2", "TR_BDF2", "AdamsBashforth", "Leapfrog", "AdamsMoulton",
-     "ssprk3_predictor"])
+@pytest.mark.parametrize(
+    "scheme", ["ssprk3_increment", "TrapeziumRule", "ImplicitMidpoint",
+               "QinZhang", "RK4", "Heun", "BDF2", "TR_BDF2", "AdamsBashforth",
+               "Leapfrog", "AdamsMoulton", "AdamsMoulton", "ssprk3_predictor"])
 def test_time_discretisation(tmpdir, scheme, tracer_setup):
     if (scheme == "AdamsBashforth"):
         # Tighter stability constraints


### PR DESCRIPTION
This PR implements a different formulation for the explicit multi-stage (RK) time discretisations, which facilitates a conservative and consistent tracer transport scheme.

Explicit multi-stage schemes now can be cast in:
- `increment_form`: our current method, which is the default. Solve for `k = F[field]`
- `update_form`: in which we solve for an updated field. Each stage has its own LHS, RHS and solver, which is necessary to facilitate the conservative/consistent transport scheme.