### PR TITLE
Thermal linear solver fixes

### DIFF
--- a/gusto/linear_solvers.py
+++ b/gusto/linear_solvers.py
@@ -605,7 +605,9 @@ class ThermalSWSolver(TimesteppingSolver):
         u, D = TrialFunctions(M)
 
         # Get background buoyancy and depth
-        bbar = split(equation.X_ref)[2]
+        _bbar = split(equation.X_ref)[2]
+        VH1 = equation.domain.spaces("H1")
+        bbar = Function(VH1).interpolate(_bbar)
         Dbar = split(equation.X_ref)[1]
 
         # Approximate elimination of b


### PR DESCRIPTION
This PR makes three changes to the `ThermalSWSolver` class in `linear_solvers.py`.

1. Checks that buoyancy is one of the fields in the equations set when using the `ThermalSWSolver`. The solver should only be used in equations sets with a thermal field and this will raise a `NotImplementedError` if the solver is being used and there is no buoyancy field.
2. Checks that a reference profile for buoyancy has been set. The solver will still work without a reference buoyancy profile but will work on the basis that the reference buoyancy is zero. This will log a warning to the user that no buoyancy reference profile has been set and to set one if the profile should be a non-zero one.
3. Considers `bbar` to be in the DG space and discretises the terms involving derivatives of `bbar` in the thermal linear solver using integration by parts.  