### PR TITLE
Fix to linearisation of contiunuity split, and solver parameters now passed through for IMEX Multistage

### DIFF
--- a/gusto/common_forms.py
+++ b/gusto/common_forms.py
@@ -3,7 +3,7 @@ Provides some basic forms for discretising various common terms in equations for
 geophysical fluid dynamics."""
 
 from firedrake import (dx, dot, grad, div, inner, outer, cross, curl, split,
-                       TestFunction, TestFunctions, TrialFunction)
+                       TestFunction, TestFunctions, TrialFunctions)
 from firedrake.fml import subject, drop
 from gusto.configuration import TransportEquationType
 from gusto.labels import (transport, transporting_velocity, diffusion,
@@ -245,7 +245,7 @@ def split_continuity_form(equation):
 
             # Add linearisations of new terms if required
             if (t.has_label(linearisation)):
-                u_trial = TrialFunction(W)[u_idx]
+                u_trial = TrialFunctions(W)[u_idx]
                 qbar = split(equation.X_ref)[idx]
                 # Add linearisation to adv_term
                 linear_adv_term = linear_advection_form(test, qbar, u_trial)

--- a/gusto/time_discretisation.py
+++ b/gusto/time_discretisation.py
@@ -475,7 +475,7 @@ class IMEXMultistage(TimeDiscretisation):
             # setup solver using residual defined in derived class
             problem = NonlinearVariationalProblem(self.res(stage), self.x_out, bcs=self.bcs)
             solver_name = self.field_name+self.__class__.__name__ + "%s" % (stage)
-            solvers.append(NonlinearVariationalSolver(problem, options_prefix=solver_name))
+            solvers.append(NonlinearVariationalSolver(problem, solver_parameters=self.solver_parameters, options_prefix=solver_name))
         return solvers
 
     @cached_property
@@ -484,7 +484,7 @@ class IMEXMultistage(TimeDiscretisation):
         # setup solver using lhs and rhs defined in derived class
         problem = NonlinearVariationalProblem(self.final_res, self.x_out, bcs=self.bcs)
         solver_name = self.field_name+self.__class__.__name__
-        return NonlinearVariationalSolver(problem, options_prefix=solver_name)
+        return NonlinearVariationalSolver(problem, solver_parameters=self.solver_parameters, options_prefix=solver_name)
 
     def apply(self, x_out, x_in):
         self.x1.assign(x_in)


### PR DESCRIPTION
IMEX Multistage was using PetSc default solver settings (very inefficient) so now passed through default solver parameters. Longer term it might be wise to have two sets of solver parameters "linear solver parameters" for linear solves (mass matrix inversions etc.) and one for nonlinear solvers (for implicit time stepping).
A fix to a bug in the linearisation in common form continuity split has also been added