### PR TITLE
Siqn improvements

### DIFF
--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -741,9 +741,10 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
 
             for inner in range(self.num_inner):
 
+                # TODO: this is where to update the reference state
+
                 with timed_stage("Apply forcing terms"):
                     logger.info(f'SIQN: Implicit forcing {(outer, inner)}')
-                    # TODO: why don't we update xnp1 with a better guess here?
                     self.forcing.apply(xp, xnp1, xrhs, "implicit")
 
                 xrhs -= xnp1(self.field_name)

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -704,10 +704,11 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
 
         with timed_stage("Apply forcing terms"):
             logger.info('SIQN: Explicit forcing')
-            # TODO: check if forcing is applied to x_after_slow or xn
             # Put explicit forcing into xstar
-            self.forcing.apply(x_after_slow, x_after_slow, xstar(self.field_name), "explicit")
+            self.forcing.apply(x_after_slow, xn, xstar(self.field_name), "explicit")
 
+        # set xp here so that variables that are not transported have
+        # the correct values
         xp(self.field_name).assign(xstar(self.field_name))
 
         for outer in range(self.num_outer):

--- a/gusto/timeloop.py
+++ b/gusto/timeloop.py
@@ -479,7 +479,8 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
                  auxiliary_equations_and_schemes=None, linear_solver=None,
                  diffusion_schemes=None, physics_schemes=None,
                  slow_physics_schemes=None, fast_physics_schemes=None,
-                 alpha=Constant(0.5), num_outer=4, num_inner=1):
+                 alpha=Constant(0.5), off_centred_u=False,
+                 num_outer=4, num_inner=1):
 
         """
         Args:
@@ -516,6 +517,9 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
             alpha (`ufl.Constant`, optional): the semi-implicit off-centering
                 parameter. A value of 1 corresponds to fully implicit, while 0
                 corresponds to fully explicit. Defaults to Constant(0.5).
+            off_centred_u (bool, optional): option to offcentre the transporting
+                velocity. Defaults to False, in which case transporting velocity
+                is centred. If True offcentring uses value of alpha.
             num_outer (int, optional): number of outer iterations in the semi-
                 implicit algorithm. The outer loop includes transport and any
                 fast physics schemes. Defaults to 4. Note that default used by
@@ -530,6 +534,10 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
         self.num_outer = num_outer
         self.num_inner = num_inner
         self.alpha = alpha
+
+        # default is to not offcentre transporting velocity but if it
+        # is offcentred then use the same value as alpha
+        self.alpha_u = Constant(alpha) if off_centred_u else Constant(0.5)
 
         self.spatial_methods = spatial_methods
 
@@ -637,7 +645,7 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
         xn = self.x.n
         xnp1 = self.x.np1
         # computes ubar from un and unp1
-        return xn('u') + self.alpha*(xnp1('u')-xn('u'))
+        return xn('u') + self.alpha_u*(xnp1('u')-xn('u'))
 
     def setup_fields(self):
         """Sets up time levels n, star, p and np1"""


### PR DESCRIPTION
This makes the SIQN timeloop closer to the LFRic timeloop in a couple of very minor ways:

1. The explicit forcing is now applied to `xn` rather than `x_after_slow_phys`. Since we haven't yet run anything slow physics this should not change anything.
2. Add the option to offcentre the transporting velocity but default to using a centred transporting velocity. This will only affect any runs that use an offcentring value of `alpha` that is not equal to a half.