### PR TITLE
Min/Max kernels

### DIFF
--- a/gusto/kernels.py
+++ b/gusto/kernels.py
@@ -10,7 +10,8 @@ tested.
 """
 
 from firedrake import dx
-from firedrake.parloops import par_loop, READ, WRITE
+from firedrake.parloops import par_loop, READ, WRITE, MIN, MAX, op2
+import numpy as np
 
 
 class LimitMidpoints():
@@ -112,3 +113,61 @@ class ClipZero():
                  {"field": (field, WRITE),
                   "field_in": (field_in, READ)},
                  is_loopy_kernel=True)
+
+
+class MinKernel():
+    """Finds the minimum DoF value of a field."""
+
+    def __init__(self):
+
+        self._kernel = op2.Kernel("""
+            static void minify(double *a, double *b) {
+                a[0] = a[0] > b[0] ? b[0] : a[0];
+            }
+            """, "minify")
+
+    def apply(self, field):
+        """
+        Performs the par loop.
+
+        Args:
+            field (:class:`Function`): The field to take the minimum of.
+
+        Returns:
+            The minimum DoF value of the field.
+        """
+
+        fmin = op2.Global(1, np.finfo(float).max, dtype=float, comm=field._comm)
+
+        op2.par_loop(self._kernel, field.dof_dset.set, fmin(MIN), field.dat(READ))
+
+        return fmin.data[0]
+
+
+class MaxKernel():
+    """Finds the maximum DoF value of a field."""
+
+    def __init__(self):
+
+        self._kernel = op2.Kernel("""
+            static void maxify(double *a, double *b) {
+                a[0] = a[0] < b[0] ? b[0] : a[0];
+            }
+            """, "maxify")
+
+    def apply(self, field):
+        """
+        Performs the par loop.
+
+        Args:
+            field (:class:`Function`): The field to take the maximum of.
+
+        Returns:
+            The maximum DoF value of the field.
+        """
+
+        fmax = op2.Global(1, np.finfo(float).min, dtype=float, comm=field._comm)
+
+        op2.par_loop(self._kernel, field.dof_dset.set, fmax(MAX), field.dat(READ))
+
+        return fmax.data[0]

--- a/unit-tests/kernel_tests/test_max_kernel.py
+++ b/unit-tests/kernel_tests/test_max_kernel.py
@@ -1,0 +1,47 @@
+"""
+A test of the MaxKernel kernel, which finds the global maximum of a field.
+"""
+
+from firedrake import UnitSquareMesh, Function, FunctionSpace, SpatialCoordinate
+from gusto import kernels
+import numpy as np
+
+
+def test_max_kernel():
+
+    # ------------------------------------------------------------------------ #
+    # Set up meshes and spaces
+    # ------------------------------------------------------------------------ #
+
+    mesh = UnitSquareMesh(3, 3)
+
+    DG1 = FunctionSpace(mesh, "DG", 1)
+
+    field = Function(DG1)
+
+    # ------------------------------------------------------------------------ #
+    # Initial conditions
+    # ------------------------------------------------------------------------ #
+
+    x, y = SpatialCoordinate(mesh)
+
+    # Some random expression
+    init_expr = (20./3.)*x*y + 300.
+    field.interpolate(init_expr)
+
+    # Set a maximum value
+    max_val = 40069.18
+    field.dat.data[5] = max_val
+
+    # ------------------------------------------------------------------------ #
+    # Apply kernel
+    # ------------------------------------------------------------------------ #
+
+    kernel = kernels.MaxKernel()
+    new_max = kernel.apply(field)
+
+    # ------------------------------------------------------------------------ #
+    # Check values
+    # ------------------------------------------------------------------------ #
+
+    assert np.isclose(new_max, max_val), 'maximum kernel is not correct'

--- a/unit-tests/kernel_tests/test_min_kernel.py
+++ b/unit-tests/kernel_tests/test_min_kernel.py
@@ -1,0 +1,47 @@
+"""
+A test of the MinKernel kernel, which finds the global minimum of a field.
+"""
+
+from firedrake import UnitSquareMesh, Function, FunctionSpace, SpatialCoordinate
+from gusto import kernels
+import numpy as np
+
+
+def test_min_kernel():
+
+    # ------------------------------------------------------------------------ #
+    # Set up meshes and spaces
+    # ------------------------------------------------------------------------ #
+
+    mesh = UnitSquareMesh(3, 3)
+
+    DG1 = FunctionSpace(mesh, "DG", 1)
+
+    field = Function(DG1)
+
+    # ------------------------------------------------------------------------ #
+    # Initial conditions
+    # ------------------------------------------------------------------------ #
+
+    x, y = SpatialCoordinate(mesh)
+
+    # Some random expression
+    init_expr = (20./3.)*x*y + 300.
+    field.interpolate(init_expr)
+
+    # Set a minimum value
+    min_val = -400.18
+    field.dat.data[5] = min_val
+
+    # ------------------------------------------------------------------------ #
+    # Apply kernel
+    # ------------------------------------------------------------------------ #
+
+    kernel = kernels.MinKernel()
+    new_min = kernel.apply(field)
+
+    # ------------------------------------------------------------------------ #
+    # Check values
+    # ------------------------------------------------------------------------ #
+
+    assert np.isclose(new_min, min_val), 'Minimum kernel is not correct'


### PR DESCRIPTION
This moves the kernels used in computing field min/max diagnostics to `kernels.py`, and adds unit-tests for them.

It also fixes these kernels (thanks for spotting this Tim!)

This allows us to close #337 and #467 