### PR TITLE
Name terms

### DIFF
--- a/examples/compressible/mountain_hydrostatic.py
+++ b/examples/compressible/mountain_hydrostatic.py
@@ -57,7 +57,7 @@ domain = Domain(mesh, dt, "CG", 1)
 # Equation
 parameters = CompressibleParameters(g=9.80665, cp=1004.)
 sponge = SpongeLayerParameters(H=H, z_level=H-20000, mubar=0.3)
-eqns = CompressibleEulerEquations(domain, parameters, sponge=sponge)
+eqns = CompressibleEulerEquations(domain, parameters, sponge_options=sponge)
 
 # I/O
 dirname = 'hydrostatic_mountain'

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -1031,10 +1031,11 @@ class CompressibleEulerEquations(PrognosticEquationSet):
         # -------------------------------------------------------------------- #
         # Gravitational Term
         # -------------------------------------------------------------------- #
-        gravity_form = gravity(subject(prognostic(Term(g*inner(domain.k, w)*dx),
+        gravity_form = gravity(subject(prognostic(g*inner(domain.k, w)*dx,
                                                   'u'), self.X))
 
-        residual = (mass_form + adv_form + pressure_gradient_form + gravity_form)
+        residual = (mass_form + adv_form + pressure_gradient_form
+                    + gravity_form)
 
         # -------------------------------------------------------------------- #
         # Moist Thermodynamic Divergence Term
@@ -1074,9 +1075,9 @@ class CompressibleEulerEquations(PrognosticEquationSet):
         # Extra Terms (Coriolis, Sponge, Diffusion and others)
         # -------------------------------------------------------------------- #
         if Omega is not None:
-            # TODO: add linearisation and label for this
-            residual += subject(prognostic(
-                inner(w, cross(2*Omega, u))*dx, "u"), self.X)
+            # TODO: add linearisation
+            residual += coriolis(subject(prognostic(
+                inner(w, cross(2*Omega, u))*dx, "u"), self.X))
 
         if sponge_options is not None:
             W_DG = FunctionSpace(domain.mesh, "DG", 2)
@@ -1370,12 +1371,14 @@ class BoussinesqEquations(PrognosticEquationSet):
         # -------------------------------------------------------------------- #
         # Pressure Gradient Term
         # -------------------------------------------------------------------- #
-        pressure_gradient_form = subject(prognostic(-div(w)*p*dx, 'u'), self.X)
+        pressure_gradient_form = pressure_gradient(subject(prognostic(
+            -div(w)*p*dx, 'u'), self.X))
 
         # -------------------------------------------------------------------- #
         # Gravitational Term
         # -------------------------------------------------------------------- #
-        gravity_form = subject(prognostic(-b*inner(w, domain.k)*dx, 'u'), self.X)
+        gravity_form = gravity(subject(prognostic(
+            -b*inner(w, domain.k)*dx, 'u'), self.X))
 
         # -------------------------------------------------------------------- #
         # Divergence Term
@@ -1400,9 +1403,9 @@ class BoussinesqEquations(PrognosticEquationSet):
         # Extra Terms (Coriolis)
         # -------------------------------------------------------------------- #
         if Omega is not None:
-            # TODO: add linearisation and label for this
-            residual += subject(prognostic(
-                inner(w, cross(2*Omega, u))*dx, 'u'), self.X)
+            # TODO: add linearisation
+            residual += coriolis(subject(prognostic(
+                inner(w, cross(2*Omega, u))*dx, 'u'), self.X))
 
         # -------------------------------------------------------------------- #
         # Linearise equations

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -8,13 +8,13 @@ from firedrake import (
     SpatialCoordinate, split, Constant, action
 )
 from firedrake.fml import (
-    Term, all_terms, keep, drop, Label, subject, name_label,
+    Term, all_terms, keep, drop, Label, subject,
     replace_subject, replace_trial_function
 )
 from gusto.fields import PrescribedFields
 from gusto.labels import (
     time_derivative, transport, prognostic, hydrostatic, linearisation,
-    pressure_gradient, coriolis
+    pressure_gradient, coriolis, divergence, gravity, incompressible, sponge
 )
 from gusto.thermodynamics import exner_pressure
 from gusto.common_forms import (
@@ -892,7 +892,7 @@ class CompressibleEulerEquations(PrognosticEquationSet):
     pressure.
     """
 
-    def __init__(self, domain, parameters, Omega=None, sponge=None,
+    def __init__(self, domain, parameters, Omega=None, sponge_options=None,
                  extra_terms=None, space_names=None,
                  linearisation_map='default',
                  u_transport_option="vector_invariant_form",
@@ -907,8 +907,9 @@ class CompressibleEulerEquations(PrognosticEquationSet):
                 the model's physical parameters.
             Omega (:class:`ufl.Expr`, optional): an expression for the planet's
                 rotation vector. Defaults to None.
-            sponge (:class:`ufl.Expr`, optional): an expression for a sponge
-                layer. Defaults to None.
+            sponge_options (:class:`SpongeLayerParameters`, optional): any
+                parameters for applying a sponge layer to the upper boundary.
+                Defaults to None.
             extra_terms (:class:`ufl.Expr`, optional): any extra terms to be
                 included in the equation set. Defaults to None.
             space_names (dict, optional): a dictionary of strings for names of
@@ -925,9 +926,9 @@ class CompressibleEulerEquations(PrognosticEquationSet):
                 'vector_invariant_form', 'vector_advection_form' and
                 'circulation_form'.
                 Defaults to 'vector_invariant_form'.
-            diffusion_options (:class:`DiffusionOptions`, optional): any options
-                to specify for applying diffusion terms to variables. Defaults
-                to None.
+            diffusion_options (:class:`DiffusionParameters`, optional): any
+                options to specify for applying diffusion terms to variables.
+                Defaults to None.
             no_normal_flow_bc_ids (list, optional): a list of IDs of domain
                 boundaries at which no normal flow will be enforced. Defaults to
                 None.
@@ -1023,15 +1024,15 @@ class CompressibleEulerEquations(PrognosticEquationSet):
                 raise NotImplementedError('Only mixing ratio tracers are implemented')
         theta_v = theta / (Constant(1.0) + tracer_mr_total)
 
-        pressure_gradient_form = name_label(subject(prognostic(
+        pressure_gradient_form = pressure_gradient(subject(prognostic(
             cp*(-div(theta_v*w)*exner*dx
-                + jump(theta_v*w, n)*avg(exner)*dS_v), 'u'), self.X), "pressure_gradient")
+                + jump(theta_v*w, n)*avg(exner)*dS_v), 'u'), self.X))
 
         # -------------------------------------------------------------------- #
         # Gravitational Term
         # -------------------------------------------------------------------- #
-        gravity_form = name_label(subject(prognostic(Term(g*inner(domain.k, w)*dx),
-                                                     'u'), self.X), "gravity")
+        gravity_form = gravity(subject(prognostic(Term(g*inner(domain.k, w)*dx),
+                                                  'u'), self.X))
 
         residual = (mass_form + adv_form + pressure_gradient_form + gravity_form)
 
@@ -1077,22 +1078,22 @@ class CompressibleEulerEquations(PrognosticEquationSet):
             residual += subject(prognostic(
                 inner(w, cross(2*Omega, u))*dx, "u"), self.X)
 
-        if sponge is not None:
+        if sponge_options is not None:
             W_DG = FunctionSpace(domain.mesh, "DG", 2)
             x = SpatialCoordinate(domain.mesh)
             z = x[len(x)-1]
-            H = sponge.H
-            zc = sponge.z_level
+            H = sponge_options.H
+            zc = sponge_options.z_level
             assert float(zc) < float(H), \
                 "The sponge level is set above the height the your domain"
-            mubar = sponge.mubar
+            mubar = sponge_options.mubar
             muexpr = conditional(z <= zc,
                                  0.0,
                                  mubar*sin((pi/2.)*(z-zc)/(H-zc))**2)
             self.mu = self.prescribed_fields("sponge", W_DG).interpolate(muexpr)
 
-            residual += name_label(subject(prognostic(
-                self.mu*inner(w, domain.k)*inner(u, domain.k)*dx, 'u'), self.X), "sponge")
+            residual += sponge(subject(prognostic(
+                self.mu*inner(w, domain.k)*inner(u, domain.k)*dx, 'u'), self.X))
 
         if diffusion_options is not None:
             for field, diffusion in diffusion_options:
@@ -1196,12 +1197,11 @@ class HydrostaticCompressibleEulerEquations(CompressibleEulerEquations):
 
         k = self.domain.k
         u = split(self.X)[0]
-        self.residual += name_label(
+        self.residual += hydrostatic(
             subject(
                 prognostic(
                     -inner(k, self.tests[0]) * inner(k, u) * dx, "u"),
-                self.X),
-            "hydrostatic_form")
+                self.X))
 
     def hydrostatic_projection(self, t):
         """
@@ -1380,19 +1380,17 @@ class BoussinesqEquations(PrognosticEquationSet):
         # -------------------------------------------------------------------- #
         # Divergence Term
         # -------------------------------------------------------------------- #
-
         if compressible:
             cs = parameters.cs
-            divergence_form = subject(
-                prognostic(cs**2 * phi * div(u) * dx, 'p'), self.X)
+            divergence_form = divergence(subject(
+                prognostic(cs**2 * phi * div(u) * dx, 'p'), self.X))
         else:
             # This enforces that div(u) = 0
             # The p features here so that the div(u) evaluated in the
             # "forcing" step replaces the whole pressure field, rather than
             # merely providing an increment to it.
-            divergence_form = name_label(
+            divergence_form = incompressible(
                 subject(prognostic(phi*(p-div(u))*dx, 'p'), self.X),
-                "incompressibility"
             )
 
         residual = (mass_form + adv_form + divergence_form

--- a/gusto/forcing.py
+++ b/gusto/forcing.py
@@ -4,9 +4,10 @@ from firedrake import (
     Function, TrialFunctions, DirichletBC, LinearVariationalProblem,
     LinearVariationalSolver
 )
-from firedrake.fml import drop, replace_subject, name_label
+from firedrake.fml import drop, replace_subject
 from gusto.labels import (
-    transport, diffusion, time_derivative, hydrostatic, physics_label
+    transport, diffusion, time_derivative, hydrostatic, physics_label,
+    sponge, incompressible
 )
 from gusto.logging import logger, DEBUG, logging_ksp_monitor_true_residual
 
@@ -35,7 +36,7 @@ class Forcing(object):
         """
 
         self.field_name = equation.field_name
-        implicit_terms = ["incompressibility", "sponge"]
+        implicit_terms = [incompressible, sponge]
         dt = equation.domain.dt
 
         W = equation.function_space
@@ -45,9 +46,10 @@ class Forcing(object):
         # set up boundary conditions on the u subspace of W
         bcs = [DirichletBC(W.sub(0), bc.function_arg, bc.sub_domain) for bc in equation.bcs['u']]
 
-        # drop terms relating to transport and diffusion
+        # drop terms relating to transport, diffusion and physics
         residual = equation.residual.label_map(
-            lambda t: any(t.has_label(transport, diffusion, physics_label, return_tuple=True)), drop)
+            lambda t: any(t.has_label(transport, diffusion, physics_label,
+                                      return_tuple=True)), drop)
 
         # the lhs of both of the explicit and implicit solvers is just
         # the time derivative form
@@ -59,38 +61,35 @@ class Forcing(object):
         # the explicit forms are multiplied by (1-alpha) and moved to the rhs
         L_explicit = -(1-alpha)*dt*residual.label_map(
             lambda t:
-                t.has_label(time_derivative)
-                or t.get(name_label) in implicit_terms
-                or t.get(name_label) == "hydrostatic_form",
+                any(t.has_label(time_derivative, hydrostatic, *implicit_terms,
+                                return_tuple=True)),
             drop,
             replace_subject(self.x0))
 
         # the implicit forms are multiplied by alpha and moved to the rhs
         L_implicit = -alpha*dt*residual.label_map(
             lambda t:
-                t.has_label(time_derivative)
-                or t.get(name_label) in implicit_terms
-                or t.get(name_label) == "hydrostatic_form",
+                any(t.has_label(
+                    time_derivative, hydrostatic, *implicit_terms,
+                    return_tuple=True)),
             drop,
             replace_subject(self.x0))
 
         # now add the terms that are always fully implicit
-        if any(t.get(name_label) in implicit_terms for t in residual):
-            L_implicit -= dt*residual.label_map(
-                lambda t: t.get(name_label) in implicit_terms,
-                replace_subject(self.x0),
-                drop)
+        L_implicit -= dt*residual.label_map(
+            lambda t: any(t.has_label(*implicit_terms, return_tuple=True)),
+            replace_subject(self.x0),
+            drop)
 
         # the hydrostatic equations require some additional forms:
         if any([t.has_label(hydrostatic) for t in residual]):
-
             L_explicit += residual.label_map(
-                lambda t: t.get(name_label) == "hydrostatic_form",
+                lambda t: t.has_label(hydrostatic),
                 replace_subject(self.x0),
                 drop)
 
             L_implicit -= residual.label_map(
-                lambda t: t.get(name_label) == "hydrostatic_form",
+                lambda t: t.has_label(hydrostatic),
                 replace_subject(self.x0),
                 drop)
 

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -39,7 +39,8 @@ class DynamicsLabel(Label):
             labelled_terms = (Label.__call__(self, t, value) for t in new_target.terms)
             return LabelledForm(*labelled_terms)
         else:
-            super().__call__(new_target, value)
+            new = super().__call__(new_target, value)
+            return new
 
 
 class PhysicsLabel(Label):
@@ -82,7 +83,8 @@ class PhysicsLabel(Label):
             labelled_terms = (Label.__call__(self, t, value) for t in new_target.terms)
             return LabelledForm(*labelled_terms)
         else:
-            super().__call__(new_target, value)
+            new = super().__call__(new_target, value)
+            return new
 
 
 # ---------------------------------------------------------------------------- #

--- a/gusto/labels.py
+++ b/gusto/labels.py
@@ -88,16 +88,22 @@ class PhysicsLabel(Label):
 # ---------------------------------------------------------------------------- #
 # Common Labels
 # ---------------------------------------------------------------------------- #
-
-time_derivative = Label("time_derivative")
 implicit = Label("implicit")
 explicit = Label("explicit")
-transport = Label("transport", validator=lambda value: type(value) == TransportEquationType)
-diffusion = Label("diffusion")
 transporting_velocity = Label("transporting_velocity", validator=lambda value: type(value) in [Function, ufl.tensors.ListTensor])
 prognostic = Label("prognostic", validator=lambda value: type(value) == str)
-pressure_gradient = DynamicsLabel("pressure_gradient")
-coriolis = DynamicsLabel("coriolis")
 linearisation = Label("linearisation", validator=lambda value: type(value) in [LabelledForm, Term])
 ibp_label = Label("ibp", validator=lambda value: type(value) == IntegrateByParts)
-hydrostatic = Label("hydrostatic", validator=lambda value: type(value) in [LabelledForm, Term])
+
+# labels for terms in the equations
+time_derivative = Label("time_derivative")
+transport = Label("transport",
+                  validator=lambda value: type(value) == TransportEquationType)
+diffusion = Label("diffusion")
+pressure_gradient = DynamicsLabel("pressure_gradient")
+coriolis = DynamicsLabel("coriolis")
+divergence = DynamicsLabel("divergence")
+gravity = DynamicsLabel("gravity")
+hydrostatic = DynamicsLabel("hydrostatic")
+incompressible = DynamicsLabel("incompressible")
+sponge = DynamicsLabel("sponge")


### PR DESCRIPTION
This fixes an inconsistency in the way we name the terms in our equations. I've got rid of `name_label` and created labels for the terms that we have.

This also fixes a bug in the `DynamicsLabel` and `PhysicsLabel` classes where nothing was returned if the super class was called.