### PR TITLE
Fix warnings

### DIFF
--- a/gusto/diagnostics.py
+++ b/gusto/diagnostics.py
@@ -8,6 +8,7 @@ from firedrake import assemble, dot, dx, Function, sqrt, \
     Projector, Interpolator, FunctionSpace, FiniteElement, \
     TensorProductElement
 from firedrake.assign import Assigner
+from ufl.domain import extract_unique_domain
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 import gusto.thermodynamics as tde
@@ -93,7 +94,7 @@ class Diagnostics(object):
             f (:class:`Function`): field to compute diagnostic for.
         """
 
-        area = assemble(1*dx(domain=f.ufl_domain()))
+        area = assemble(1*dx(domain=extract_unique_domain(f)))
         return sqrt(assemble(inner(f, f)*dx)/area)
 
     @staticmethod

--- a/gusto/io.py
+++ b/gusto/io.py
@@ -7,8 +7,9 @@ import sys
 import time
 from gusto.diagnostics import Diagnostics, CourantNumber
 from gusto.meshes import get_flat_latlon_mesh
-from firedrake import (Function, functionspaceimpl, File, Constant,
+from firedrake import (Function, functionspaceimpl, Constant,
                        DumbCheckpoint, FILE_CREATE, FILE_READ, CheckpointFile)
+from firedrake.output import VTKFile
 from pyop2.mpi import MPI
 import numpy as np
 from gusto.logging import logger, update_logfile_location
@@ -423,7 +424,7 @@ class IO(object):
         if self.output.dump_vtus:
             # setup pvd output file
             outfile_pvd = path.join(self.dumpdir, "field_output.pvd")
-            self.pvd_dumpfile = File(
+            self.pvd_dumpfile = VTKFile(
                 outfile_pvd, project_output=self.output.project_fields,
                 comm=self.mesh.comm)
 
@@ -453,9 +454,9 @@ class IO(object):
         if len(self.output.dumplist_latlon) > 0:
             mesh_ll = get_flat_latlon_mesh(self.mesh)
             outfile_ll = path.join(self.dumpdir, "field_output_latlon.pvd")
-            self.dumpfile_ll = File(outfile_ll,
-                                    project_output=self.output.project_fields,
-                                    comm=self.mesh.comm)
+            self.dumpfile_ll = VTKFile(outfile_ll,
+                                       project_output=self.output.project_fields,
+                                       comm=self.mesh.comm)
 
             # make functions on latlon mesh, as specified by dumplist_latlon
             self.to_dump_latlon = []

--- a/gusto/kernels.py
+++ b/gusto/kernels.py
@@ -74,8 +74,7 @@ class LimitMidpoints():
         par_loop(self._kernel, dx,
                  {"field_hat": (field_hat, WRITE),
                   "field_DG1": (field_DG1, READ),
-                  "field_old": (field_old, READ)},
-                 is_loopy_kernel=True)
+                  "field_old": (field_old, READ)})
 
 
 class ClipZero():
@@ -111,8 +110,7 @@ class ClipZero():
         """
         par_loop(self._kernel, dx,
                  {"field": (field, WRITE),
-                  "field_in": (field_in, READ)},
-                 is_loopy_kernel=True)
+                  "field_in": (field_in, READ)})
 
 
 class MinKernel():

--- a/gusto/physics.py
+++ b/gusto/physics.py
@@ -1109,15 +1109,15 @@ class SWSaturationAdjustment(PhysicsParametrisation):
         """
         logger.info(f'Evaluating physics parametrisation {self.label.label}')
         if self.convective_feedback:
-            self.D.assign(x_in.split()[self.VD_idx])
+            self.D.assign(x_in.subfunctions[self.VD_idx])
         if self.thermal_feedback:
-            self.b.assign(x_in.split()[self.Vb_idx])
+            self.b.assign(x_in.subfunctions[self.Vb_idx])
         if self.time_varying_saturation:
             self.saturation_curve.interpolate(self.saturation_computation(x_in))
         if self.set_tau_to_dt:
             self.tau.assign(dt)
-        self.water_v.assign(x_in.split()[self.Vv_idx])
-        self.cloud.assign(x_in.split()[self.Vc_idx])
+        self.water_v.assign(x_in.subfunctions[self.Vv_idx])
+        self.cloud.assign(x_in.subfunctions[self.Vc_idx])
         if self.time_varying_gamma_v:
             self.gamma_v.interpolate(self.gamma_v_computation(x_in))
         for interpolator in self.source_interpolators:

--- a/gusto/recovery/recovery_kernels.py
+++ b/gusto/recovery/recovery_kernels.py
@@ -160,7 +160,6 @@ class BoundaryRecoveryExtruded():
         par_loop(self._top_kernel, dx,
                  args={"x_out": (x_out, WRITE),
                        "x_in": (x_in, READ)},
-                 is_loopy_kernel=True,
                  iteration_region=ON_TOP)
         par_loop(self._bot_kernel, dx,
                  args={"x_out": (x_out, WRITE),
@@ -241,7 +240,6 @@ class BoundaryRecoveryHCurl():
         par_loop(self._bot_kernel, dx,
                  args={"x_out": (x_out, WRITE),
                        "x_in": (x_in, READ)},
-                 is_loopy_kernel=True,
                  iteration_region=ON_BOTTOM)
 
 


### PR DESCRIPTION
Fixes some minor warnings originating from Firedrake. Original purpose of branch was to remove warnings coming from interpolation but I think that all of ours are coming from legitimate interpolations that will still be allowed after the Firedrake change (i.e. `f.interpolate(expr)` is still ok when `f` is a Firedrake function).