### PR TITLE
Ensemble parallelism

### DIFF
--- a/gusto/configuration.py
+++ b/gusto/configuration.py
@@ -61,7 +61,7 @@ class Configuration(object):
 
         When attributes are provided as floats or integers, these are converted
         to Firedrake :class:`Constant` objects, other than a handful of special
-        integers (dumpfreq, pddumpfreq, chkptfreq and log_level).
+        integers (dumpfreq, pddumpfreq and chkptfreq).
 
         Args:
             name: the attribute's name.

--- a/gusto/equations.py
+++ b/gusto/equations.py
@@ -172,7 +172,8 @@ class AdvectionDiffusionEquation(PrognosticEquation):
                 equation's prognostic is defined on.
             field_name (str): name of the prognostic field.
             Vu (:class:`FunctionSpace`, optional): the function space for the
-                velocity field. If this is  Defaults to None.
+                velocity field. Defaults to None in which case use the
+                HDiv space.
             diffusion_parameters (:class:`DiffusionParameters`, optional):
                 parameters describing the diffusion to be applied.
         """

--- a/integration-tests/model/test_parallel_io.py
+++ b/integration-tests/model/test_parallel_io.py
@@ -5,14 +5,14 @@ import pytest
 
 @pytest.mark.parallel(nprocs=4)
 @pytest.mark.parametrize("spatial_parallelism", [True, False])
-def test_parallel_io(tmpdir):
+def test_parallel_io(tmpdir, spatial_parallelism):
 
     if spatial_parallelism:
         ensemble = Ensemble(COMM_WORLD, 2)
     else:
         ensemble = Ensemble(COMM_WORLD, 1)
 
-    mesh = PeriodicUnitSquareMesh(10, comm=ensemble.comm)
+    mesh = PeriodicUnitSquareMesh(10, 10, comm=ensemble.comm)
     dt = 0.1
     domain = Domain(mesh, dt, "BDM", 1)
 

--- a/integration-tests/model/test_parallel_io.py
+++ b/integration-tests/model/test_parallel_io.py
@@ -1,0 +1,36 @@
+from firedrake import Ensemble, COMM_WORLD, PeriodicUnitSquareMesh
+from gusto import *
+import pytest
+
+
+@pytest.mark.parallel(nprocs=4)
+@pytest.mark.parametrize("spatial_parallelism", [True, False])
+def test_parallel_io(tmpdir):
+
+    if spatial_parallelism:
+        ensemble = Ensemble(COMM_WORLD, 2)
+    else:
+        ensemble = Ensemble(COMM_WORLD, 1)
+
+    mesh = PeriodicUnitSquareMesh(10, comm=ensemble.comm)
+    dt = 0.1
+    domain = Domain(mesh, dt, "BDM", 1)
+
+    # Equation
+    diffusion_params = DiffusionParameters(kappa=0.75, mu=5)
+    V = domain.spaces("DG")
+
+    equation = AdvectionDiffusionEquation(domain, V, "f",
+                                          diffusion_parameters=diffusion_params)
+    spatial_methods = [DGUpwind(equation, "f"),
+                       InteriorPenaltyDiffusion(equation, "f", diffusion_params)]
+
+    # I/O
+    output = OutputParameters(dirname=str(tmpdir))
+    io = IO(domain, output)
+
+    # Time stepper
+    stepper = Timestepper(equation, SSPRK3(domain), io, spatial_methods,
+                          ensemble=ensemble)
+
+    stepper.run(0, 3*dt)

--- a/integration-tests/model/test_parallel_io.py
+++ b/integration-tests/model/test_parallel_io.py
@@ -17,19 +17,15 @@ def test_parallel_io(tmpdir, spatial_parallelism):
     domain = Domain(mesh, dt, "BDM", 1)
 
     # Equation
-    diffusion_params = DiffusionParameters(kappa=0.75, mu=5)
-    V = domain.spaces("DG")
-
-    equation = AdvectionDiffusionEquation(domain, V, "f",
-                                          diffusion_parameters=diffusion_params)
-    spatial_methods = [DGUpwind(equation, "f"),
-                       InteriorPenaltyDiffusion(equation, "f", diffusion_params)]
+    parameters = ShallowWaterParameters(H=100)
+    equation = ShallowWaterEquations(domain, parameters)
 
     # I/O
     output = OutputParameters(dirname=str(tmpdir))
     io = IO(domain, output)
 
     # Time stepper
+    spatial_methods = [DGUpwind(equation, "u"), DGUpwind(equation, "D")]
     stepper = Timestepper(equation, SSPRK3(domain), io, spatial_methods,
                           ensemble=ensemble)
 


### PR DESCRIPTION
When running time parallel problems we still need to interact with the io. This PR is a start. The `Ensemble` is created first so that the spatial communicator can be passed to the mesh. The ensemble instance is then passed to the timestepper so that it can be passed as required to the io and (in future, or on other branches!) to the time discretisation classes.

Here I have sorted out the VTK output. Diagnostics also seem to work, but I have not verified that they are correct. I have not thought about netCDF output or the case where we pick up. I have implemented a test that doesn't check anything other than for hanging. I can see that it does hang if `spatial_parallelism=True` but this seems to be a pytest issue as it is creating multiple output directories, one for each process.

I know @JDBetteridge and @tommbendall have been looking at parallel tests and having issues - would be good to hear what you think!