### PR TITLE
Add `gusto.recovery` to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,4 @@ setup(name="gusto",
       description="Toolkit for compatible finite element dynamical cores",
       author="The Gusto Team",
       url="http://www.firedrakeproject.org/gusto/",
-      packages=["gusto"])
+      packages=["gusto", "gusto.recovery"])


### PR DESCRIPTION
Noticed this when running through `pip install` rather than `python3 setup.py`, it's possible that `pip` is more picky than legacy setuptools when installing subpackages.

cc @jshipton 