### PR TITLE
Reorganise prescribed transport

### DIFF
--- a/gusto/timestepping/split_timestepper.py
+++ b/gusto/timestepping/split_timestepper.py
@@ -165,6 +165,9 @@ class SplitPrescribedTransport(Timestepper):
                 represents the model time, and returns a `ufl.Expr`.
         """
 
+        if self.is_velocity_setup:
+            raise RuntimeError('Prescribed velocity already set up!')
+
         self.velocity_projection = Projector(
             expr_func(self.t), self.fields('u')
         )
@@ -183,6 +186,8 @@ class SplitPrescribedTransport(Timestepper):
                 transporting velocity.
         """
 
+        if self.is_velocity_setup:
+            raise RuntimeError('Prescribed velocity already set up!')
         self.velocity_apply = apply_method
         self.is_velocity_setup = True
 

--- a/gusto/timestepping/timestepper.py
+++ b/gusto/timestepping/timestepper.py
@@ -367,6 +367,9 @@ class PrescribedTransport(Timestepper):
                 represents the model time, and returns a `ufl.Expr`.
         """
 
+        if self.is_velocity_setup:
+            raise RuntimeError('Prescribed velocity already set up!')
+
         self.velocity_projection = Projector(
             expr_func(self.t), self.fields('u')
         )
@@ -385,6 +388,8 @@ class PrescribedTransport(Timestepper):
                 transporting velocity.
         """
 
+        if self.is_velocity_setup:
+            raise RuntimeError('Prescribed velocity already set up!')
         self.velocity_apply = apply_method
         self.is_velocity_setup = True
 

--- a/gusto/timestepping/timestepper.py
+++ b/gusto/timestepping/timestepper.py
@@ -312,22 +312,20 @@ class PrescribedTransport(Timestepper):
     """
     Implements a timeloop with a prescibed transporting velocity.
     """
-    def __init__(self, equation, scheme, io, transport_method,
-                 physics_parametrisations=None,
-                 prescribed_transporting_velocity=None):
+    def __init__(self, equation, scheme, io, prescribed_transporting_velocity,
+                 transport_method, physics_parametrisations=None):
         """
         Args:
             equation (:class:`PrognosticEquation`): the prognostic equation
             scheme (:class:`TimeDiscretisation`): the scheme to use to timestep
                 the prognostic equation.
+            io (:class:`IO`): the model's object for controlling input/output.
+            prescribed_transporting_velocity: (bool): Whether a time-varying
+                transporting velocity will be defined. If True, this will
+                require the transporting velocity to be setup by calling either
+                the `setup_prescribed_expr` or `setup_prescribed_apply` methods.
             transport_method (:class:`TransportMethod`): describes the method
                 used for discretising the transport term.
-            io (:class:`IO`): the model's object for controlling input/output.
-            physics_schemes: (list, optional): a list of :class:`Physics` and
-                :class:`TimeDiscretisation` options describing physical
-                parametrisations and timestepping schemes to use for each.
-                Timestepping schemes for physics must be explicit. Defaults to
-                None.
             physics_parametrisations: (iter, optional): an iterable of
                 :class:`PhysicsParametrisation` objects that describe physical
                 parametrisations to be included to add to the equation. They can
@@ -344,12 +342,10 @@ class PrescribedTransport(Timestepper):
         super().__init__(equation, scheme, io, spatial_methods=transport_methods,
                          physics_parametrisations=physics_parametrisations)
 
-        if prescribed_transporting_velocity is not None:
-            self.velocity_projection = Projector(
-                prescribed_transporting_velocity(self.t),
-                self.fields('u'))
-        else:
-            self.velocity_projection = None
+        self.prescribed_transport_velocity = prescribed_transporting_velocity
+        self.is_velocity_setup = not self.prescribed_transport_velocity
+        self.velocity_projection = None
+        self.velocity_apply = None
 
     @property
     def transporting_velocity(self):
@@ -360,6 +356,38 @@ class PrescribedTransport(Timestepper):
         self.fields = StateFields(self.x, self.equation.prescribed_fields,
                                   *self.io.output.dumplist)
 
+    def setup_prescribed_expr(self, expr_func):
+        """
+        Sets up the prescribed transporting velocity, through a python function
+        which has time as an argument, and returns a `ufl.Expr`. This allows the
+        velocity to be updated with time.
+
+        Args:
+            expr_func (func): a python function with a single argument that
+                represents the model time, and returns a `ufl.Expr`.
+        """
+
+        self.velocity_projection = Projector(
+            expr_func(self.t), self.fields('u')
+        )
+
+        self.is_velocity_setup = True
+
+    def setup_prescribed_apply(self, apply_method):
+        """
+        Sets up the prescribed transporting velocity, through a python function
+        which has time as an argument. This function will perform the evaluation
+        of the transporting velocity.
+
+        Args:
+            expr_func (func): a python function with a single argument that
+                represents the model time, and performs the evaluation of the
+                transporting velocity.
+        """
+
+        self.velocity_apply = apply_method
+        self.is_velocity_setup = True
+
     def run(self, t, tmax, pick_up=False):
         """
         Runs the model for the specified time, from t to tmax
@@ -368,14 +396,31 @@ class PrescribedTransport(Timestepper):
             tmax (float): the end time of the run
             pick_up: (bool): specify whether to pick_up from a previous run
         """
+
+        # Throw an error if no transporting velocity has been set up
+        if self.prescribed_transport_velocity and not self.is_velocity_setup:
+            raise RuntimeError(
+                'A time-varying prescribed velocity is required. This must be '
+                + 'set up through calling either the setup_prescribed_expr or '
+                + 'setup_prescribed_apply routines.')
+
         # It's best to have evaluated the velocity before we start
         if self.velocity_projection is not None:
             self.velocity_projection.project()
+        if self.velocity_apply is not None:
+            self.velocity_apply(self.t)
 
         super().run(t, tmax, pick_up=pick_up)
 
     def timestep(self):
+        """
+        Implements the time step, which possibly involves evaluation of the
+        prescribed transporting velocity.
+        """
+
         if self.velocity_projection is not None:
             self.velocity_projection.project()
+        if self.velocity_apply is not None:
+            self.velocity_apply(self.t)
 
         super().timestep()

--- a/integration-tests/equations/test_advection_diffusion.py
+++ b/integration-tests/equations/test_advection_diffusion.py
@@ -36,7 +36,10 @@ def run_advection_diffusion(tmpdir):
     io = IO(domain, output)
 
     # Time stepper
-    stepper = PrescribedTransport(equation, SSPRK3(domain), io, spatial_methods)
+    time_varying_velocity = False
+    stepper = PrescribedTransport(
+        equation, SSPRK3(domain), io, time_varying_velocity, spatial_methods
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/equations/test_coupled_transport.py
+++ b/integration-tests/equations/test_coupled_transport.py
@@ -51,7 +51,10 @@ def test_coupled_transport_scalar(tmpdir, geometry, equation_form1, equation_for
     transport_scheme = SSPRK3(domain)
     transport_method = [DGUpwind(eqn, 'f1'), DGUpwind(eqn, 'f2')]
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f1").interpolate(setup.f_init)

--- a/integration-tests/equations/test_coupled_transport.py
+++ b/integration-tests/equations/test_coupled_transport.py
@@ -104,7 +104,10 @@ def test_conservative_coupled_transport(tmpdir, m_X_space, tracer_setup):
 
     transport_method = [DGUpwind(eqn, 'f1'), DGUpwind(eqn, 'f2')]
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f1").interpolate(setup.f_init)

--- a/integration-tests/equations/test_forced_advection.py
+++ b/integration-tests/equations/test_forced_advection.py
@@ -64,8 +64,11 @@ def run_forced_advection(tmpdir):
     io = IO(domain, output, diagnostic_fields=diagnostic_fields)
 
     # Time Stepper
-    stepper = PrescribedTransport(meqn, RK4(domain), io, transport_method,
-                                  physics_parametrisations=physics_parametrisations)
+    time_varying_velocity = False
+    stepper = PrescribedTransport(
+        meqn, RK4(domain), io, time_varying_velocity, transport_method,
+        physics_parametrisations=physics_parametrisations
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/model/test_IMEX.py
+++ b/integration-tests/model/test_IMEX.py
@@ -34,7 +34,10 @@ def test_time_discretisation(tmpdir, scheme, tracer_setup):
 
     transport_method = DGUpwind(eqn, "f")
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/model/test_conservative_transport_with_physics.py
+++ b/integration-tests/model/test_conservative_transport_with_physics.py
@@ -58,9 +58,10 @@ def run_conservative_transport_with_physics(dirname):
     physics_schemes = [(SourceSink(eqn, 'ash', basic_expression), SSPRK3(domain))]
 
     # Time stepper
-    stepper = SplitPrescribedTransport(eqn, SSPRK3(domain, increment_form=False),
-                                       io, transport_method,
-                                       physics_schemes=physics_schemes)
+    time_varying_velocity = False
+    stepper = SplitPrescribedTransport(
+        eqn, SSPRK3(domain, increment_form=False), io, time_varying_velocity,
+        transport_method, physics_schemes=physics_schemes)
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/model/test_nc_outputting.py
+++ b/integration-tests/model/test_nc_outputting.py
@@ -96,7 +96,10 @@ def test_nc_outputting(tmpdir, geometry, domain_and_mesh_details):
         diagnostic_fields = [ZonalComponent('u'), MeridionalComponent('u'), RadialComponent('u')]
 
     io = IO(domain, output, diagnostic_fields=diagnostic_fields)
-    stepper = PrescribedTransport(eqn, transport_scheme, io, transport_method)
+    time_varying_velocity = False
+    stepper = PrescribedTransport(
+        eqn, transport_scheme, io, time_varying_velocity, transport_method
+    )
 
     # ------------------------------------------------------------------------ #
     # Initialise fields

--- a/integration-tests/model/test_sdc.py
+++ b/integration-tests/model/test_sdc.py
@@ -74,7 +74,10 @@ def test_sdc(tmpdir, scheme, tracer_setup):
 
     transport_method = DGUpwind(eqn, 'f')
 
-    timestepper = PrescribedTransport(eqn, scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/model/test_time_discretisation.py
+++ b/integration-tests/model/test_time_discretisation.py
@@ -58,7 +58,10 @@ def test_time_discretisation(tmpdir, scheme, tracer_setup):
 
     transport_method = DGUpwind(eqn, 'f')
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/physics/test_precipitation.py
+++ b/integration-tests/physics/test_precipitation.py
@@ -51,8 +51,11 @@ def setup_fallout(dirname):
 
     # build time stepper
     scheme = SSPRK3(domain)
-    stepper = SplitPrescribedTransport(eqn, scheme, io, transport_method,
-                                       physics_schemes=physics_parametrisations)
+    time_varying_velocity = False
+    stepper = SplitPrescribedTransport(
+        eqn, scheme, io, time_varying_velocity, transport_method,
+        physics_schemes=physics_parametrisations
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/physics/test_source_sink.py
+++ b/integration-tests/physics/test_source_sink.py
@@ -59,8 +59,11 @@ def run_source_sink(dirname, process, time_varying):
     physics_parametrisations = [SourceSink(eqn, 'ash', expression, time_varying)]
 
     # Time stepper
-    stepper = PrescribedTransport(eqn, SSPRK3(domain), io, transport_method,
-                                  physics_parametrisations=physics_parametrisations)
+    time_varying_velocity = False
+    stepper = PrescribedTransport(
+        eqn, SSPRK3(domain), io, time_varying_velocity,
+        transport_method, physics_parametrisations=physics_parametrisations
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/physics/test_terminator_toy.py
+++ b/integration-tests/physics/test_terminator_toy.py
@@ -60,21 +60,24 @@ def run_terminator_toy(dirname):
     physics_schemes = [(TerminatorToy(eqn, k1=k1, k2=k2, species1_name='X',
                         species2_name='X2'), BackwardEuler(domain))]
 
+    transport_scheme = SSPRK3(domain)
+    transport_method = [DGUpwind(eqn, 'X'), DGUpwind(eqn, 'X2')]
+
+    time_varying_velocity = True
+    stepper = SplitPrescribedTransport(
+        eqn, transport_scheme, io, time_varying_velocity,
+        spatial_methods=transport_method, physics_schemes=physics_schemes
+    )
+
     # Set up a non-divergent, time-varying, velocity field
     def u_t(t):
         return as_vector([Constant(0)*lamda, Constant(0)*lamda, Constant(0)*lamda])
 
+    stepper.setup_prescribed_expr(u_t)
+
     X_T_0 = 4e-6
     X_0 = X_T_0 + 0*lamda
     X2_0 = 0*lamda
-
-    transport_scheme = SSPRK3(domain)
-    transport_method = [DGUpwind(eqn, 'X'), DGUpwind(eqn, 'X2')]
-
-    stepper = SplitPrescribedTransport(eqn, transport_scheme, io,
-                                       spatial_methods=transport_method,
-                                       physics_schemes=physics_schemes,
-                                       prescribed_transporting_velocity=u_t)
 
     stepper.fields("X").interpolate(X_0)
     stepper.fields("X2").interpolate(X2_0)

--- a/integration-tests/transport/test_dg_transport.py
+++ b/integration-tests/transport/test_dg_transport.py
@@ -55,7 +55,10 @@ def test_dg_transport_vector(tmpdir, geometry, equation_form, tracer_setup):
     transport_scheme = SSPRK3(domain)
     transport_method = DGUpwind(eqn, "f")
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(f_init)

--- a/integration-tests/transport/test_dg_transport.py
+++ b/integration-tests/transport/test_dg_transport.py
@@ -28,7 +28,10 @@ def test_dg_transport_scalar(tmpdir, geometry, equation_form, tracer_setup):
     transport_scheme = SSPRK3(domain)
     transport_method = DGUpwind(eqn, "f")
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/transport/test_embedded_dg_advection.py
+++ b/integration-tests/transport/test_embedded_dg_advection.py
@@ -35,7 +35,11 @@ def test_embedded_dg_advection_scalar(tmpdir, ibp, equation_form, space,
     transport_schemes = SSPRK3(domain, options=opts)
     transport_method = DGUpwind(eqn, "f", ibp=ibp)
 
-    timestepper = PrescribedTransport(eqn, transport_schemes, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_schemes, setup.io, time_varying_velocity,
+        transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/transport/test_limiters.py
+++ b/integration-tests/transport/test_limiters.py
@@ -90,7 +90,10 @@ def setup_limiters(dirname, space):
     transport_method = DGUpwind(eqn, "tracer")
 
     # Build time stepper
-    stepper = PrescribedTransport(eqn, transport_schemes, io, transport_method)
+    time_varying_velocity = False
+    stepper = PrescribedTransport(
+        eqn, transport_schemes, io, time_varying_velocity, transport_method
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial condition

--- a/integration-tests/transport/test_mixed_fs_options.py
+++ b/integration-tests/transport/test_mixed_fs_options.py
@@ -167,7 +167,10 @@ def setup_limiters(dirname, space_A, space_B):
     transport_method = [DGUpwind(eqn, 'tracerA'), DGUpwind(eqn, 'tracerB')]
 
     # Build time stepper
-    stepper = PrescribedTransport(eqn, transport_schemes, io, transport_method)
+    time_varying_velocity = False
+    stepper = PrescribedTransport(
+        eqn, transport_schemes, io, time_varying_velocity, transport_method
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial condition

--- a/integration-tests/transport/test_recovered_transport.py
+++ b/integration-tests/transport/test_recovered_transport.py
@@ -38,7 +38,10 @@ def test_recovered_space_setup(tmpdir, geometry, tracer_setup):
     transport_scheme = SSPRK3(domain, options=recovery_opts)
     transport_method = DGUpwind(eqn, "f")
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initialise fields
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/transport/test_subcycling.py
+++ b/integration-tests/transport/test_subcycling.py
@@ -27,7 +27,10 @@ def test_subcyling(tmpdir, subcycling, tracer_setup):
         transport_scheme = SSPRK3(domain, subcycle_by_courant=0.25)
     transport_method = DGUpwind(eqn, "f")
 
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)

--- a/integration-tests/transport/test_supg_transport.py
+++ b/integration-tests/transport/test_supg_transport.py
@@ -42,7 +42,10 @@ def test_supg_transport_scalar(tmpdir, equation_form, scheme, space,
         transport_scheme = TrapeziumRule(domain, options=opts)
 
     transport_method = DGUpwind(eqn, "f", ibp=ibp)
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     timestepper.fields("f").interpolate(setup.f_init)
@@ -84,7 +87,10 @@ def test_supg_transport_vector(tmpdir, equation_form, scheme, space,
         transport_scheme = TrapeziumRule(domain, options=opts)
 
     transport_method = DGUpwind(eqn, "f", ibp=ibp)
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initial conditions
     f = timestepper.fields("f")

--- a/integration-tests/transport/test_vector_recovered_space.py
+++ b/integration-tests/transport/test_vector_recovered_space.py
@@ -42,7 +42,10 @@ def test_vector_recovered_space_setup(tmpdir, geometry, tracer_setup):
     eqn = AdvectionEquation(domain, Vu, "f")
     transport_scheme = SSPRK3(domain, options=rec_opts)
     transport_method = DGUpwind(eqn, "f")
-    timestepper = PrescribedTransport(eqn, transport_scheme, setup.io, transport_method)
+    time_varying_velocity = False
+    timestepper = PrescribedTransport(
+        eqn, transport_scheme, setup.io, time_varying_velocity, transport_method
+    )
 
     # Initialise fields
     f_init = as_vector([setup.f_init]*gdim)


### PR DESCRIPTION
This reorganises the prescribed transport to allow more complicated methods for defining the transporting velocity. 

The transporting velocity is now set up after the stepper, and can be done through three methods:
- either not at all, in which case the velocity is assumed to be constant in time
- through a time-varying expression as a python function (as we already done)
- through a user-defined apply method -- this is the main new capability

The main motivation is that sometimes we want more complicated methods for defining the transporting velocity, e.g.:
1. specifying the time-varying velocity through a stream function, by interpolating into the H1 space then projecting `gradperp(psi)`
2. the velocity is discontinuous in time. These cases cannot be handled with a single expression and so need something more complicated

It also has the nice benefit that time-varying winds are now set up after the timestepper, allowing the wind to be defined with the initial conditions.