### PR TITLE
Solver Convergence Improvements

### DIFF
--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -33,7 +33,7 @@ __all__ = ["BoussinesqSolver", "LinearTimesteppingSolver", "CompressibleSolver",
 class TimesteppingSolver(object, metaclass=ABCMeta):
     """Base class for timestepping linear solvers for Gusto."""
 
-    def __init__(self, equations, alpha=0.5, tau_values=None,
+    def __init__(self, equations, alpha=0.5, tau_values={},
                  solver_parameters=None, overwrite_solver_parameters=False):
         """
         Args:
@@ -41,7 +41,7 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_values (dict, optional): contains the semi-implicit relaxation
-                parameters. Defaults to None.
+                parameters. Defaults to an empty dictionary.
             solver_parameters (dict, optional): contains the options to be
                 passed to the underlying :class:`LinearVariationalSolver`.
                 Defaults to None.
@@ -54,13 +54,6 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
         self.dt = equations.domain.dt
         self.alpha = alpha
         self.tau_values = tau_values
-
-        # Check that we have a tau value for each field
-        if self.tau_values is not None:
-            for field in equations.field_names:
-                if field not in self.tau_values:
-                    raise KeyError(f"You must select tau values for all fields to be solved, "
-                                   f"missing value is {field}")
 
         if solver_parameters is not None:
             if not overwrite_solver_parameters:
@@ -145,7 +138,7 @@ class CompressibleSolver(TimesteppingSolver):
                                                            'pc_type': 'bjacobi',
                                                            'sub_pc_type': 'ilu'}}}
 
-    def __init__(self, equations, alpha=0.5, tau_values=None,
+    def __init__(self, equations, alpha=0.5, tau_values={},
                  quadrature_degree=None, solver_parameters=None,
                  overwrite_solver_parameters=False):
         """
@@ -154,7 +147,7 @@ class CompressibleSolver(TimesteppingSolver):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_values (dict, optional): contains the semi-implicit relaxation
-                parameters. Defaults to None.
+                parameters. Defaults to an empty dictionary.
             quadrature_degree (tuple, optional): a tuple (q_h, q_v) where q_h is
                 the required quadrature degree in the horizontal direction and
                 q_v is that in the vertical direction. Defaults to None.
@@ -186,9 +179,9 @@ class CompressibleSolver(TimesteppingSolver):
         dt = self.dt
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        beta_u_ = dt*self.tau_values["u"] if self.tau_values is not None else self.alpha
-        beta_t_ = dt*self.tau_values["theta"] if self.tau_values is not None else self.alpha
-        beta_r_ = dt*self.tau_values["rho"] if self.tau_values is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
+        beta_t_ = dt*self.tau_values.get("theta") if self.tau_values.get("theta") is not None else self.alpha
+        beta_r_ = dt*self.tau_values.get("rho") if self.tau_values.get("rho") is not None else self.alpha
 
         cp = equations.parameters.cp
         Vu = equations.domain.spaces("HDiv")
@@ -467,9 +460,9 @@ class BoussinesqSolver(TimesteppingSolver):
         dt = self.dt
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        beta_u_ = dt*self.tau_values["u"] if self.tau_values is not None else self.alpha
-        beta_p_ = dt*self.tau_values["p"] if self.tau_values is not None else self.alpha
-        beta_b_ = dt*self.tau_values["b"] if self.tau_values is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
+        beta_p_ = dt*self.tau_values.get("p") if self.tau_values.get("p") is not None else self.alpha
+        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else self.alpha
         Vu = equation.domain.spaces("HDiv")
         Vb = equation.domain.spaces("theta")
         Vp = equation.domain.spaces("DG")
@@ -614,9 +607,9 @@ class ThermalSWSolver(TimesteppingSolver):
     def _setup_solver(self):
         equation = self.equations      # just cutting down line length a bit
         dt = self.dt
-        beta_u_ = dt*self.tau_values["u"] if self.tau_values is not None else self.alpha
-        beta_d_ = dt*self.tau_values["D"] if self.tau_values is not None else self.alpha
-        beta_b_ = dt*self.tau_values["b"] if self.tau_values is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
+        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else self.alpha
+        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else self.alpha
         Vu = equation.domain.spaces("HDiv")
         VD = equation.domain.spaces("DG")
         Vb = equation.domain.spaces("DG")
@@ -843,8 +836,8 @@ class MoistConvectiveSWSolver(TimesteppingSolver):
     def _setup_solver(self):
         equation = self.equations      # just cutting down line length a bit
         dt = self.dt
-        beta_u_ = dt*self.tau_values["u"] if self.tau_values is not None else self.alpha
-        beta_d_ = dt*self.tau_values["D"] if self.tau_values is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
+        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else self.alpha
         Vu = equation.domain.spaces("HDiv")
         VD = equation.domain.spaces("DG")
 

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -147,7 +147,7 @@ class CompressibleSolver(TimesteppingSolver):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_values (dict, optional): contains the semi-implicit relaxation
-                parameters. Defaults to None.
+                parameters. Defaults to None, in which case the value of alpha is used.
             quadrature_degree (tuple, optional): a tuple (q_h, q_v) where q_h is
                 the required quadrature degree in the horizontal direction and
                 q_v is that in the vertical direction. Defaults to None.

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -179,9 +179,9 @@ class CompressibleSolver(TimesteppingSolver):
         dt = self.dt
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
-        beta_t_ = dt*self.tau_values.get("theta") if self.tau_values.get("theta") is not None else self.alpha
-        beta_r_ = dt*self.tau_values.get("rho") if self.tau_values.get("rho") is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
+        beta_t_ = dt*self.tau_values.get("theta") if self.tau_values.get("theta") is not None else dt*self.alpha
+        beta_r_ = dt*self.tau_values.get("rho") if self.tau_values.get("rho") is not None else dt*self.alpha
 
         cp = equations.parameters.cp
         Vu = equations.domain.spaces("HDiv")
@@ -460,9 +460,9 @@ class BoussinesqSolver(TimesteppingSolver):
         dt = self.dt
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
-        beta_p_ = dt*self.tau_values.get("p") if self.tau_values.get("p") is not None else self.alpha
-        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
+        beta_p_ = dt*self.tau_values.get("p") if self.tau_values.get("p") is not None else dt*self.alpha
+        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else dt*self.alpha
         Vu = equation.domain.spaces("HDiv")
         Vb = equation.domain.spaces("theta")
         Vp = equation.domain.spaces("DG")
@@ -607,9 +607,9 @@ class ThermalSWSolver(TimesteppingSolver):
     def _setup_solver(self):
         equation = self.equations      # just cutting down line length a bit
         dt = self.dt
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
-        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else self.alpha
-        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
+        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else dt*self.alpha
+        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else dt*self.alpha
         Vu = equation.domain.spaces("HDiv")
         VD = equation.domain.spaces("DG")
         Vb = equation.domain.spaces("DG")
@@ -836,8 +836,8 @@ class MoistConvectiveSWSolver(TimesteppingSolver):
     def _setup_solver(self):
         equation = self.equations      # just cutting down line length a bit
         dt = self.dt
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else self.alpha
-        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else self.alpha
+        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
+        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else dt*self.alpha
         Vu = equation.domain.spaces("HDiv")
         VD = equation.domain.spaces("DG")
 

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -60,20 +60,9 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
 
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        if tau_u is not None:
-            self.tau_u = tau_u
-        else:
-            self.tau_u = alpha
-
-        if tau_t is not None:
-            self.tau_t = tau_t
-        else:
-            self.tau_t = alpha
-
-        if tau_r is not None:
-            self.tau_r = tau_r
-        else:
-            self.tau_r = alpha
+        self.tau_u = tau_u if tau_u is not None else alpha
+        self.tau_t = tau_t if tau_t is not None else alpha
+        self.tau_r = tau_r if tau_r is not None else alpha
 
         if solver_parameters is not None:
             if not overwrite_solver_parameters:

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -57,10 +57,11 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
         self.equations = equations
         self.dt = equations.domain.dt
         self.alpha = alpha
+
         # Set relaxation parameters.
-        self.tau_u=tau_u
-        self.tau_t=tau_t
-        self.tau_r=tau_r
+        self.tau_u = tau_u
+        self.tau_t = tau_t
+        self.tau_r = tau_r
 
         if solver_parameters is not None:
             if not overwrite_solver_parameters:
@@ -145,7 +146,7 @@ class CompressibleSolver(TimesteppingSolver):
                                                            'pc_type': 'bjacobi',
                                                            'sub_pc_type': 'ilu'}}}
 
-    def __init__(self, equations, alpha=0.5, tau_u = 0.5, tau_r = 0.5, tau_t = 0.5,
+    def __init__(self, equations, alpha=0.5, tau_u=0.5, tau_r=0.5, tau_t=0.5,
                  quadrature_degree=None, solver_parameters=None,
                  overwrite_solver_parameters=False):
         """

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -41,7 +41,7 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_values (dict, optional): contains the semi-implicit relaxation
-                parameters. Defaults to None.
+                parameters. Defaults to None, in which case the value of alpha is used.
             solver_parameters (dict, optional): contains the options to be
                 passed to the underlying :class:`LinearVariationalSolver`.
                 Defaults to None.

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -33,7 +33,7 @@ __all__ = ["BoussinesqSolver", "LinearTimesteppingSolver", "CompressibleSolver",
 class TimesteppingSolver(object, metaclass=ABCMeta):
     """Base class for timestepping linear solvers for Gusto."""
 
-    def __init__(self, equations, alpha=0.5, tau_u=0.5, tau_r=0.5, tau_t=0.5,
+    def __init__(self, equations, alpha=0.5, tau_u=None, tau_r=None, tau_t=None,
                  solver_parameters=None, overwrite_solver_parameters=False):
         """
         Args:
@@ -41,11 +41,11 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_u (float, optional): the semi-implicit relaxation parameter for
-                wind. Defaults to 0.5.
+                wind. Defaults to None.
             tau_r (float, optional): the semi-implicit relaxation parameter for
-                density-like variable. Defaults to 0.5.
+                density-like variable. Defaults to None.
             tau_t (float, optional): the semi-implicit relaxation parameter for
-                temperature-like variable. Defaults to 0.5.
+                temperature-like variable. Defaults to None.
             solver_parameters (dict, optional): contains the options to be
                 passed to the underlying :class:`LinearVariationalSolver`.
                 Defaults to None.
@@ -58,10 +58,22 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
         self.dt = equations.domain.dt
         self.alpha = alpha
 
-        # Set relaxation parameters.
-        self.tau_u = tau_u
-        self.tau_t = tau_t
-        self.tau_r = tau_r
+        # Set relaxation parameters. If an alternative has not been given, set
+        # to semi-implicit off-centering factor
+        if tau_u is not None:
+            self.tau_u = tau_u
+        else:
+            self.tau_u = alpha
+
+        if tau_t is not None:
+            self.tau_t = tau_t
+        else:
+            self.tau_t = alpha
+
+        if tau_r is not None:
+            self.tau_r = tau_r
+        else:
+            self.tau_r = alpha
 
         if solver_parameters is not None:
             if not overwrite_solver_parameters:

--- a/gusto/solvers/linear_solvers.py
+++ b/gusto/solvers/linear_solvers.py
@@ -33,7 +33,7 @@ __all__ = ["BoussinesqSolver", "LinearTimesteppingSolver", "CompressibleSolver",
 class TimesteppingSolver(object, metaclass=ABCMeta):
     """Base class for timestepping linear solvers for Gusto."""
 
-    def __init__(self, equations, alpha=0.5, tau_values={},
+    def __init__(self, equations, alpha=0.5, tau_values=None,
                  solver_parameters=None, overwrite_solver_parameters=False):
         """
         Args:
@@ -41,7 +41,7 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_values (dict, optional): contains the semi-implicit relaxation
-                parameters. Defaults to an empty dictionary.
+                parameters. Defaults to None.
             solver_parameters (dict, optional): contains the options to be
                 passed to the underlying :class:`LinearVariationalSolver`.
                 Defaults to None.
@@ -53,7 +53,7 @@ class TimesteppingSolver(object, metaclass=ABCMeta):
         self.equations = equations
         self.dt = equations.domain.dt
         self.alpha = alpha
-        self.tau_values = tau_values
+        self.tau_values = tau_values if tau_values is not None else {}
 
         if solver_parameters is not None:
             if not overwrite_solver_parameters:
@@ -138,7 +138,7 @@ class CompressibleSolver(TimesteppingSolver):
                                                            'pc_type': 'bjacobi',
                                                            'sub_pc_type': 'ilu'}}}
 
-    def __init__(self, equations, alpha=0.5, tau_values={},
+    def __init__(self, equations, alpha=0.5, tau_values=None,
                  quadrature_degree=None, solver_parameters=None,
                  overwrite_solver_parameters=False):
         """
@@ -147,7 +147,7 @@ class CompressibleSolver(TimesteppingSolver):
             alpha (float, optional): the semi-implicit off-centring factor.
                 Defaults to 0.5. A value of 1 is fully-implicit.
             tau_values (dict, optional): contains the semi-implicit relaxation
-                parameters. Defaults to an empty dictionary.
+                parameters. Defaults to None.
             quadrature_degree (tuple, optional): a tuple (q_h, q_v) where q_h is
                 the required quadrature degree in the horizontal direction and
                 q_v is that in the vertical direction. Defaults to None.
@@ -179,9 +179,9 @@ class CompressibleSolver(TimesteppingSolver):
         dt = self.dt
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
-        beta_t_ = dt*self.tau_values.get("theta") if self.tau_values.get("theta") is not None else dt*self.alpha
-        beta_r_ = dt*self.tau_values.get("rho") if self.tau_values.get("rho") is not None else dt*self.alpha
+        beta_u_ = dt*self.tau_values.get("u", self.alpha)
+        beta_t_ = dt*self.tau_values.get("theta", self.alpha)
+        beta_r_ = dt*self.tau_values.get("rho", self.alpha)
 
         cp = equations.parameters.cp
         Vu = equations.domain.spaces("HDiv")
@@ -460,9 +460,9 @@ class BoussinesqSolver(TimesteppingSolver):
         dt = self.dt
         # Set relaxation parameters. If an alternative has not been given, set
         # to semi-implicit off-centering factor
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
-        beta_p_ = dt*self.tau_values.get("p") if self.tau_values.get("p") is not None else dt*self.alpha
-        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else dt*self.alpha
+        beta_u_ = dt*self.tau_values.get("u", self.alpha)
+        beta_p_ = dt*self.tau_values.get("p", self.alpha)
+        beta_b_ = dt*self.tau_values.get("b", self.alpha)
         Vu = equation.domain.spaces("HDiv")
         Vb = equation.domain.spaces("theta")
         Vp = equation.domain.spaces("DG")
@@ -607,9 +607,9 @@ class ThermalSWSolver(TimesteppingSolver):
     def _setup_solver(self):
         equation = self.equations      # just cutting down line length a bit
         dt = self.dt
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
-        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else dt*self.alpha
-        beta_b_ = dt*self.tau_values.get("b") if self.tau_values.get("b") is not None else dt*self.alpha
+        beta_u_ = dt*self.tau_values.get("u", self.alpha)
+        beta_d_ = dt*self.tau_values.get("D", self.alpha)
+        beta_b_ = dt*self.tau_values.get("b", self.alpha)
         Vu = equation.domain.spaces("HDiv")
         VD = equation.domain.spaces("DG")
         Vb = equation.domain.spaces("DG")
@@ -836,8 +836,8 @@ class MoistConvectiveSWSolver(TimesteppingSolver):
     def _setup_solver(self):
         equation = self.equations      # just cutting down line length a bit
         dt = self.dt
-        beta_u_ = dt*self.tau_values.get("u") if self.tau_values.get("u") is not None else dt*self.alpha
-        beta_d_ = dt*self.tau_values.get("D") if self.tau_values.get("D") is not None else dt*self.alpha
+        beta_u_ = dt*self.tau_values.get("u", self.alpha)
+        beta_d_ = dt*self.tau_values.get("D", self.alpha)
         Vu = equation.domain.spaces("HDiv")
         VD = equation.domain.spaces("DG")
 

--- a/gusto/timestepping/semi_implicit_quasi_newton.py
+++ b/gusto/timestepping/semi_implicit_quasi_newton.py
@@ -485,14 +485,14 @@ class Forcing(object):
 
         x_out.assign(x_in(self.field_name))
         x_out += self.xF
-    
+
     def zero_forcing_terms(self, equation, x_in, x_out, transported_field_names):
         """
         Zero forcing term F(x) for non-wind transport.
 
         This takes x_in and x_out, where                                      \n
         x_out = x_in + scale*F(x_nl)                                          \n
-        for some field x_nl and sets x_out = x_in for all non-wind transport terms 
+        for some field x_nl and sets x_out = x_in for all non-wind transport terms
 
         Args:
             equation (:class:`PrognosticEquationSet`): the prognostic

--- a/gusto/timestepping/semi_implicit_quasi_newton.py
+++ b/gusto/timestepping/semi_implicit_quasi_newton.py
@@ -35,7 +35,7 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
                  diffusion_schemes=None, physics_schemes=None,
                  slow_physics_schemes=None, fast_physics_schemes=None,
                  alpha=Constant(0.5), off_centred_u=False,
-                 num_outer=2, num_inner=2):
+                 num_outer=2, num_inner=2, accelerator=False):
 
         """
         Args:
@@ -84,6 +84,8 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
                 implicit forcing (pressure gradient and Coriolis) terms, and the
                 linear solve. Defaults to 2. Note that default used by the Met
                 Office's ENDGame and GungHo models is 2.
+            accelerator (bool, optional): Whether to zero non-wind implicit forcings
+                for transport terms in order to speed up solver convergence
         """
 
         self.num_outer = num_outer
@@ -120,10 +122,12 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
                      + f"physics scheme {parametrisation.label.label}")
 
         self.active_transport = []
+        self.transported_fields = []
         for scheme in transport_schemes:
             assert scheme.nlevels == 1, "multilevel schemes not supported as part of this timestepping loop"
             assert scheme.field_name in equation_set.field_names
             self.active_transport.append((scheme.field_name, scheme))
+            self.transported_fields.append(scheme.field_name)
             # Check that there is a corresponding transport method
             method_found = False
             for method in spatial_methods:
@@ -184,6 +188,7 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
             self.linear_solver = linear_solver
         self.forcing = Forcing(equation_set, self.alpha)
         self.bcs = equation_set.bcs
+        self.accelerator = accelerator
 
     def _apply_bcs(self):
         """
@@ -302,6 +307,9 @@ class SemiImplicitQuasiNewton(BaseTimestepper):
                 with timed_stage("Apply forcing terms"):
                     logger.info(f'Semi-implicit Quasi Newton: Implicit forcing {(outer, inner)}')
                     self.forcing.apply(xp, xnp1, xrhs, "implicit")
+                    if (inner > 0 and self.accelerator):
+                        # Zero implicit forcing to accelerate solver convergence
+                        self.forcing.zero_forcing_terms(self.equation, xp, xrhs, self.transported_fields)
 
                 xrhs -= xnp1(self.field_name)
                 xrhs += xrhs_phys
@@ -477,3 +485,24 @@ class Forcing(object):
 
         x_out.assign(x_in(self.field_name))
         x_out += self.xF
+    
+    def zero_forcing_terms(self, equation, x_in, x_out, transported_field_names):
+        """
+        Zero forcing term F(x) for non-wind transport.
+
+        This takes x_in and x_out, where                                      \n
+        x_out = x_in + scale*F(x_nl)                                          \n
+        for some field x_nl and sets x_out = x_in for all non-wind transport terms 
+
+        Args:
+            equation (:class:`PrognosticEquationSet`): the prognostic
+                equation set to be solved
+            x_in (:class:`FieldCreator`): the field to be incremented.
+            x_out (:class:`FieldCreator`): the output field to be updated.
+            transported_field_names (str): list of fields names for transported fields
+        """
+        for field_name in transported_field_names:
+            if field_name != 'u':
+                logger.info(f'SIQN: Zeroing Implicit forcing for {field_name}')
+                field_index = equation.field_names.index(field_name)
+                x_out.subfunctions[field_index].assign(x_in(field_name))

--- a/gusto/timestepping/semi_implicit_quasi_newton.py
+++ b/gusto/timestepping/semi_implicit_quasi_newton.py
@@ -503,6 +503,6 @@ class Forcing(object):
         """
         for field_name in transported_field_names:
             if field_name != 'u':
-                logger.info(f'SIQN: Zeroing Implicit forcing for {field_name}')
+                logger.info(f'Semi-Implicit Quasi Newton: Zeroing implicit forcing for {field_name}')
                 field_index = equation.field_names.index(field_name)
                 x_out.subfunctions[field_index].assign(x_in(field_name))


### PR DESCRIPTION
Importing solver improvements we have in GungHo:

- tau values for linear solver which accelerate convergence if set to 1. This has been shown to make the moist baroclinic in channel stable for 2x2 SIQN with tau_t and tau_r = 1. Description of why these work has been attached in 
[Tau_Values.pdf](https://github.com/user-attachments/files/16623363/Tau_Values.pdf)


- Accelerate solver convergence by zeroing implicit forcing's for transport terms

These changes have been added on switches, so do not change KGOs.