### PR TITLE
Conservative transport integration test

### DIFF
--- a/gusto/core/configuration.py
+++ b/gusto/core/configuration.py
@@ -8,8 +8,8 @@ __all__ = [
     "IntegrateByParts", "TransportEquationType", "OutputParameters",
     "BoussinesqParameters", "CompressibleParameters",
     "ShallowWaterParameters",
-    "EmbeddedDGOptions", "RecoveryOptions", "ConservativeRecoveryOptions",
-    "SUPGOptions", "MixedFSOptions",
+    "EmbeddedDGOptions", "ConservativeEmbeddedDGOptions", "RecoveryOptions",
+    "ConservativeRecoveryOptions", "SUPGOptions", "MixedFSOptions",
     "SpongeLayerParameters", "DiffusionParameters", "BoundaryLayerParameters"
 ]
 

--- a/gusto/equations/prognostic_equations.py
+++ b/gusto/equations/prognostic_equations.py
@@ -282,6 +282,17 @@ class PrognosticEquationSet(PrognosticEquation, metaclass=ABCMeta):
                 name of the active tracer.
         """
 
+        # Check if there are any conservatively transported tracers.
+        # If so, ensure that the reference density is indexed before this tracer.
+        for i in range(len(active_tracers) - 1):
+            tracer = active_tracers[i]
+            if tracer.transport_eqn == TransportEquationType.tracer_conservative:
+                ref_density = next(x for x in active_tracers if x.name == tracer.density_name)
+                j = active_tracers.index(ref_density)
+                if j > i:
+                    # Swap the indices of the tracer and the reference density
+                    active_tracers[i], active_tracers[j] = active_tracers[j], active_tracers[i]
+
         # Loop through tracer fields and add field names and spaces
         for tracer in active_tracers:
             if isinstance(tracer, ActiveTracer):

--- a/gusto/time_discretisation/wrappers.py
+++ b/gusto/time_discretisation/wrappers.py
@@ -129,6 +129,7 @@ class EmbeddedDGWrapper(Wrapper):
             self.x_out_projector = Recoverer(self.x_out, self.x_projected)
         elif self.options.project_back_method == 'conservative_project':
             self.is_conservative = True
+            self.rho_name=self.options.rho_name
             self.increment_orig = Function(original_space)
             self.increment = Function(self.function_space)
             self.rho_in_orig = Function(self.options.orig_rho_space)
@@ -235,6 +236,7 @@ class RecoveryWrapper(Wrapper):
         # Operator to recover to higher discontinuous space
         if self.options.project_low_method == 'conservative_project':
             self.is_conservative = True
+            self.rho_name=self.options.rho_name
             self.increment_orig = Function(original_space)
             self.increment = Function(self.function_space)
             self.rho_in_orig = Function(self.options.orig_rho_space)
@@ -460,8 +462,10 @@ class MixedFSWrapper(object):
 
             if field_name in self.subwrappers:
                 subwrapper = self.subwrappers[field_name]
+                print(field_name)
+                print(subwrapper.is_conservative)
                 if subwrapper.is_conservative:
-                    self.pre_update_rho(subwrapper, x_in)
+                    self.pre_update_rho(subwrapper)
                 subwrapper.pre_apply(field)
                 x_in_sub.assign(subwrapper.x_in)
             else:
@@ -482,7 +486,7 @@ class MixedFSWrapper(object):
                 subwrapper = self.subwrappers[field_name]
                 subwrapper.x_out.assign(field)
                 if subwrapper.is_conservative:
-                    self.post_update_rho(subwrapper, x_out)
+                    self.post_update_rho(subwrapper)
                 subwrapper.post_apply(x_out_sub)
             else:
                 x_out_sub.assign(field)
@@ -497,8 +501,8 @@ class MixedFSWrapper(object):
 
         rho_subwrapper = self.subwrappers[subwrapper.rho_name]
 
-        self.rho_in_orig_space.assign(rho_subwrapper.x_in_tmp)
-        self.rho_in_embedded_space.assign(rho_subwrapper.x_in)
+        subwrapper.rho_in_orig.assign(rho_subwrapper.x_in_tmp)
+        subwrapper.rho_in_embedded.assign(rho_subwrapper.x_in)
 
     def post_update_rho(self, subwrapper):
         """
@@ -510,5 +514,5 @@ class MixedFSWrapper(object):
 
         rho_subwrapper = self.subwrappers[subwrapper.rho_name]
 
-        self.rho_out_orig_space.assign(rho_subwrapper.x_projected)
-        self.rho_out_embedded_space.assign(rho_subwrapper.x_out)
+        subwrapper.rho_out_orig.assign(rho_subwrapper.x_projected)
+        subwrapper.rho_out_embedded.assign(rho_subwrapper.x_out)

--- a/integration-tests/transport/test_conservative_transport.py
+++ b/integration-tests/transport/test_conservative_transport.py
@@ -1,0 +1,186 @@
+"""
+Tests the conservative transport method, for a mixing ratio and density in the
+same and different spaces. This checks that there is a conservation of
+"""
+
+from gusto import *
+from firedrake import PeriodicIntervalMesh, ExtrudedMesh, exp, cos, sin, SpatialCoordinate, \
+    assemble, dx, FunctionSpace, pi, min_value, as_vector, BrokenElement, errornorm
+import pytest
+
+
+def setup_conservative_transport(dirname, space, property):
+
+    # Domain
+    Lx = 2000.
+    Hz = 2000.
+
+    # Time parameters
+    dt = 2.
+    tmax = 2000.
+
+    nlayers = 10.  # horizontal layers
+    columns = 10.  # number of columns
+
+    # Define the spaces and order
+    if space == 'same':
+        rho_d_space = 'DG'
+        m_X_space = 'DG'
+        space_order = 1
+    elif space == 'diff_order_0':
+        rho_d_space = 'DG'
+        m_X_space = 'theta'
+        space_order = 0
+    elif space == 'diff_order_1':
+        rho_d_space = 'DG'
+        m_X_space = 'theta'
+        space_order = 1
+
+    period_mesh = PeriodicIntervalMesh(columns, Lx)
+    mesh = ExtrudedMesh(period_mesh, layers=nlayers, layer_height=Hz/nlayers)
+    domain = Domain(mesh, dt, "CG", space_order)
+    x, z = SpatialCoordinate(mesh)
+
+    V_rho = domain.spaces(rho_d_space)
+    V_m_X = domain.spaces(m_X_space)
+
+    m_X = ActiveTracer(name='m_X', space=m_X_space,
+                       variable_type=TracerVariableType.mixing_ratio,
+                       transport_eqn=TransportEquationType.tracer_conservative,
+                       density_name='rho_d')
+
+    rho_d = ActiveTracer(name='rho_d', space=rho_d_space,
+                         variable_type=TracerVariableType.density,
+                         transport_eqn=TransportEquationType.conservative)
+
+    # Define m_X first to test that it will automatically
+    # re-order the tracers to have the density field
+    # indexed before the mixing ratio.
+    tracers = [m_X, rho_d]
+
+    # Equation
+    V = domain.spaces("HDiv")
+    eqn = CoupledTransportEquation(domain, active_tracers=tracers, Vu=V)
+    output = OutputParameters(dirname=dirname)
+
+    io = IO(domain, output)
+
+    # Set up the divergent, time-varying, velocity field
+    U = Lx/tmax
+    W = U/10.
+
+    def u_t(t):
+        xd = x - U*t
+        u = U - (W*pi*Lx/Hz)*cos(pi*t/tmax)*cos(2*pi*xd/Lx)*cos(pi*z/Hz)
+        w = 2*pi*W*cos(pi*t/tmax)*sin(2*pi*xd/Lx)*sin(pi*z/Hz)
+
+        u_expr = as_vector((u, w))
+
+        return u_expr
+
+    # Specify locations of the two Gaussians
+    xc1 = 5.*Lx/8.
+    zc1 = Hz/2.
+
+    xc2 = 3.*Lx/8.
+    zc2 = Hz/2.
+
+    def l2_dist(xc, zc):
+        return min_value(abs(x-xc), Lx-abs(x-xc))**2 + (z-zc)**2
+
+    lc = 2.*Lx/25.
+    m0 = 0.02
+
+    # Set the initial state from the configuration choice
+    if property == 'conservation':
+        f0 = 0.05
+
+        rho_t = 0.5
+        rho_b = 1.
+
+        rho_d_0 = rho_b + z*(rho_t-rho_b)/Hz
+
+        g1 = f0*exp(-l2_dist(xc1, zc1)/(lc**2))
+        g2 = f0*exp(-l2_dist(xc2, zc2)/(lc**2))
+
+        m_X_0 = m0 + g1 + g2
+    else:
+        f0 = 0.5
+        rho_b = 0.5
+
+        g1 = f0*exp(-l2_dist(xc1, zc1)/(lc**2))
+        g2 = f0*exp(-l2_dist(xc2, zc2)/(lc**2))
+
+        rho_d_0 = rho_b + g1 + g2
+
+        # Constant mass field
+        m_X_0 = m0 + 0*x
+
+    if space == 'diff_order_0':
+        VCG1 = FunctionSpace(mesh, 'CG', 1)
+        VDG1 = domain.spaces('DG1_equispaced')
+
+        suboptions = {'rho_d': RecoveryOptions(embedding_space=VDG1,
+                                               recovered_space=VCG1,
+                                               project_low_method='recover',
+                                               boundary_method=BoundaryMethod.taylor),
+                      'm_X': ConservativeRecoveryOptions(embedding_space=VDG1,
+                                                         recovered_space=VCG1,
+                                                         boundary_method=BoundaryMethod.taylor,
+                                                         rho_name='rho_d',
+                                                         orig_rho_space=V_rho)
+                      }
+    elif space == 'diff_order_1':
+        Vt_brok = FunctionSpace(mesh, BrokenElement(V_m_X.ufl_element()))
+
+        suboptions = {'rho_d': EmbeddedDGOptions(embedding_space=Vt_brok),
+                      'm_X': ConservativeEmbeddedDGOptions(rho_name='rho_d',
+                                                           orig_rho_space=V_rho)}
+    else:
+        suboptions = {}
+
+    opts = MixedFSOptions(suboptions=suboptions)
+
+    transport_scheme = SSPRK3(domain, options=opts, increment_form=False)
+    transport_methods = [DGUpwind(eqn, "m_X"), DGUpwind(eqn, "rho_d")]
+
+    # Timestepper
+    time_varying_velocity = True
+    stepper = PrescribedTransport(eqn, transport_scheme, io, transport_methods, prescribed_transporting_velocity=u_t)
+
+    # Initial Conditions
+    stepper.fields("m_X").interpolate(m_X_0)
+    stepper.fields("rho_d").interpolate(rho_d_0)
+    u0 = stepper.fields("u")
+    u0.project(u_t(0))
+
+    m_X_init = Function(V_m_X)
+    rho_d_init = Function(V_rho)
+
+    m_X_init.assign(stepper.fields("m_X"))
+    rho_d_init.assign(stepper.fields("rho_d"))
+
+    return stepper, m_X_init, rho_d_init
+
+
+@pytest.mark.parametrize("space", ["same", "diff_order_0", "diff_order_1"])
+@pytest.mark.parametrize("property", ["consistency", "conservation"])
+def test_conservative_transport(tmpdir, space, property):
+
+    # Setup and run
+    dirname = str(tmpdir)
+
+    stepper, m_X_0, rho_d_0 = setup_conservative_transport(dirname, space, property)
+
+    # Run for five timesteps
+    stepper.run(t=0, tmax=10)
+    m_X = stepper.fields("m_X")
+    rho_d = stepper.fields("rho_d")
+
+    # Perform the check
+    if property == 'consistency':
+        assert errornorm(m_X_0, m_X) < 1e-14, "conservative transport is not consistent"
+    else:
+        rho_X_init = assemble(m_X_0*rho_d_0*dx)
+        rho_X_final = assemble(m_X*rho_d*dx)
+        assert abs((rho_X_init - rho_X_final)/rho_X_init) < 1e-14, "conservative transport is not conservative"

--- a/integration-tests/transport/test_conservative_transport.py
+++ b/integration-tests/transport/test_conservative_transport.py
@@ -132,7 +132,6 @@ def setup_conservative_transport(dirname, space, property):
                       }
     elif space == 'diff_order_1':
         Vt_brok = FunctionSpace(mesh, BrokenElement(V_m_X.ufl_element()))
-
         suboptions = {'rho_d': EmbeddedDGOptions(embedding_space=Vt_brok),
                       'm_X': ConservativeEmbeddedDGOptions(rho_name='rho_d',
                                                            orig_rho_space=V_rho)}
@@ -145,7 +144,6 @@ def setup_conservative_transport(dirname, space, property):
     transport_methods = [DGUpwind(eqn, "m_X"), DGUpwind(eqn, "rho_d")]
 
     # Timestepper
-    time_varying_velocity = True
     stepper = PrescribedTransport(eqn, transport_scheme, io, transport_methods, prescribed_transporting_velocity=u_t)
 
     # Initial Conditions
@@ -179,7 +177,7 @@ def test_conservative_transport(tmpdir, space, property):
 
     # Perform the check
     if property == 'consistency':
-        assert errornorm(m_X_0, m_X) < 1e-14, "conservative transport is not consistent"
+        assert errornorm(m_X_0, m_X) < 1e-13, "conservative transport is not consistent"
     else:
         rho_X_init = assemble(m_X_0*rho_d_0*dx)
         rho_X_final = assemble(m_X*rho_d*dx)


### PR DESCRIPTION
Adds an integration test for conservative transport, which tests consistency and conservation for three configurations of rho_d and m_X: Same space (both in DG) order 1, different spaces (rho_d in DG, m_X in theta) for orders 0 and 1.
Also, fixed some bugs in the wrapper.py script with the implementation of the conservative versions of the EmbeddedDG and Recovery wrappers.