### PR TITLE
Advective-then-Flux form for Runge-Kutta schemes

### DIFF
--- a/examples/compressible_euler/skamarock_klemp_nonhydrostatic.py
+++ b/examples/compressible_euler/skamarock_klemp_nonhydrostatic.py
@@ -19,7 +19,7 @@ from firedrake import (
 import numpy as np
 from gusto import (
     Domain, IO, OutputParameters, SemiImplicitQuasiNewton, SSPRK3, DGUpwind,
-    TrapeziumRule, SUPGOptions, CourantNumber, Perturbation, Gradient,
+    SUPGOptions, CourantNumber, Perturbation, Gradient,
     CompressibleParameters, CompressibleEulerEquations, CompressibleSolver,
     compressible_hydrostatic_balance, logger, RichardsonNumber,
     RungeKuttaFormulation

--- a/examples/compressible_euler/skamarock_klemp_nonhydrostatic.py
+++ b/examples/compressible_euler/skamarock_klemp_nonhydrostatic.py
@@ -21,7 +21,8 @@ from gusto import (
     Domain, IO, OutputParameters, SemiImplicitQuasiNewton, SSPRK3, DGUpwind,
     TrapeziumRule, SUPGOptions, CourantNumber, Perturbation, Gradient,
     CompressibleParameters, CompressibleEulerEquations, CompressibleSolver,
-    compressible_hydrostatic_balance, logger, RichardsonNumber
+    compressible_hydrostatic_balance, logger, RichardsonNumber,
+    RungeKuttaFormulation
 )
 
 skamarock_klemp_nonhydrostatic_defaults = {
@@ -106,13 +107,13 @@ def skamarock_klemp_nonhydrostatic(
     # Transport schemes
     theta_opts = SUPGOptions()
     transported_fields = [
-        TrapeziumRule(domain, "u"),
-        SSPRK3(domain, "rho"),
-        SSPRK3(domain, "theta", options=theta_opts)
+        SSPRK3(domain, "u", subcycle_by_courant=0.25),
+        SSPRK3(domain, "rho", subcycle_by_courant=0.25, rk_formulation=RungeKuttaFormulation.linear),
+        SSPRK3(domain, "theta", subcycle_by_courant=0.25, options=theta_opts)
     ]
     transport_methods = [
         DGUpwind(eqns, "u"),
-        DGUpwind(eqns, "rho"),
+        DGUpwind(eqns, "rho", advective_then_flux=True),
         DGUpwind(eqns, "theta", ibp=theta_opts.ibp)
     ]
 

--- a/examples/shallow_water/moist_thermal_williamson_5.py
+++ b/examples/shallow_water/moist_thermal_williamson_5.py
@@ -24,8 +24,7 @@ from gusto import (
     ShallowWaterParameters, ShallowWaterEquations, Sum,
     lonlatr_from_xyz, InstantRain, SWSaturationAdjustment, WaterVapour,
     CloudWater, Rain, GeneralIcosahedralSphereMesh, RelativeVorticity,
-    ZonalComponent, MeridionalComponent, RungeKuttaFormulation, SSPRK3,
-    SemiImplicitQuasiNewton, ThermalSWSolver
+    ZonalComponent, MeridionalComponent
 )
 
 moist_thermal_williamson_5_defaults = {
@@ -143,28 +142,13 @@ def moist_thermal_williamson_5(
         gamma_r=gamma_r
     )
 
-    transported_fields = [
-        SSPRK3(domain, "u", subcycle_by_courant=0.25),
-        SSPRK3(domain, "D", subcycle_by_courant=0.25, rk_formulation=RungeKuttaFormulation.linear),
-        SSPRK3(domain, "b", subcycle_by_courant=0.25),
-        SSPRK3(domain, "water_vapour", subcycle_by_courant=0.25),
-        SSPRK3(domain, "cloud_water", subcycle_by_courant=0.25),
-    ]
     transport_methods = [
-        DGUpwind(eqns, "u"),
-        DGUpwind(eqns, "D", advective_then_flux=True),
-        DGUpwind(eqns, "b"),
-        DGUpwind(eqns, "water_vapour"),
-        DGUpwind(eqns, "cloud_water")
+        DGUpwind(eqns, field_name) for field_name in eqns.field_names
     ]
-
-    # Linear solver
-    linear_solver = ThermalSWSolver(eqns)
 
     # Time stepper
-    stepper = SemiImplicitQuasiNewton(
-        eqns, io, transported_fields, transport_methods,
-        linear_solver=linear_solver
+    stepper = Timestepper(
+        eqns, io, RK4(domain), spatial_methods=transport_methods
     )
 
     # ------------------------------------------------------------------------ #

--- a/examples/shallow_water/moist_thermal_williamson_5.py
+++ b/examples/shallow_water/moist_thermal_williamson_5.py
@@ -146,9 +146,9 @@ def moist_thermal_williamson_5(
         DGUpwind(eqns, field_name) for field_name in eqns.field_names
     ]
 
-    # Time stepper
+    # Timestepper
     stepper = Timestepper(
-        eqns, io, RK4(domain), spatial_methods=transport_methods
+        eqns, RK4(domain), io, spatial_methods=transport_methods
     )
 
     # ------------------------------------------------------------------------ #

--- a/examples/shallow_water/williamson_5.py
+++ b/examples/shallow_water/williamson_5.py
@@ -12,7 +12,7 @@ from firedrake import (
 )
 from gusto import (
     Domain, IO, OutputParameters, SemiImplicitQuasiNewton, SSPRK3, DGUpwind,
-    TrapeziumRule, ShallowWaterParameters, ShallowWaterEquations, Sum,
+    ShallowWaterParameters, ShallowWaterEquations, Sum,
     lonlatr_from_xyz, GeneralIcosahedralSphereMesh, ZonalComponent,
     MeridionalComponent, RelativeVorticity, RungeKuttaFormulation
 )

--- a/examples/shallow_water/williamson_5.py
+++ b/examples/shallow_water/williamson_5.py
@@ -14,7 +14,7 @@ from gusto import (
     Domain, IO, OutputParameters, SemiImplicitQuasiNewton, SSPRK3, DGUpwind,
     TrapeziumRule, ShallowWaterParameters, ShallowWaterEquations, Sum,
     lonlatr_from_xyz, GeneralIcosahedralSphereMesh, ZonalComponent,
-    MeridionalComponent, RelativeVorticity
+    MeridionalComponent, RelativeVorticity, RungeKuttaFormulation
 )
 
 williamson_5_defaults = {
@@ -83,8 +83,14 @@ def williamson_5(
     io = IO(domain, output, diagnostic_fields=diagnostic_fields)
 
     # Transport schemes
-    transported_fields = [TrapeziumRule(domain, "u"), SSPRK3(domain, "D")]
-    transport_methods = [DGUpwind(eqns, "u"), DGUpwind(eqns, "D")]
+    transported_fields = [
+        SSPRK3(domain, "u", subcycle_by_courant=0.25),
+        SSPRK3(domain, "D", subcycle_by_courant=0.25, rk_formulation=RungeKuttaFormulation.linear)
+    ]
+    transport_methods = [
+        DGUpwind(eqns, "u"),
+        DGUpwind(eqns, "D", advective_then_flux=True)
+    ]
 
     # Time stepper
     stepper = SemiImplicitQuasiNewton(

--- a/gusto/core/labels.py
+++ b/gusto/core/labels.py
@@ -97,6 +97,8 @@ prognostic = Label("prognostic", validator=lambda value: type(value) == str)
 linearisation = Label("linearisation", validator=lambda value: type(value) in [LabelledForm, Term])
 mass_weighted = Label("mass_weighted", validator=lambda value: type(value) in [LabelledForm, Term])
 ibp_label = Label("ibp", validator=lambda value: type(value) == IntegrateByParts)
+all_but_last = Label("all_but_last", validator=lambda value: type(value) in [LabelledForm, Term])
+
 
 # labels for terms in the equations
 time_derivative = Label("time_derivative")

--- a/gusto/spatial_methods/transport_methods.py
+++ b/gusto/spatial_methods/transport_methods.py
@@ -8,8 +8,10 @@ from firedrake import (
 )
 from firedrake.fml import Term, keep, drop
 from gusto.core.configuration import IntegrateByParts, TransportEquationType
-from gusto.core.labels import (prognostic, transport, transporting_velocity, ibp_label,
-                               mass_weighted)
+from gusto.core.labels import (
+    prognostic, transport, transporting_velocity, ibp_label, mass_weighted,
+    all_but_last
+)
 from gusto.core.logging import logger
 from gusto.spatial_methods.spatial_methods import SpatialMethod
 
@@ -82,6 +84,10 @@ class TransportMethod(SpatialMethod):
 
             # Create new term
             new_term = Term(self.form.form, original_term.labels)
+
+            # Add all_but_last form
+            if hasattr(self, "all_but_last_form"):
+                new_term = all_but_last(new_term, self.all_but_last_form)
 
             # Check if this is a conservative transport
             if original_term.has_label(mass_weighted):
@@ -230,13 +236,13 @@ class DGUpwind(TransportMethod):
                     )
 
                 if advective_then_flux and vector_manifold_correction:
-                    self.form_for_early_stages = vector_manifold_advection_form(
+                    self.all_but_last_form = vector_manifold_advection_form(
                         self.domain, self.test, self.field, ibp=ibp,
                         outflow=outflow
                     )
 
                 elif advective_then_flux:
-                    self.form_for_early_stages = upwind_advection_form(
+                    self.all_but_last_form = upwind_advection_form(
                         self.domain, self.test, self.field, ibp=ibp,
                         outflow=outflow
                     )

--- a/gusto/spatial_methods/transport_methods.py
+++ b/gusto/spatial_methods/transport_methods.py
@@ -181,7 +181,7 @@ class DGUpwind(TransportMethod):
         self.outflow = outflow
 
         if (advective_then_flux
-            and self.transport_equation_type != TransportEquationType.conservative):
+                and self.transport_equation_type != TransportEquationType.conservative):
             raise ValueError(
                 'DG Upwind: advective_then_flux form can only be used with '
                 + 'the conservative form of the transport equation'

--- a/gusto/spatial_methods/transport_methods.py
+++ b/gusto/spatial_methods/transport_methods.py
@@ -175,7 +175,7 @@ class DGUpwind(TransportMethod):
                 transport equation for all but the last steps of some
                 (potentially subcycled) Runge-Kutta scheme, before using the
                 conservative form for the final step to deliver a mass-
-                conserving increment. This optiona only makes sense to use with
+                conserving increment. This option only makes sense to use with
                 Runge-Kutta, and should be used with the "linear" Runge-Kutta
                 formulation. Defaults to False, in which case the conservative
                 form is used for every step.

--- a/gusto/time_discretisation/explicit_runge_kutta.py
+++ b/gusto/time_discretisation/explicit_runge_kutta.py
@@ -27,16 +27,16 @@ class RungeKuttaFormulation(Enum):
     The following Runge-Kutta methods for solving dy/dt = F(y) are encoded here:
     - `increment`:                                                            \n
         k_0 = F[y^n]                                                          \n
-        k_m = F[y^n - dt*\sum_{i=0}^{m-1} a_{m,i} * k_i], for m = 1 to M - 1  \n
-        y^{n+1} = y^n - dt*\sum_{i=0}^{M-1} b_i*k_i                           \n
+        k_m = F[y^n - dt*Sum_{i=0}^{m-1} a_{m,i} * k_i], for m = 1 to M - 1   \n
+        y^{n+1} = y^n - dt*Sum_{i=0}^{M-1} b_i*k_i                            \n
     - `predictor`:
         y^0 = y^n                                                             \n
-        y^m = q^0 - dt*\sum_{i=0}^{m-1} a_{m,i} * F[y^i], for m = 1 to M - 1  \n
-        y^{n+1} = y^0 - dt*\sum_{i=0}^{m-1} b_i * F[y^i]                      \n
+        y^m = q^0 - dt*Sum_{i=0}^{m-1} a_{m,i} * F[y^i], for m = 1 to M - 1   \n
+        y^{n+1} = y^0 - dt*Sum_{i=0}^{m-1} b_i * F[y^i]                       \n
     - `linear`:
         y^0 = y^n                                                             \n
-        y^m = q^0 - dt*F[\sum_{i=0}^{m-1} a_{m,i} * y^i], for m = 1 to M - 1  \n
-        y^{n+1} = y^0 - dt*F[\sum_{i=0}^{m-1} b_i * y^i]                      \n
+        y^m = q^0 - dt*F[Sum_{i=0}^{m-1} a_{m,i} * y^i], for m = 1 to M - 1   \n
+        y^{n+1} = y^0 - dt*F[Sum_{i=0}^{m-1} b_i * y^i]                       \n
     """
 
     increment = 1595712

--- a/gusto/time_discretisation/explicit_runge_kutta.py
+++ b/gusto/time_discretisation/explicit_runge_kutta.py
@@ -31,11 +31,11 @@ class RungeKuttaFormulation(Enum):
         y^{n+1} = y^n - dt*Sum_{i=0}^{M-1} b_i*k_i                            \n
     - `predictor`:
         y^0 = y^n                                                             \n
-        y^m = q^0 - dt*Sum_{i=0}^{m-1} a_{m,i} * F[y^i], for m = 1 to M - 1   \n
+        y^m = y^0 - dt*Sum_{i=0}^{m-1} a_{m,i} * F[y^i], for m = 1 to M - 1   \n
         y^{n+1} = y^0 - dt*Sum_{i=0}^{m-1} b_i * F[y^i]                       \n
     - `linear`:
         y^0 = y^n                                                             \n
-        y^m = q^0 - dt*F[Sum_{i=0}^{m-1} a_{m,i} * y^i], for m = 1 to M - 1   \n
+        y^m = y^0 - dt*F[Sum_{i=0}^{m-1} a_{m,i} * y^i], for m = 1 to M - 1   \n
         y^{n+1} = y^0 - dt*F[Sum_{i=0}^{m-1} b_i * y^i]                       \n
     """
 

--- a/gusto/time_discretisation/time_discretisation.py
+++ b/gusto/time_discretisation/time_discretisation.py
@@ -94,7 +94,7 @@ class TimeDiscretisation(object, metaclass=ABCMeta):
                             'Time discretisation: suboption SUPG is currently not implemented within MixedOptions')
                     else:
                         raise RuntimeError(
-                            f'Time discretisation: suboption wrapper {wrapper_name} not implemented')
+                            f'Time discretisation: suboption wrapper {self.wrapper_name} not implemented')
             elif self.wrapper_name == "embedded_dg":
                 self.wrapper = EmbeddedDGWrapper(self, options)
             elif self.wrapper_name == "recovered":

--- a/gusto/time_discretisation/time_discretisation.py
+++ b/gusto/time_discretisation/time_discretisation.py
@@ -423,6 +423,7 @@ class ExplicitTimeDiscretisation(TimeDiscretisation):
 
         self.x0.assign(x_in)
         for i in range(self.ncycles):
+            self.subcycle_idx = i
             self.apply_cycle(self.x1, self.x0)
             self.x0.assign(self.x1)
         x_out.assign(self.x1)

--- a/integration-tests/equations/test_coupled_transport.py
+++ b/integration-tests/equations/test_coupled_transport.py
@@ -98,9 +98,14 @@ def test_conservative_coupled_transport(tmpdir, m_X_space, tracer_setup):
                       'f2': EmbeddedDGOptions()}
         opts = MixedFSOptions(suboptions=suboptions)
 
-        transport_scheme = SSPRK3(domain, options=opts, increment_form=False)
+        transport_scheme = SSPRK3(
+            domain, options=opts,
+            rk_formulation=RungeKuttaFormulation.predictor
+        )
     else:
-        transport_scheme = SSPRK3(domain, increment_form=False)
+        transport_scheme = SSPRK3(
+            domain, rk_formulation=RungeKuttaFormulation.predictor
+        )
 
     transport_method = [DGUpwind(eqn, 'f1'), DGUpwind(eqn, 'f2')]
 

--- a/integration-tests/model/test_conservative_transport_with_physics.py
+++ b/integration-tests/model/test_conservative_transport_with_physics.py
@@ -60,8 +60,10 @@ def run_conservative_transport_with_physics(dirname):
     # Time stepper
     time_varying_velocity = False
     stepper = SplitPrescribedTransport(
-        eqn, SSPRK3(domain, increment_form=False), io, time_varying_velocity,
-        transport_method, physics_schemes=physics_schemes)
+        eqn, SSPRK3(domain, rk_formulation=RungeKuttaFormulation.predictor),
+        io, time_varying_velocity, transport_method,
+        physics_schemes=physics_schemes
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial conditions

--- a/integration-tests/model/test_time_discretisation.py
+++ b/integration-tests/model/test_time_discretisation.py
@@ -9,9 +9,12 @@ def run(timestepper, tmax, f_end):
 
 
 @pytest.mark.parametrize(
-    "scheme", ["ssprk3_increment", "TrapeziumRule", "ImplicitMidpoint",
-               "QinZhang", "RK4", "Heun", "BDF2", "TR_BDF2", "AdamsBashforth",
-               "Leapfrog", "AdamsMoulton", "AdamsMoulton", "ssprk3_predictor"])
+    "scheme", [
+        "ssprk3_increment", "TrapeziumRule", "ImplicitMidpoint", "QinZhang",
+        "RK4", "Heun", "BDF2", "TR_BDF2", "AdamsBashforth", "Leapfrog",
+        "AdamsMoulton", "AdamsMoulton", "ssprk3_predictor", "ssprk3_linear"
+    ]
+)
 def test_time_discretisation(tmpdir, scheme, tracer_setup):
     if (scheme == "AdamsBashforth"):
         # Tighter stability constraints
@@ -28,9 +31,11 @@ def test_time_discretisation(tmpdir, scheme, tracer_setup):
         eqn = AdvectionEquation(domain, V, "f")
 
     if scheme == "ssprk3_increment":
-        transport_scheme = SSPRK3(domain, increment_form=True)
+        transport_scheme = SSPRK3(domain, rk_formulation=RungeKuttaFormulation.increment)
     elif scheme == "ssprk3_predictor":
-        transport_scheme = SSPRK3(domain, increment_form=False)
+        transport_scheme = SSPRK3(domain, rk_formulation=RungeKuttaFormulation.predictor)
+    elif scheme == "ssprk3_linear":
+        transport_scheme = SSPRK3(domain, rk_formulation=RungeKuttaFormulation.linear)
     elif scheme == "TrapeziumRule":
         transport_scheme = TrapeziumRule(domain)
     elif scheme == "ImplicitMidpoint":

--- a/integration-tests/transport/test_advective_then_flux.py
+++ b/integration-tests/transport/test_advective_then_flux.py
@@ -1,0 +1,109 @@
+"""
+Tests transport using a Runge-Kutta scheme with an advective-then-flux approach.
+This should yield increments that are linear in the divergence (and thus
+preserve a constant in divergence-free flow).
+"""
+
+from gusto import *
+from firedrake import (
+    PeriodicRectangleMesh, cos, sin, SpatialCoordinate,
+    assemble, dx, pi, as_vector, errornorm, Function
+)
+import pytest
+
+
+def setup_advective_then_flux(dirname, desirable_property):
+
+    # ------------------------------------------------------------------------ #
+    # Model set up
+    # ------------------------------------------------------------------------ #
+
+    # Time parameters
+    dt = 2.
+
+    # Domain
+    domain_width = 2000.
+    ncells_1d = 10.
+    mesh = PeriodicRectangleMesh(
+        ncells_1d, ncells_1d, domain_width, domain_width, quadrilateral=True
+    )
+    domain = Domain(mesh, dt, "RTCF", 1)
+
+    # Equation
+    V_DG = domain.spaces('DG')
+    V_HDiv = domain.spaces("HDiv")
+    eqn = ContinuityEquation(domain, V_DG, "rho", Vu=V_HDiv)
+
+    # IO
+    output = OutputParameters(dirname=dirname)
+    io = IO(domain, output)
+
+    # Transport method
+    transport_scheme = SSPRK3(
+        domain, rk_formulation=RungeKuttaFormulation.linear, fixed_subcycles=3
+    )
+    transport_method = DGUpwind(eqn, "rho", advective_then_flux=True)
+
+    # Timestepper
+    time_varying = False
+    stepper = PrescribedTransport(
+        eqn, transport_scheme, io, time_varying, transport_method
+    )
+
+    # ------------------------------------------------------------------------ #
+    # Initial Conditions
+    # ------------------------------------------------------------------------ #
+
+    x, y = SpatialCoordinate(mesh)
+
+    # Density is initially constant for both tests
+    rho_0 = 10.0
+
+    # Set the initial state from the configuration choice
+    if desirable_property == 'constancy':
+        # Divergence free velocity
+        num_steps = 5
+        psi = Function(domain.spaces('H1'))
+        psi_expr = cos(2*pi*x/domain_width)*sin(2*pi*y/domain_width)
+        psi.interpolate(psi_expr)
+        u_expr = domain.perp(grad(psi_expr))
+
+    elif desirable_property == 'divergence_linearity':
+        # Divergent velocity
+        num_steps = 1
+        u_expr = as_vector([
+            cos(2*pi*x/domain_width)*sin(4*pi*y/domain_width),
+            -pi*sin(2*pi*x*y/(domain_width)**2)
+        ])
+
+    stepper.fields("rho").assign(Constant(rho_0))
+    stepper.fields("u").project(u_expr)
+
+    rho_true = Function(V_DG)
+    rho_true.assign(stepper.fields("rho"))
+
+    return stepper, rho_true, dt, num_steps
+
+
+@pytest.mark.parametrize("desirable_property", ["constancy", "divergence_linearity"])
+def test_advective_then_flux(tmpdir, desirable_property):
+
+    # Setup and run
+    dirname = str(tmpdir)
+
+    stepper, rho_true, dt, num_steps = \
+        setup_advective_then_flux(dirname, desirable_property)
+
+    # Run for five timesteps
+    stepper.run(t=0, tmax=dt*num_steps)
+    rho = stepper.fields("rho")
+
+    # Check for divergence-linearity/constancy
+    assert errornorm(rho, rho_true) < 2e-13, \
+        "advective-then-flux form is not yielding the correct answer"
+
+    # Check for conservation
+    mass_initial = assemble(rho_true*dx)
+    mass_final = assemble(rho*dx)
+    assert abs(mass_final - mass_initial) < 1e-14, \
+        "advective-then-flux form is not conservative"

--- a/integration-tests/transport/test_advective_then_flux.py
+++ b/integration-tests/transport/test_advective_then_flux.py
@@ -7,7 +7,7 @@ preserve a constant in divergence-free flow).
 from gusto import *
 from firedrake import (
     PeriodicRectangleMesh, cos, sin, SpatialCoordinate,
-    assemble, dx, pi, as_vector, errornorm, Function, div, as_vector
+    assemble, dx, pi, as_vector, errornorm, Function, div
 )
 import pytest
 

--- a/integration-tests/transport/test_dg_transport.py
+++ b/integration-tests/transport/test_dg_transport.py
@@ -14,7 +14,9 @@ def run(timestepper, tmax, f_end):
 
 
 @pytest.mark.parametrize("geometry", ["slice", "sphere"])
-@pytest.mark.parametrize("equation_form", ["advective", "continuity"])
+@pytest.mark.parametrize("equation_form", [
+    "advective", "continuity", "advective_then_flux"
+])
 def test_dg_transport_scalar(tmpdir, geometry, equation_form, tracer_setup):
     setup = tracer_setup(tmpdir, geometry)
     domain = setup.domain
@@ -25,8 +27,13 @@ def test_dg_transport_scalar(tmpdir, geometry, equation_form, tracer_setup):
     else:
         eqn = ContinuityEquation(domain, V, "f")
 
-    transport_scheme = SSPRK3(domain)
-    transport_method = DGUpwind(eqn, "f")
+
+    if equation_form == "advective_then_flux":
+        transport_method = DGUpwind(eqn, "f", advective_then_flux=True)
+        transport_scheme = SSPRK3(domain, rk_formulation=RungeKuttaFormulation.linear)
+    else:
+        transport_method = DGUpwind(eqn, "f")
+        transport_scheme = SSPRK3(domain)
 
     time_varying_velocity = False
     timestepper = PrescribedTransport(

--- a/integration-tests/transport/test_dg_transport.py
+++ b/integration-tests/transport/test_dg_transport.py
@@ -27,7 +27,6 @@ def test_dg_transport_scalar(tmpdir, geometry, equation_form, tracer_setup):
     else:
         eqn = ContinuityEquation(domain, V, "f")
 
-
     if equation_form == "advective_then_flux":
         transport_method = DGUpwind(eqn, "f", advective_then_flux=True)
         transport_scheme = SSPRK3(domain, rk_formulation=RungeKuttaFormulation.linear)


### PR DESCRIPTION
This PR implements an "advective-then-flux" form for RK schemes with the conservative transport equation.

This involves:
- adding an enumerator for the formulation of the RK scheme -- we now have `linear`, `predictor` and `increment` forms, which follow the attached document
- I have implemented the `linear` form, which allows the final RK stage of the final subcycle to use a different operator
- there is a new `all_but_last` label, which indicates the form to use for all but the very final RK stage
- there is an `advective_then_flux` boolean argument to the `DGUpwind` operator, which signifies to use the `advective` form of the transport equation for all-but-the-last RK stage
- there is of course a unit-test which demonstrates that this formulation has the correct properties

This seems to have a similarly positive impact to the density/depth predictor for transport with large Courant numbers.