### PR TITLE
Update workflow to use node20 instead of node16

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as
     # part of the jobs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install checkedout Gusto
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
     name: "Run linter"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Setup flake8 annotations
@@ -33,7 +33,7 @@ jobs:
     # #example-error-annotation-on-github-actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check workflow files
         uses: docker://rhysd/actionlint:latest
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Build with Jekyll

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Github actions now uses node20 instead of node16. 
In line with this:

- `actions/checkout@v3` is updated to `actions/checkout@v4`
-  `actions/setup-python@v4` is updated to `actions/setup-python@v5`
- `actions/configure-pages@v3` is updated to `actions/configure-pages@v5`
- `actions/deploy-pages@v2` is updated to `actions/deploy-pages@v4`

The current flake8 notations action rbialon/flake8-annotations@v1 still uses node16 and there doesn't appear to be an updated version of this that uses node20.