### PR TITLE
Do not refactor mass matrices in SIQN transport calculation

### DIFF
--- a/gusto/timestepping/semi_implicit_quasi_newton.py
+++ b/gusto/timestepping/semi_implicit_quasi_newton.py
@@ -531,11 +531,13 @@ class Forcing(object):
 
         # now we can set up the explicit and implicit problems
         explicit_forcing_problem = LinearVariationalProblem(
-            a.form, L_explicit.form, self.xF, bcs=bcs
+            a.form, L_explicit.form, self.xF, bcs=bcs,
+            constant_jacobian=True
         )
 
         implicit_forcing_problem = LinearVariationalProblem(
-            a.form, L_implicit.form, self.xF, bcs=bcs
+            a.form, L_implicit.form, self.xF, bcs=bcs,
+            constant_jacobian=True
         )
 
         self.solvers = {}


### PR DESCRIPTION
This is one of the changes made in #569. I don't have time to do any more on that PR this week, but seeing as this change makes the biggest difference (for the cases I've tried), and also doesn't break any tests, I'm adding it here so it can go into main quicker.

Flamegraphs below for the dry baroclinic sphere test case from the gusto_test_case repository, run on 32 cores with the following arguments:
```
--ncell_per_edge=30 --nlayers=10 --dt=900 --tmax=9000 --dumpfreq=10000 -log_view :flamelog.txt:ascii_flamegraph
```

Flamegraph for main:
![flamelog-baroclinic_wave_nc30_nl10_dt900_tm9000_p032-7986162](https://github.com/user-attachments/assets/f91ae30e-8dbe-47e2-8eb6-7ea98166106d)

Flamegraph for this branch:
![flamelog-baroclinic_wave_nc30_nl10_dt900_tm9000_p32-7992404](https://github.com/user-attachments/assets/b6358271-05db-4128-8372-40f869c34ec8)

Original takes 685s for 10 timesteps, this branch takes 365s.