### PR TITLE
Fix Gusto following changes to value_size and value_shape

### DIFF
--- a/gusto/core/coordinates.py
+++ b/gusto/core/coordinates.py
@@ -99,7 +99,7 @@ class Coordinates(object):
         space = domain.spaces(space_name)
 
         # Use the appropriate scalar function space if the space is vector
-        if np.prod(space.ufl_element().value_shape) > 1:
+        if np.prod(space.value_shape) > 1:
             # TODO: get scalar space, and only compute coordinates if necessary
             logger.warning(f'Space {space_name} has more than one dimension, '
                            + 'and coordinates used for netCDF output have not '

--- a/gusto/recovery/recovery.py
+++ b/gusto/recovery/recovery.py
@@ -332,20 +332,20 @@ def find_eff_coords(V0):
     vec_DG1 = VectorFunctionSpace(mesh, DG1_element)
     x = SpatialCoordinate(mesh)
 
-    if isinstance(V0.ufl_element(), VectorElement) or V0.ufl_element().value_size > 1:
+    if isinstance(V0.ufl_element(), VectorElement) or V0.value_size > 1:
         eff_coords_list = []
         V0_coords_list = []
 
         # treat this separately for each component
-        for i in range(V0.ufl_element().value_size):
+        for i in range(V0.value_size):
             # fill an d-dimensional list with i-th coordinate
-            x_list = [x[i] for j in range(V0.ufl_element().value_size)]
+            x_list = [x[i] for j in range(V0.value_size)]
 
             # the i-th element in V0_coords_list is a vector with all components the i-th coord
             ith_V0_coords = Function(V0).project(as_vector(x_list))
             V0_coords_list.append(ith_V0_coords)
 
-        for i in range(V0.ufl_element().value_size):
+        for i in range(V0.value_size):
             # slice through V0_coords_list to obtain the coords of the DOFs for that component
             x_list = [V0_coords[i] for V0_coords in V0_coords_list]
 

--- a/gusto/solvers/preconditioners.py
+++ b/gusto/solvers/preconditioners.py
@@ -72,7 +72,7 @@ class VerticalHybridizationPC(PCBase):
         for i, Vi in enumerate(V):
 
             # Vector-valued spaces will have a non-empty value_shape
-            if Vi.ufl_element().value_shape:
+            if Vi.value_shape:
                 self.vidx = i
             else:
                 self.pidx = i


### PR DESCRIPTION
Updates parts of Gusto getting `value_shape` or `value_size` from the `ufl_element`, to now get it from the function space directly. This fixes the broken main branch following the Firedrake PR: https://github.com/firedrakeproject/firedrake/pull/3862