### PR TITLE
Remove remove_initial_w

### DIFF
--- a/examples/compressible_euler/mountain_hydrostatic.py
+++ b/examples/compressible_euler/mountain_hydrostatic.py
@@ -18,7 +18,7 @@ from gusto import (
     TrapeziumRule, SUPGOptions, ZComponent, Perturbation,
     CompressibleParameters, HydrostaticCompressibleEulerEquations,
     CompressibleSolver, compressible_hydrostatic_balance, HydrostaticImbalance,
-    SpongeLayerParameters, MinKernel, MaxKernel, remove_initial_w, logger
+    SpongeLayerParameters, MinKernel, MaxKernel, logger
 )
 
 mountain_hydrostatic_defaults = {
@@ -243,8 +243,7 @@ def mountain_hydrostatic(
 
     theta0.assign(theta_b)
     rho0.assign(rho_b)
-    u0.project(as_vector([initial_wind, 0.0]))
-    remove_initial_w(u0)
+    u0.project(as_vector([initial_wind, 0.0]), bcs=eqns.bcs['u'])
 
     stepper.set_reference_profiles([('rho', rho_b), ('theta', theta_b)])
 

--- a/gusto/initialisation/hydrostatic_initialisation.py
+++ b/gusto/initialisation/hydrostatic_initialisation.py
@@ -12,9 +12,10 @@ from gusto.core import logger
 from gusto.recovery import Recoverer, BoundaryMethod
 
 
-__all__ = ["boussinesq_hydrostatic_balance",
-           "compressible_hydrostatic_balance", "remove_initial_w",
-           "saturated_hydrostatic_balance", "unsaturated_hydrostatic_balance"]
+__all__ = [
+    "boussinesq_hydrostatic_balance", "compressible_hydrostatic_balance",
+    "saturated_hydrostatic_balance", "unsaturated_hydrostatic_balance"
+]
 
 
 def boussinesq_hydrostatic_balance(equation, b0, p0, top=False, params=None):
@@ -217,23 +218,6 @@ def compressible_hydrostatic_balance(equation, theta0, rho0, exner0=None,
         rho0.assign(rho_)
     else:
         rho0.interpolate(thermodynamics.rho(parameters, theta0, exner))
-
-
-def remove_initial_w(u):
-    """
-    Removes the vertical component of a velocity field.
-
-    Args:
-        u (:class:`Function`): the velocity field to be altered.
-    """
-    Vu = u.function_space()
-    Vv = FunctionSpace(Vu._ufl_domain, Vu.ufl_element()._elements[-1])
-    bc = DirichletBC(Vu[0], 0.0, "bottom")
-    bc.apply(u)
-    uv = Function(Vv).project(u)
-    ustar = Function(u.function_space()).project(uv)
-    uin = Function(u.function_space()).assign(u - ustar)
-    u.assign(uin)
 
 
 def saturated_hydrostatic_balance(equation, state_fields, theta_e, mr_t,


### PR DESCRIPTION
The `remove_initial_w` routine no longer works, but I actually don't think it's necessary so this PR removes it.

I think we can achieve the same result by including boundary conditions in the initial projection of the velocity field.

This causes a failing test in the case studies but has not been picked up by our normal testing because the `mountain_hydrostatic` test is currently set to xfail, as the hydrostatic equations have not been fixed yet.

----

As a record, below is the error message from `remove_initial_w`:
```
Traceback (most recent call last):
  File "/home/thomas/firedrake/src/gusto/case_studies/case_studies/compressible_euler/mountain_nonhydrostatic.py", line 283, in <module>
    mountain_nonhydrostatic(**vars(args))
  File "/home/thomas/firedrake/src/gusto/case_studies/case_studies/compressible_euler/mountain_nonhydrostatic.py", line 224, in mountain_nonhydrostatic
    remove_initial_w(u0)
  File "/home/thomas/firedrake/src/gusto/gusto/initialisation/hydrostatic_initialisation.py", line 232, in remove_initial_w
    bc.apply(u)
  File "petsc4py/PETSc/Log.pyx", line 188, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "petsc4py/PETSc/Log.pyx", line 189, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "/home/thomas/firedrake/src/firedrake/firedrake/adjoint_utils/dirichletbc.py", line 32, in wrapper
    ret = apply(self, *args, **kwargs)
  File "/home/thomas/firedrake/src/firedrake/firedrake/bcs.py", line 448, in apply
    r = r.sub(idx)
  File "petsc4py/PETSc/Log.pyx", line 188, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "petsc4py/PETSc/Log.pyx", line 189, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "/home/thomas/firedrake/src/firedrake/firedrake/function.py", line 349, in sub
    return self._components[i]
  File "/usr/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/home/thomas/firedrake/src/firedrake/firedrake/function.py", line 333, in _components
    return tuple(type(self)(self.function_space().sub(i), self.topological.sub(i))
  File "/home/thomas/firedrake/src/firedrake/firedrake/function.py", line 333, in <genexpr>
    return tuple(type(self)(self.function_space().sub(i), self.topological.sub(i))
  File "petsc4py/PETSc/Log.pyx", line 188, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "petsc4py/PETSc/Log.pyx", line 189, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "/home/thomas/firedrake/src/firedrake/firedrake/functionspaceimpl.py", line 187, in sub
    raise IndexError("Invalid component %d, not in [0, %d)" % (i, bound))
IndexError: Invalid component 1, not in [0, 1)
```