### PR TITLE
Reduce pyproject.toml boilerplate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,19 +24,5 @@ classifiers = [
 Homepage = "http://www.firedrakeproject.org/gusto/"
 Repository = "https://github.com/firedrakeproject/gusto.git"
 
-[tool.setuptools]
-packages = [
-  "gusto",
-  "gusto.complex_proxy",
-  "gusto.core",
-  "gusto.diagnostics",
-  "gusto.equations",
-  "gusto.initialisation",
-  "gusto.physics",
-  "gusto.recovery",
-  "gusto.rexi",
-  "gusto.solvers",
-  "gusto.spatial_methods",
-  "gusto.time_discretisation",
-  "gusto.timestepping",
-]
+[tool.setuptools.packages.find]
+include = ["gusto"]


### PR DESCRIPTION
This fix gets automatic package discovery working so it isn't necessary to specify all subpackages.