### PR TITLE
Fixes following retirement of quadrature_degree as a Projector kwarg

### DIFF
--- a/gusto/physics/boundary_and_turbulence.py
+++ b/gusto/physics/boundary_and_turbulence.py
@@ -296,9 +296,11 @@ class WindDrag(PhysicsParametrisation):
 
             du_expr = surface_expr * (u_np1_expr - u_hori) / self.dt
 
+            project_params = {
+                'quadrature_degree': equation.domain.max_quad_degree
+            }
             self.source_projector = Projector(
-                du_expr, source_u_proj,
-                quadrature_degree=equation.domain.max_quad_degree
+                du_expr, source_u_proj, form_compiler_parameters=project_params
             )
 
             source_expr = inner(test, source_u - k*dot(source_u, k)) * dx

--- a/gusto/physics/microphysics.py
+++ b/gusto/physics/microphysics.py
@@ -348,7 +348,7 @@ class Fallout(PhysicsParametrisation):
 
         if moments != AdvectedMoments.M0:
             project_params = {
-                'quadrature_degree': equation.domain.max_quad_degree
+                'quadrature_degree': domain.max_quad_degree
             }
             self.determine_v = Projector(
                 -v_expression*domain.k, v,

--- a/gusto/physics/microphysics.py
+++ b/gusto/physics/microphysics.py
@@ -347,9 +347,12 @@ class Fallout(PhysicsParametrisation):
                 + 'AdvectedMoments.M0 and AdvectedMoments.M3')
 
         if moments != AdvectedMoments.M0:
+            project_params = {
+                'quadrature_degree': equation.domain.max_quad_degree
+            }
             self.determine_v = Projector(
                 -v_expression*domain.k, v,
-                quadrature_degree=domain.max_quad_degree
+                form_compiler_parameters=project_params
             )
 
     def evaluate(self, x_in, dt, x_out=None):

--- a/gusto/timestepping/timestepper.py
+++ b/gusto/timestepping/timestepper.py
@@ -427,9 +427,12 @@ class PrescribedTransport(Timestepper):
         if self.is_velocity_setup:
             raise RuntimeError('Prescribed velocity already set up!')
 
+        project_params = {
+            'quadrature_degree': equation.domain.max_quad_degree
+        }
         self.velocity_projection = Projector(
             expr_func(self.t), self.fields('u'),
-            quadrature_degree=self.equation.domain.max_quad_degree
+            form_compiler_parameters=project_params
         )
 
         self.is_velocity_setup = True

--- a/gusto/timestepping/timestepper.py
+++ b/gusto/timestepping/timestepper.py
@@ -428,7 +428,7 @@ class PrescribedTransport(Timestepper):
             raise RuntimeError('Prescribed velocity already set up!')
 
         project_params = {
-            'quadrature_degree': equation.domain.max_quad_degree
+            'quadrature_degree': self.equation.domain.max_quad_degree
         }
         self.velocity_projection = Projector(
             expr_func(self.t), self.fields('u'),


### PR DESCRIPTION
This fixes the failing Gusto and Case Studies tests following Firedrake PR [#4073](https://github.com/firedrakeproject/firedrake/pull/4073), which deprecated the `quadrature_degree` argument to the `Projector`