### PR TITLE
Use firedrake-vanilla-default container for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     # The docker container to use.
     container:
-      image: firedrakeproject/firedrake-docdeps:latest
+      image: firedrakeproject/firedrake-vanilla-default:latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The docdeps container was accidentally reintroduced in https://github.com/firedrakeproject/gusto/commit/0992440f051dcce6497677e289b1fe15bf3cbf23.