### PR TITLE
Small updates to Schaer mountain example

### DIFF
--- a/examples/compressible_euler/schaer_mountain.py
+++ b/examples/compressible_euler/schaer_mountain.py
@@ -96,9 +96,9 @@ def schaer_mountain(
     domain = Domain(mesh, dt, "CG", element_order)
 
     # Equation
-    parameters = CompressibleParameters(g=g, cp=cp)
+    parameters = CompressibleParameters(mesh, g=g, cp=cp)
     sponge = SpongeLayerParameters(
-        H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
+        mesh, H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
     )
     eqns = CompressibleEulerEquations(
         domain, parameters, sponge_options=sponge, u_transport_option=u_eqn_type

--- a/examples/compressible_euler/test_compressible_euler_examples.py
+++ b/examples/compressible_euler/test_compressible_euler_examples.py
@@ -46,6 +46,24 @@ def test_dry_bryan_fritsch_parallel():
     test_dry_bryan_fritsch()
 
 
+def test_schaer_mountain():
+    from schaer_mountain import schaer_mountain
+    test_name = 'schaer_mountain'
+    schaer_mountain(
+        ncolumns=10,
+        nlayers=10,
+        dt=8.0,
+        tmax=40.0,
+        dumpfreq=5,
+        dirname=make_dirname(test_name)
+    )
+
+
+@pytest.mark.parallel(nprocs=3)
+def test_schaer_mountain_parallel():
+    test_schaer_mountain()
+
+
 def test_skamarock_klemp_nonhydrostatic():
     from skamarock_klemp_nonhydrostatic import skamarock_klemp_nonhydrostatic
     test_name = 'skamarock_klemp_nonhydrostatic'


### PR DESCRIPTION
Mesh was missing as an argument from `CompressibleParameters()` and `SpongeLayerParameters()`.