### PR TITLE
`interpolate` fixes

### DIFF
--- a/gusto/physics/microphysics.py
+++ b/gusto/physics/microphysics.py
@@ -174,7 +174,7 @@ class SaturationAdjustment(PhysicsParametrisation):
         self.source = Function(W)
         self.source_expr = [split(self.source)[V_idx] for V_idx in V_idxs]
         self.source_int = [self.source.subfunctions[V_idx] for V_idx in V_idxs]
-        self.source_interpolate = [interpolate(sat_adj_expr*factor, source)
+        self.source_interpolate = [interpolate(sat_adj_expr*factor, source.function_space())
                                    for source, factor in zip(self.source_int, factors)]
 
         tests = [equation.tests[idx] for idx in V_idxs]
@@ -202,7 +202,7 @@ class SaturationAdjustment(PhysicsParametrisation):
             self.rho_recoverer.project()
         # Evaluate the source
         for interpolator, src in zip(self.source_interpolate, self.source_int):
-            src.assign(assemble(interpolator))
+            assemble(interpolator, tensor=src)
 
         # If a source output is provided, assign the source term to it
         if x_out is not None:
@@ -462,7 +462,7 @@ class Coalescence(PhysicsParametrisation):
                                                         min_value(accu_rate, self.cloud_water / self.dt),
                                                         min_value(accr_rate + accu_rate, self.cloud_water / self.dt))))
 
-        self.source_interpolate = interpolate(rain_expr, self.source_int)
+        self.source_interpolate = interpolate(rain_expr, self.source_int.function_space())
 
         # Add term to equation's residual
         test_cl = equation.tests[self.cloud_idx]
@@ -493,7 +493,7 @@ class Coalescence(PhysicsParametrisation):
         self.rain.assign(x_in.subfunctions[self.rain_idx])
         self.cloud_water.assign(x_in.subfunctions[self.cloud_idx])
 
-        self.source_int.assign(assemble(self.source_interpolate))
+        assemble(self.source_interpolate, tensor=self.source_int)
         # If a source output is provided, assign the source term to it
         if x_out is not None:
             x_out.assign(self.source)

--- a/gusto/physics/physics_parametrisation.py
+++ b/gusto/physics/physics_parametrisation.py
@@ -125,14 +125,14 @@ class SourceSink(PhysicsParametrisation):
 
         # Handle method of evaluating source/sink
         if self.method == 'interpolate':
-            self.source_interpolate = interpolate(expression, self.source_int)
+            self.source_interpolate = interpolate(expression, self.source_int.function_space())
         else:
             self.source_projector = Projector(expression, self.source_int)
 
         # If not time-varying, evaluate for the first time here
         if not self.time_varying:
             if self.method == 'interpolate':
-                self.source_int.assign(assemble(self.source_interpolate))
+                assemble(self.source_interpolate, tensor=self.source_int)
             else:
                 self.source_projector.project()
 

--- a/gusto/physics/shallow_water_microphysics.py
+++ b/gusto/physics/shallow_water_microphysics.py
@@ -144,7 +144,7 @@ class InstantRain(PhysicsParametrisation):
         self.source_interpolate = interpolate(conditional(
             self.water_v > self.saturation_curve,
             (1/self.tau)*gamma_r*(self.water_v - self.saturation_curve),
-            0), self.source_int)
+            0), self.source_int.function_space())
 
     def evaluate(self, x_in, dt, x_out=None):
         """
@@ -169,7 +169,7 @@ class InstantRain(PhysicsParametrisation):
             self.tau.assign(dt)
         self.water_v.assign(x_in.subfunctions[self.Vv_idx])
 
-        self.source_int.assign(assemble(self.source_interpolate))
+        assemble(self.source_interpolate, tensor=self.source_int)
 
         if x_out is not None:
             x_out.assign(self.source)


### PR DESCRIPTION
After the next release `interpolate` won't accept a `Function` in the second slot