### PR TITLE
Change the sign of buoyancy momentum term in the Boussinesq equations description

### DIFF
--- a/gusto/equations/boussinesq_equations.py
+++ b/gusto/equations/boussinesq_equations.py
@@ -25,7 +25,7 @@ class BoussinesqEquations(PrognosticEquationSet):
     to compressible.
 
     The compressible form of the equations is
-    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p + b*k = 0,                                     \n
+    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p - b*k = 0,                                     \n
     ∂p/∂t + cs**2 ∇.u = p,                                                    \n
     ∂b/∂t + (u.∇)b = 0,                                                       \n
     where k is the vertical unit vector, Ω is the planet's rotation vector
@@ -33,7 +33,7 @@ class BoussinesqEquations(PrognosticEquationSet):
 
     For the incompressible form of the equations, the pressure features as
     a Lagrange multiplier to enforce incompressibility. The equations are     \n
-    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p + b*k = 0,                                     \n
+    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p - b*k = 0,                                     \n
     ∇.u = p,                                                                  \n
     ∂b/∂t + (u.∇)b = 0,                                                       \n
     where k is the vertical unit vector and Ω is the planet's rotation vector.
@@ -226,7 +226,7 @@ class LinearBoussinesqEquations(BoussinesqEquations):
     to compressible.
 
     The compressible form of the equations is
-    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p + b*k = 0,                                     \n
+    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p - b*k = 0,                                     \n
     ∂p/∂t + cs**2 ∇.u = p,                                                    \n
     ∂b/∂t + (u.∇)b = 0,                                                       \n
     where k is the vertical unit vector, Ω is the planet's rotation vector
@@ -234,7 +234,7 @@ class LinearBoussinesqEquations(BoussinesqEquations):
 
     For the incompressible form of the equations, the pressure features as
     a Lagrange multiplier to enforce incompressibility. The equations are     \n
-    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p + b*k = 0,                                     \n
+    ∂u/∂t + (u.∇)u + 2Ω×u + ∇p - b*k = 0,                                     \n
     ∇.u = p,                                                                  \n
     ∂b/∂t + (u.∇)b = 0,                                                       \n
     where k is the vertical unit vector and Ω is the planet's rotation vector.


### PR DESCRIPTION
Change the sign of buoyancy momentum term in the Boussinesq equations description to be -b*k instead of b*k. This is consistent with the equation sets in the literature, e.g. Vallis book page 74.