### PR TITLE
set both file and console log level to environment variable

### DIFF
--- a/gusto/core/logging.py
+++ b/gusto/core/logging.py
@@ -65,7 +65,7 @@ def capture_exceptions(exception_type, exception_value, traceback, logger=logger
 sys.excepthook = capture_exceptions
 
 # Set the log level based on environment variables
-log_level = os.environ.get("GUSTO_LOG_LEVEL", WARNING)
+log_level = os.environ.get("GUSTO_LOG_LEVEL", INFO)
 logfile_level = os.environ.get("GUSTO_FILE_LOG_LEVEL", log_level)
 logconsole_level = os.environ.get("GUSTO_CONSOLE_LOG_LEVEL", log_level)
 log_level_list = [log_level, logfile_level, logconsole_level]


### PR DESCRIPTION
Currently the log level can be set via the `GUSTO_LOG_LEVEL` environment variable which defaults to `WARNING`. The file log level and console log level can be set separately, also via environment variables, and they default to `DEBUG` and `INFO` respectively. The logger level is then set to be the minimum (i.e. max amount of output) of these three.

These defaults mean that, in general, people are running with the log level set to `DEBUG` which is not optimal for performance. This change makes the file log level and the console log level the same as the `GUSTO_LOG_LEVEL` environment variable (which takes the default `WARNING`). This should lead to better default performance.

@tommbendall possibly we'd prefer to have the default be `INFO`?