### PR TITLE
Minor updates to complex proxy

### DIFF
--- a/gusto/complex_proxy/vector_impl.py
+++ b/gusto/complex_proxy/vector_impl.py
@@ -59,7 +59,7 @@ def FunctionSpace(V):
 
     :arg V: the real-valued FunctionSpace.
     """
-    return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
+    return fd.FunctionSpace(V.mesh().unique(), FiniteElement(V.ufl_element()))
 
 
 def DirichletBC(W, V, bc, function_arg=None):
@@ -73,15 +73,11 @@ def DirichletBC(W, V, bc, function_arg=None):
     if function_arg is None:
         function_arg = bc.function_arg
 
-    sub_domain = bc.sub_domain
-
     if type(V.ufl_element()) is fd.MixedElement:
-        idx = bc.function_space().index
-        Ws = (W.sub(idx).sub(0), W.sub(idx).sub(1))
-    else:
-        Ws = (W.sub(0), W.sub(1))
+        W = W.sub(bc.function_space().index)
 
-    return tuple(fd.DirichletBC(Wsub, function_arg, sub_domain) for Wsub in Ws)
+    return tuple(fd.DirichletBC(W.sub(part), function_arg, bc.sub_domain)
+                 for part in (re, im))
 
 
 def split(u, i):

--- a/unit-tests/complex_proxy/test_complex_mixed.py
+++ b/unit-tests/complex_proxy/test_complex_mixed.py
@@ -119,6 +119,10 @@ def test_mixed_function_space(mesh, mixed_element):
     V = fd.FunctionSpace(mesh, mixed_element)
     W = cpx.FunctionSpace(V)
 
+    assert V.ufl_element() == mixed_element
+    assert W.ufl_element() == cpx.FiniteElement(mixed_element)
+    assert W.ufl_element().num_sub_elements == 2*V.ufl_element().num_sub_elements
+
     assert len(W.subspaces) == 2*len(V.subspaces), "The complex space should have twice the number of components as the real space"
 
     for i in range(V.ufl_element().num_sub_elements):
@@ -519,10 +523,7 @@ def test_mixed_linear_solve(mesh, bc_type):
     if bc_type == "nobc":
         bcs = []
     elif bc_type == "dirichletbc":
-        bcs = [
-            fd.DirichletBC(V.sub(1), 0, 3),
-            fd.DirichletBC(V.sub(1), 0, 4)
-        ]
+        bcs = [fd.DirichletBC(V.sub(0), 0, 1)]
     else:
         raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
 

--- a/unit-tests/complex_proxy/test_complex_vector.py
+++ b/unit-tests/complex_proxy/test_complex_vector.py
@@ -519,10 +519,7 @@ def test_mixed_linear_solve(mesh, bc_type):
     if bc_type == "nobc":
         bcs = []
     elif bc_type == "dirichletbc":
-        bcs = [
-            fd.DirichletBC(V.sub(1), 0, 3),
-            fd.DirichletBC(V.sub(1), 0, 4)
-        ]
+        bcs = [fd.DirichletBC(V.sub(0), 0, 1)]
     else:
         raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
 


### PR DESCRIPTION
1. use `mesh.unique()` for both vector and mixed implementations of FunctionSpace
2. stricter FunctionSpace test to catch more `mesh.unique` errors when constructing the proxy space
3. In the solve tests set boundary conditions on a component space that actually has boundary values.
4. Small rearrangement of BC construction to match asQ so keep it easy to compare diffs