### PR TITLE
Allow outputting to an existing directory

### DIFF
--- a/gusto/core/configuration.py
+++ b/gusto/core/configuration.py
@@ -112,6 +112,7 @@ class OutputParameters(Configuration):
     # name and points is the points at which to dump them
     point_data = []
     tolerance = None
+    overwrite_files = False
 
 
 class WrapperOptions(Configuration, metaclass=ABCMeta):

--- a/gusto/core/io.py
+++ b/gusto/core/io.py
@@ -414,7 +414,7 @@ class IO(object):
             # Gather errors from each rank and raise appropriate error everywhere
             # This allreduce also ensures that all ranks are in sync wrt the results dir
             raise_exception = self.mesh.comm.allreduce(raise_parallel_exception, op=MPI.MAX)
-            if raise_exception == 1:
+            if raise_exception == 1 and not self.output.overwrite_files:
                 raise GustoIOError(f'results directory {self.dumpdir} already exists')
             elif raise_exception == 2:
                 if error:


### PR DESCRIPTION
Give gusto permission to write output into an existing directory

In particular this means you can call `stepper.run` multiple times in the same script.