### PR TITLE
CI: consistent timeouts for pytest and gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       PYOP2_CFLAGS: -O0
       # Make sure that tests with >4 processes are not silently skipped
       PYTEST_MPI_MAX_NPROCS: 4
-      EXTRA_PYTEST_ARGS: --durations=100 --timeout=3600 --timeout-method=thread -o faulthandler_timeout=3660 --show-capture=no --verbose gusto-repo/unit-tests gusto-repo/integration-tests gusto-repo/examples
+      EXTRA_PYTEST_ARGS: --durations=100 --timeout-method=thread --show-capture=no --verbose gusto-repo/unit-tests gusto-repo/integration-tests gusto-repo/examples
     steps:
       - name: Fix HOME
         # For unknown reasons GitHub actions overwrite HOME to /github/home
@@ -93,28 +93,28 @@ jobs:
           . venv-gusto/bin/activate
           : # Use pytest-xdist here so we can have a single collated output (not possible
           : # for parallel tests)
-          firedrake-run-split-tests 1 1 -n 12 --dist worksteal "$EXTRA_PYTEST_ARGS" --log-file=gusto1.log
+          firedrake-run-split-tests 1 1 -n 12 --dist worksteal "$EXTRA_PYTEST_ARGS" --log-file=gusto1.log --timeout=600 -o faulthandler_timeout=660
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 2)
         if: success() || steps.install-two.conclusion == 'success'
         run: |
           . venv-gusto/bin/activate
-          firedrake-run-split-tests 2 6 "$EXTRA_PYTEST_ARGS" "--log-file=gusto2_{#}.log"
+          firedrake-run-split-tests 2 6 "$EXTRA_PYTEST_ARGS" "--log-file=gusto2_{#}.log" --timeout=240 -o faulthandler_timeout=300
         timeout-minutes: 30
 
       - name: Run tests (nprocs = 3)
         if: success() || steps.install-two.conclusion == 'success'
         run: |
           . venv-gusto/bin/activate
-          firedrake-run-split-tests 3 4 "$EXTRA_PYTEST_ARGS" "--log-file=gusto3_{#}.log"
+          firedrake-run-split-tests 3 4 "$EXTRA_PYTEST_ARGS" "--log-file=gusto3_{#}.log" --timeout=180 -o faulthandler_timeout=240
         timeout-minutes: 10
 
       - name: Run tests (nprocs = 4)
         if: success() || steps.install-two.conclusion == 'success'
         run: |
           . venv-gusto/bin/activate
-          firedrake-run-split-tests 4 3 "$EXTRA_PYTEST_ARGS" "--log-file=gusto4_{#}.log"
+          firedrake-run-split-tests 4 3 "$EXTRA_PYTEST_ARGS" "--log-file=gusto4_{#}.log" --timeout=180 -o faulthandler_timeout=240
         timeout-minutes: 10
 
       - name: Upload pytest log files


### PR DESCRIPTION
There are two timeout limits set in the gusto CI, firstly a _per test_ limit given to pytest, and secondly a _per job step_ limit
given to github actions.
Currently the pytest limit is 1hr, so pytest will only timeout if a single tests takes more than an hour. However the per step limits given to gh actions are 1 hr or less, so the pytest limit is never hit.

This means that if a test takes too long or hangs the job gets killed by github, and we don't see any useful output. This PR reduces the pytest timeout limits so that hopefully hanging tests will be killed by pytest and we will see what test hung and where it hung.

Example timeout jobs without useful output:
https://github.com/firedrakeproject/gusto/actions/runs/25160405858/job/73753067758#step:11:726
https://github.com/firedrakeproject/gusto/actions/runs/24886988087/job/72869313732?pr=728