### PR TITLE
New method for calculating vorticity diagnostic

### DIFF
--- a/gusto/diagnostics/shallow_water_diagnostics.py
+++ b/gusto/diagnostics/shallow_water_diagnostics.py
@@ -3,9 +3,11 @@
 
 from firedrake import (
     dx, TestFunction, TrialFunction, grad, inner, curl, Function, assemble,
-    LinearVariationalProblem, LinearVariationalSolver, conditional, interpolate
+    LinearVariationalProblem, LinearVariationalSolver, conditional, interpolate,
+    Projector
 )
 from gusto.diagnostics.diagnostics import DiagnosticField, Energy
+from gusto.core.function_spaces import is_cg
 
 __all__ = ["ShallowWaterKineticEnergy", "ShallowWaterPotentialEnergy",
            "ShallowWaterPotentialEnstrophy", "PotentialVorticity",
@@ -159,7 +161,23 @@ class Vorticity(DiagnosticField):
             raise ValueError(f"vorticity type must be one of {vorticity_types}, not {vorticity_type}")
         space = domain.spaces("H1")
 
-        u = state_fields("u")
+        # Work out continuity requirements of space
+        if self.space is None or not is_cg(self.space):
+            # Using DG, calculate u in HCurl space as intermediary
+            self.hcurl_intermediary = True
+            assert self.method != 'solve', (
+                'vorticity diagnostics can only be output in L2 space when '
+                + 'not using "solve" method'
+            )
+            space = domain.spaces("L2")
+            u_hdiv = state_fields("u")
+            self.u_hcurl = Function(domain.spaces("HCurl"))
+            u = self.u_hcurl  # Point u to u_hcurl
+        else:
+            # Using CG, calculate vorticity directly from HDiv u
+            self.hcurl_intermediary = False
+            u = state_fields("u")
+
         if vorticity_type in ["absolute", "potential"]:
             f = state_fields("coriolis")
         if vorticity_type == "potential":
@@ -195,6 +213,15 @@ class Vorticity(DiagnosticField):
             problem = LinearVariationalProblem(a, L, self.field,
                                                constant_jacobian=constant_jacobian)
             self.evaluator = LinearVariationalSolver(problem, solver_parameters={"ksp_type": "cg"})
+
+        elif self.hcurl_intermediary:
+            self.hcurl_projection = Projector(u_hdiv, self.u_hcurl)
+
+    def compute(self):
+        """Compute the vorticity, possibly via velocity in HCurl space."""
+        if self.hcurl_intermediary:
+            self.hcurl_projection.project()
+        super().compute()
 
 
 class PotentialVorticity(Vorticity):

--- a/gusto/diagnostics/shallow_water_diagnostics.py
+++ b/gusto/diagnostics/shallow_water_diagnostics.py
@@ -159,17 +159,19 @@ class Vorticity(DiagnosticField):
         vorticity_types = ["relative", "absolute", "potential"]
         if vorticity_type not in vorticity_types:
             raise ValueError(f"vorticity type must be one of {vorticity_types}, not {vorticity_type}")
-        space = domain.spaces("H1")
+
+        # Set default space
+        if self.space is None:
+            self.space = domain.spaces("H1")
 
         # Work out continuity requirements of space
-        if self.space is None or not is_cg(self.space):
+        if not is_cg(self.space):
             # Using DG, calculate u in HCurl space as intermediary
             self.hcurl_intermediary = True
             assert self.method != 'solve', (
                 'vorticity diagnostics can only be output in L2 space when '
                 + 'not using "solve" method'
             )
-            space = domain.spaces("L2")
             u_hdiv = state_fields("u")
             self.u_hcurl = Function(domain.spaces("HCurl"))
             u = self.u_hcurl
@@ -194,12 +196,12 @@ class Vorticity(DiagnosticField):
             elif vorticity_type == "relative":
                 self.expr = curl_operator(u)
 
-        super().setup(domain, state_fields, space=space)
+        super().setup(domain, state_fields, space=self.space)
 
         # Set up problem now that self.field has been set up
         if self.method == 'solve':
-            gamma = TestFunction(space)
-            q = TrialFunction(space)
+            gamma = TestFunction(self.space)
+            q = TrialFunction(self.space)
 
             if vorticity_type == "potential":
                 a = q*gamma*D*dx

--- a/gusto/diagnostics/shallow_water_diagnostics.py
+++ b/gusto/diagnostics/shallow_water_diagnostics.py
@@ -172,11 +172,14 @@ class Vorticity(DiagnosticField):
             space = domain.spaces("L2")
             u_hdiv = state_fields("u")
             self.u_hcurl = Function(domain.spaces("HCurl"))
-            u = self.u_hcurl  # Point u to u_hcurl
+            u = self.u_hcurl
+            curl_operator = domain.divperp
+
         else:
             # Using CG, calculate vorticity directly from HDiv u
             self.hcurl_intermediary = False
             u = state_fields("u")
+            curl_operator = curl
 
         if vorticity_type in ["absolute", "potential"]:
             f = state_fields("coriolis")
@@ -185,11 +188,11 @@ class Vorticity(DiagnosticField):
 
         if self.method != 'solve':
             if vorticity_type == "potential":
-                self.expr = (curl(u) + f) / D
+                self.expr = (curl_operator(u) + f) / D
             elif vorticity_type == "absolute":
-                self.expr = curl(u) + f
+                self.expr = curl_operator(u) + f
             elif vorticity_type == "relative":
-                self.expr = curl(u)
+                self.expr = curl_operator(u)
 
         super().setup(domain, state_fields, space=space)
 
@@ -233,10 +236,15 @@ class PotentialVorticity(Vorticity):
         Args:
             space (:class:`FunctionSpace`, optional): the function space to
                 evaluate the diagnostic field in. Defaults to None, in which
-                case a default space will be chosen for this diagnostic.
+                case a default space will be chosen for this diagnostic, which
+                is the H1 space. Note that if the diagnostic is in the L2 space,
+                it should be evaluated with the 'interpolate' or 'project'
+                method, and will project the velocity into the HCurl space as
+                an intermediary step.
             method (str, optional): a string specifying the method of evaluation
                 for this diagnostic. Valid options are 'interpolate', 'project',
-                'assign' and 'solve'. Defaults to 'solve'.
+                'assign' and 'solve'. Defaults to 'solve'. Note that the 'solve'
+                method is only available when the diagnostic is in the H1 space.
         """
         self.solve_implemented = True
         super().__init__(space=space, method=method,
@@ -262,10 +270,15 @@ class AbsoluteVorticity(Vorticity):
         Args:
             space (:class:`FunctionSpace`, optional): the function space to
                 evaluate the diagnostic field in. Defaults to None, in which
-                case a default space will be chosen for this diagnostic.
+                case a default space will be chosen for this diagnostic, which
+                is the H1 space. Note that if the diagnostic is in the L2 space,
+                it should be evaluated with the 'interpolate' or 'project'
+                method, and will project the velocity into the HCurl space as
+                an intermediary step.
             method (str, optional): a string specifying the method of evaluation
                 for this diagnostic. Valid options are 'interpolate', 'project',
-                'assign' and 'solve'. Defaults to 'solve'.
+                'assign' and 'solve'. Defaults to 'solve'. Note that the 'solve'
+                method is only available when the diagnostic is in the H1 space.
         """
         self.solve_implemented = True
         super().__init__(space=space, method=method, required_fields=('u', 'coriolis'))
@@ -290,10 +303,15 @@ class RelativeVorticity(Vorticity):
         Args:
             space (:class:`FunctionSpace`, optional): the function space to
                 evaluate the diagnostic field in. Defaults to None, in which
-                case a default space will be chosen for this diagnostic.
+                case a default space will be chosen for this diagnostic, which
+                is the H1 space. Note that if the diagnostic is in the L2 space,
+                it should be evaluated with the 'interpolate' or 'project'
+                method, and will project the velocity into the HCurl space as
+                an intermediary step.
             method (str, optional): a string specifying the method of evaluation
                 for this diagnostic. Valid options are 'interpolate', 'project',
-                'assign' and 'solve'. Defaults to 'solve'.
+                'assign' and 'solve'. Defaults to 'solve'. Note that the 'solve'
+                method is only available when the diagnostic is in the H1 space.
         """
         self.solve_implemented = True
         super().__init__(space=space, method=method, required_fields=('u',))


### PR DESCRIPTION
This implements a new method for calculating vorticity diagnostics for shallow-water equations.

We currently solve a linear variational problem to evaluate the vorticity in H1 from the velocity in HDiv, which is equivalent to the "weak curl". I am wondering if this can give very noisy results on the cubed-sphere...

... so this PR implements a different method, which first projects the velocity into HCurl, and then interpolates the "strong curl" of that velocity into a DG space.