### PR TITLE
Try to fix apparent grid imprinting in height diagnostic in shallow-water

### DIFF
--- a/examples/shallow_water/moist_thermal_williamson_5.py
+++ b/examples/shallow_water/moist_thermal_williamson_5.py
@@ -160,11 +160,12 @@ def moist_thermal_williamson_5(
     c0 = stepper.fields("cloud_water")
     r0 = stepper.fields("rain")
     Omega = parameters.Omega
+    topog_field = stepper.fields('topography')
 
     uexpr = as_vector([-u_max*y/radius, u_max*x/radius, 0.0])
 
     Dexpr = (
-        mean_depth - tpexpr
+        mean_depth - topog_field
         - (radius * Omega * u_max + 0.5*u_max**2)*(z/radius)**2/g
     )
 

--- a/examples/shallow_water/williamson_5.py
+++ b/examples/shallow_water/williamson_5.py
@@ -69,28 +69,33 @@ def williamson_5(
         dirname=dirname, dumpfreq=dumpfreq,
         dump_vtus=True, dump_nc=True, dumplist=['D', 'topography']
     )
-    diagnostic_fields = [Sum('D', 'topography'), RelativeVorticity(),
-                         MeridionalComponent('u'), ZonalComponent('u')]
+
+    diagnostic_fields = [
+        Sum('D', 'topography'), RelativeVorticity(),
+        MeridionalComponent('u'), ZonalComponent('u')
+    ]
 
     # Transport schemes
     subcycling_options = SubcyclingOptions(subcycle_by_courant=0.25)
 
-    model = SIQNModel(mesh, dt, parameters, eqns,
-                      family='BDM')
-    model.setup(output, subcycling_options=subcycling_options,
-                diagnostic_fields=diagnostic_fields)
+    model = SIQNModel(mesh, dt, parameters, eqns, family='BDM')
+    model.setup(
+        output, subcycling_options=subcycling_options,
+        diagnostic_fields=diagnostic_fields
+    )
 
     # ------------------------------------------------------------------------ #
     # Initial conditions
     # ------------------------------------------------------------------------ #
 
     stepper = model.stepper
+    topog_field = stepper.fields('topography')
     u0 = stepper.fields('u')
     D0 = stepper.fields('D')
     Omega = parameters.Omega
     uexpr = as_vector([-u_max*y/radius, u_max*x/radius, 0.0])
     Dexpr = (
-        mean_depth - tpexpr
+        mean_depth - topog_field
         - (radius*Omega*u_max + 0.5*u_max**2)*(z/radius)**2/g
     )
 

--- a/gusto/equations/shallow_water_equations.py
+++ b/gusto/equations/shallow_water_equations.py
@@ -217,7 +217,7 @@ class ShallowWaterEquations(PrognosticEquationSet):
 
         topog_expr = self.parameters.topog_expr
         if topog_expr is not None:
-            self.prescribed_fields('topography', self.domain.spaces('DG')).interpolate(topog_expr)
+            self.prescribed_fields('topography', self.domain.spaces('DG')).project(topog_expr)
             topography_form = subject(prognostic
                                       (-g*div(w)*topog_expr*dx(degree=quad), 'u'),
                                       self.X)
@@ -496,7 +496,7 @@ class ThermalShallowWaterEquations(ShallowWaterEquations):
         topog_expr = self.parameters.topog_expr
         if topog_expr is not None:
             topog = self.prescribed_fields(
-                'topography', self.domain.spaces('DG')).interpolate(topog_expr)
+                'topography', self.domain.spaces('DG')).project(topog_expr)
             if self.equivalent_buoyancy:
                 topography_form = subject(prognostic(
                     - topog * div(b*w) * dx


### PR DESCRIPTION
I think the problem is inconsistency between how the topography is specified, used in the momentum equation and also how the initial depth field is initialised.

This is an attempt to make them consistent!

Should fix #737 

Here are before and after plots of the icosahedron at different refinement levels:
<img width="1381" height="834" alt="williamson_5_I4" src="https://github.com/user-attachments/assets/8feba46d-3091-4845-b610-0d3f4e201dda" />
<img width="1381" height="834" alt="williamson_5_I8" src="https://github.com/user-attachments/assets/c3eecfca-4e70-46e6-b0da-8085ca6a46e1" />
<img width="1381" height="834" alt="williamson_5_I16" src="https://github.com/user-attachments/assets/eb69a134-1d6a-458e-b938-72a442467844" />
