### PR TITLE
Fix Ubuntu tests by moving mpiexec outside pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,22 +18,64 @@ lint:
 	@echo "    Linting gusto plotting scripts"
 	@python3 -m flake8 $(FLAKE8_FORMAT) plotting
 
+# Set the Gusto logging level to avoid showing too much output
+#export GUSTO_CONSOLE_LOG_LEVEL=WARNING
+
+# Disable threading as this can slow down tests
+export OMP_NUM_THREADS=1
+
+# Run parallel tests:
+#  - The first argument specifies the number of processors
+#  - The second argument specifies the directory to search for tests
+define run_parallel_tests
+	@mpiexec -n $(1) python3 -m pytest -q $(2) -v -m parallel[match] $(PYTEST_ARGS) --show-capture=no
+endef
+
+# Run all unit tests
+define run_unit_test
+	@echo "    Running all unit-tests"
+	@python3 -m pytest unit-tests $(PYTEST_ARGS) --show-capture=no
+endef
+
+# Run all integration tests
+# There are currently no integration tests using 3 or 4 MPI ranks. Add a call to run_parallel_tests
+# below if such a test is added in future
+define run_integration_test
+	@echo "    Running all integration-tests"
+	@python3 -m pytest -q integration-tests -m parallel[match] $(PYTEST_ARGS) --show-capture=no
+	$(call run_parallel_tests,2,integration-tests)
+endef
+
+# Run serial examples i.e 'not parallel' or nprocs=1
+define run_example
+	@echo "    Running serial examples"
+	@python3 -m pytest -q examples -v -m parallel[match] $(PYTEST_ARGS) --show-capture=no
+endef
+
+# Run parallel examples using 2, 3 or 4 processors
+# If a test is added with more than 4 processors then add the relevant call to run_parallel_tests below
+define run_parallel_example
+	@echo "    Running all parallel examples"
+	$(call run_parallel_tests,2,examples)
+	$(call run_parallel_tests,3,examples)
+	$(call run_parallel_tests,4,examples)
+endef
+
 test:
 	@echo "    Running all tests"
-	@python3 -m pytest -q -s unit-tests integration-tests examples $(PYTEST_ARGS) --show-capture=no
+	$(run_unit_test)
+	$(run_integration_test)
+	$(run_example)
+	$(run_parallel_example)
 
 unit_test:
-	@echo "    Running all unit-tests"
-	@python3 -m pytest -q -s unit-tests $(PYTEST_ARGS) --show-capture=no
+	$(run_unit_test)
 
 integration_test:
-	@echo "    Running all integration-tests"
-	@python3 -m pytest -q -s integration-tests $(PYTEST_ARGS) --show-capture=no
+	$(run_integration_test)
 
 example:
-	@echo "    Running all examples"
-	@python3 -m pytest -q -s examples -v -m "not parallel" $(PYTEST_ARGS) --show-capture=no
+	$(run_example)
 
 parallel_example:
-	@echo "    Running all parallel examples"
-	@python3 -m pytest -q -s examples -v -m "parallel" $(PYTEST_ARGS) --show-capture=no
+	$(run_parallel_example)

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ lint:
 	@echo "    Linting gusto plotting scripts"
 	@python3 -m flake8 $(FLAKE8_FORMAT) plotting
 
-# Set the Gusto logging level to avoid showing too much output
-#export GUSTO_CONSOLE_LOG_LEVEL=WARNING
-
 # Disable threading as this can slow down tests
 export OMP_NUM_THREADS=1
 
@@ -28,28 +25,28 @@ export OMP_NUM_THREADS=1
 #  - The first argument specifies the number of processors
 #  - The second argument specifies the directory to search for tests
 define run_parallel_tests
-	@mpiexec -n $(1) python3 -m pytest -q $(2) -v -m parallel[match] $(PYTEST_ARGS) --show-capture=no
+	@mpiexec -n $(1) python3 -m pytest $(2) -m parallel[match] $(PYTEST_ARGS)
 endef
 
-# Run all unit tests
+# Run all unit tests assuming they are all serial
 define run_unit_test
 	@echo "    Running all unit-tests"
-	@python3 -m pytest unit-tests $(PYTEST_ARGS) --show-capture=no
+	@python3 -m pytest unit-tests $(PYTEST_ARGS)
 endef
 
 # Run all integration tests
-# There are currently no integration tests using 3 or 4 MPI ranks. Add a call to run_parallel_tests
+# There are currently no integration tests using more than 2 MPI ranks. Add a call to run_parallel_tests
 # below if such a test is added in future
 define run_integration_test
 	@echo "    Running all integration-tests"
-	@python3 -m pytest -q integration-tests -m parallel[match] $(PYTEST_ARGS) --show-capture=no
+	@python3 -m pytest integration-tests -m parallel[match] $(PYTEST_ARGS)
 	$(call run_parallel_tests,2,integration-tests)
 endef
 
 # Run serial examples i.e 'not parallel' or nprocs=1
 define run_example
 	@echo "    Running serial examples"
-	@python3 -m pytest -q examples -v -m parallel[match] $(PYTEST_ARGS) --show-capture=no
+	@python3 -m pytest examples -m parallel[match] $(PYTEST_ARGS)
 endef
 
 # Run parallel examples using 2, 3 or 4 processors


### PR DESCRIPTION
Parallel tests are failing on Ubuntu because mpiexec is being run inside pytest (see #742). This PR changes the Makefile so that mpiexec is run outside pytest which fixes the problem.

Running mpiexec outside pytest requires a separate invocation for each number of MPI ranks tested. This PR also modifies the verbosity of the test output so that it is easier to keep track of what has passed and what has failed. 