### PR TITLE
Reordering options to fix diverged solve

### DIFF
--- a/gusto/solvers/solver_presets.py
+++ b/gusto/solvers/solver_presets.py
@@ -127,6 +127,8 @@ def hybridised_solver_parameters(equation, solver_prognostics, alpha=0.5, tau_va
                 'pc_python_type': 'firedrake.AssembledPC',
                 'assembled_pc_type': 'bjacobi',
                 'assembled_sub_pc_type': 'ilu',
+                'assembled_sub_pc_factor_mat_ordering_type': 'rcm',
+                'assembled_sub_pc_factor_reuse_ordering': None,
             },
             'fieldsplit_1': {
                 'ksp_type': 'preonly',


### PR DESCRIPTION
Higher resolution baroclinic wave configurations are crashing due to the solver failing to converge (DIVERGED_LINEAR_SOLVE error). The baroclinic wave runs successfully with a C34 cubed-sphere grid but fails with C48 resolution.
This PR fixes the crash by getting PETSc to work out a better ordering before calculating the ILU factorisation.