### PR TITLE
Remove unnecessary firedrake.__future__ import

### DIFF
--- a/gusto/physics/chemistry.py
+++ b/gusto/physics/chemistry.py
@@ -1,7 +1,6 @@
 """Objects describe chemical conversion and reaction processes."""
 
 from firedrake import dx, split, Function, sqrt, exp, Constant, conditional, max_value, min_value, assemble
-from firedrake.__future__ import interpolate
 from firedrake.fml import subject
 from gusto.core.labels import prognostic, source_label
 from gusto.core.logging import logger

--- a/gusto/physics/chemistry.py
+++ b/gusto/physics/chemistry.py
@@ -1,6 +1,6 @@
 """Objects describe chemical conversion and reaction processes."""
 
-from firedrake import dx, split, Function, sqrt, exp, Constant, conditional, max_value, min_value, assemble
+from firedrake import dx, split, Function, sqrt, exp, Constant, conditional, max_value, min_value, assemble, interpolate
 from firedrake.fml import subject
 from gusto.core.labels import prognostic, source_label
 from gusto.core.logging import logger


### PR DESCRIPTION
I am removing this from Firedrake `main` in https://github.com/firedrakeproject/firedrake/pull/5269 (merged)