### PR TITLE
Use options_prefix to pass parameters to RieszMap

### DIFF
--- a/gusto/solvers/preconditioners.py
+++ b/gusto/solvers/preconditioners.py
@@ -480,9 +480,6 @@ class CompressibleHybridisedSCPC(PCBase):
         self._process_context(pc)
         prefix = pc.getOptionsPrefix()
 
-        # Unpack sub-solver parameters from the options prefix
-        self.riesz_map_parameters = PETSc.Options(prefix + "riesz_map_").getAll()
-
         if logger.isEnabledFor(DEBUG):
             self.scpc_solve_parameters['ksp_monitor_true_residual'] = None
             self.scpc_solve_parameters['ksp_converged_reason'] = None
@@ -520,7 +517,7 @@ class CompressibleHybridisedSCPC(PCBase):
 
         # Riesz map for the dual of the original function space
         self.riesz_map = RieszMap(self.W.dual(),
-                                  solver_parameters=self.riesz_map_parameters,
+                                  options_prefix=prefix + "riesz_map_",
                                   constant_jacobian=True)
 
         self.y_hybrid = Function(self.W_hyb)


### PR DESCRIPTION
The next release of Firedrake will allow passing `options_prefix` to a `RieszMap` so we don't need to handle those options manually in the compressible euler solver.

Should not be merged until the next Firedrake release.